### PR TITLE
fix(deps): resolve windows cross-env issues and add missing db migrations

### DIFF
--- a/apps/ai-plane/package.json
+++ b/apps/ai-plane/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "NODE_OPTIONS='--import tsx' nest start --watch",
+    "dev": "cross-env NODE_OPTIONS=\"--import tsx\" nest start --watch",
     "build": "nest build",
     "start": "node dist/main.js",
     "typecheck": "tsc --noEmit",

--- a/apps/collab-plane/package.json
+++ b/apps/collab-plane/package.json
@@ -30,7 +30,7 @@
     "zod": "^4.3.6"
   },
   "scripts": {
-    "dev": "NODE_OPTIONS='--import tsx' nest start --watch",
+    "dev": "cross-env NODE_OPTIONS=\"--import tsx\" nest start --watch",
     "build": "nest build",
     "start": "node dist/main.js",
     "typecheck": "tsc --noEmit",

--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -38,7 +38,7 @@
     "zod": "^4.3.6"
   },
   "scripts": {
-    "dev": "NODE_OPTIONS='--import tsx' nest start --watch",
+    "dev": "cross-env NODE_OPTIONS=\"--import tsx\" nest start --watch",
     "build": "nest build",
     "start": "node dist/main.js",
     "typecheck": "tsc --noEmit",

--- a/apps/execution-plane/package.json
+++ b/apps/execution-plane/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "NODE_OPTIONS='--import tsx' nest start --watch",
+    "dev": "cross-env NODE_OPTIONS=\"--import tsx\" nest start --watch",
     "build": "nest build",
     "start": "node dist/main.js",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@biomejs/biome": "^2.4.4",
     "@commitlint/cli": "^20.4.2",
     "@commitlint/config-conventional": "^20.4.2",
+    "cross-env": "^10.1.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.3.1",
     "turbo": "^2.8.12",

--- a/packages/db/drizzle/0000_shallow_lake.sql
+++ b/packages/db/drizzle/0000_shallow_lake.sql
@@ -1,0 +1,3 @@
+CREATE TYPE "public"."difficulty" AS ENUM('easy', 'medium', 'hard');--> statement-breakpoint
+CREATE TYPE "public"."room_status" AS ENUM('waiting', 'warmup', 'coding', 'wrapup', 'finished');--> statement-breakpoint
+CREATE TYPE "public"."user_role" AS ENUM('user', 'admin');

--- a/packages/db/drizzle/meta/0000_snapshot.json
+++ b/packages/db/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,34 @@
+{
+  "id": "4207d7df-b6bc-4498-b53a-57e2a5fe9c9f",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {},
+  "enums": {
+    "public.difficulty": {
+      "name": "difficulty",
+      "schema": "public",
+      "values": ["easy", "medium", "hard"]
+    },
+    "public.room_status": {
+      "name": "room_status",
+      "schema": "public",
+      "values": ["waiting", "warmup", "coding", "wrapup", "finished"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["user", "admin"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1773115452586,
+      "tag": "0000_shallow_lake",
+      "breakpoints": true
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^20.4.2
         version: 20.4.2
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -507,8 +510,6 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.3.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-
-  apps/executor: {}
 
   apps/web:
     dependencies:
@@ -1224,6 +1225,9 @@ packages:
   '@e2b/code-interpreter@2.3.3':
     resolution: {integrity: sha512-WOpSwc1WpvxyOijf6WMbR76BUuvd2O9ddXgCHHi65lkuy6YgQGq7oyd8PNsT331O9Tqbccjy6uF4xanSdLX1UA==}
     engines: {node: '>=20'}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -4112,6 +4116,11 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -7347,6 +7356,8 @@ snapshots:
     dependencies:
       e2b: 2.13.1
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
       esbuild: 0.18.20
@@ -10377,6 +10388,11 @@ snapshots:
   cron-parser@4.9.0:
     dependencies:
       luxon: 3.7.2
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:


### PR DESCRIPTION
1. Running pnpm dev in Windows terminals previously failed due to unsupported NODE_OPTIONS syntax. Added cross-env as a dev dependency and updated the dev scripts across the 4 backend apps to ensure cross-platform compatibility.
2. Generated and committed the missing meta/_journal.json and corresponding SQL migration files using pnpm db:generate. This fixes the issue where pnpm db:migrate would fail on a fresh clone.