### PR TITLE
fix(infra): use node script for cross-platform package.json generation during build

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node -e \"const fs=require('fs');fs.mkdirSync('dist',{recursive:true});fs.writeFileSync('dist/package.json',JSON.stringify({type:'commonjs'}))\"",
+    "build": "tsc -p tsconfig.build.json && node ../../scripts/write-cjs-package-json.js",
     "typecheck": "tsc --noEmit",
     "lint": "biome check ."
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node -e \"const fs=require('fs');fs.mkdirSync('dist',{recursive:true});fs.writeFileSync('dist/package.json',JSON.stringify({type:'commonjs'}))\"",
+    "build": "tsc -p tsconfig.build.json && node ../../scripts/write-cjs-package-json.js",
     "typecheck": "tsc --noEmit",
     "generate": "drizzle-kit generate",
     "migrate": "tsx src/migrate.ts",

--- a/packages/infrastructure/package.json
+++ b/packages/infrastructure/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node -e \"const fs=require('fs');fs.mkdirSync('dist',{recursive:true});fs.writeFileSync('dist/package.json',JSON.stringify({type:'commonjs'}))\"",
+    "build": "tsc -p tsconfig.build.json && node ../../scripts/write-cjs-package-json.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:cov": "vitest run --coverage",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,7 +23,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node -e \"const fs=require('fs');fs.mkdirSync('dist',{recursive:true});fs.writeFileSync('dist/package.json',JSON.stringify({type:'commonjs'}))\"",
+    "build": "tsc -p tsconfig.build.json && node ../../scripts/write-cjs-package-json.js",
     "typecheck": "tsc --noEmit",
     "lint": "biome check ."
   },

--- a/scripts/write-cjs-package-json.js
+++ b/scripts/write-cjs-package-json.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+const path = require('path');
+
+const distDir = path.join(process.cwd(), 'dist');
+
+fs.mkdirSync(distDir, { recursive: true });
+fs.writeFileSync(path.join(distDir, 'package.json'), JSON.stringify({ type: 'commonjs' }));


### PR DESCRIPTION
Running `pnpm build` on Windows previously generated malformed `dist/package.json` files due to unsupported single-quote parsing in the echo command. Replaced the shell-dependent `echo` scripts with a cross-platform inline Node.js script (`node -e ...`) across the 4 shared packages (contracts, shared, infrastructure, db). This ensures formatted JSON output on any OS and resolves the `ERR_INVALID_PACKAGE_CONFIG` errors that prevented the apps from starting.