### PR TITLE
Feat/session feedback api

### DIFF
--- a/apps/control-plane/src/app.module.ts
+++ b/apps/control-plane/src/app.module.ts
@@ -11,6 +11,7 @@ import { InfrastructureModule } from './infrastructure/infrastructure.module.js'
 import { AuthModule } from './modules/auth/auth.module.js';
 import { DbModule } from './modules/db/db.module.js';
 import { ExecutionModule } from './modules/execution/execution.module.js';
+import { FeedbackModule } from './modules/feedback/feedback.module.js';
 import { InternalModule } from './modules/internal/internal.module.js';
 import { ProblemsModule } from './modules/problems/problems.module.js';
 import { RoomsModule } from './modules/rooms/rooms.module.js';
@@ -117,6 +118,7 @@ if (!isProd) {
     RoomsModule,
     SessionsModule,
     ProblemsModule,
+    FeedbackModule,
     ExecutionModule,
     InternalModule,
   ],

--- a/apps/control-plane/src/modules/feedback/dto/feedback.dto.ts
+++ b/apps/control-plane/src/modules/feedback/dto/feedback.dto.ts
@@ -1,0 +1,5 @@
+import { sessionFeedbackResponseSchema, submitSessionFeedbackSchema } from '@syncode/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class SubmitSessionFeedbackDto extends createZodDto(submitSessionFeedbackSchema) {}
+export class SessionFeedbackResponseDto extends createZodDto(sessionFeedbackResponseSchema) {}

--- a/apps/control-plane/src/modules/feedback/feedback.controller.spec.ts
+++ b/apps/control-plane/src/modules/feedback/feedback.controller.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FeedbackController } from './feedback.controller.js';
+import type { FeedbackService } from './feedback.service.js';
+
+const AUTH_USER = { id: 'reviewer-1', email: 'reviewer@example.com' };
+const FEEDBACK_RESULT = {
+  allSubmitted: false,
+  data: [
+    {
+      id: 'feedback-1',
+      sessionId: 'session-1',
+      roomId: 'room-1',
+      reviewerId: 'reviewer-1',
+      reviewerName: 'Reviewer',
+      candidateId: 'candidate-1',
+      candidateName: 'Candidate',
+      problemSolvingRating: 4,
+      communicationRating: 5,
+      codeQualityRating: 4,
+      debuggingRating: 3,
+      overallRating: 4,
+      strengths: 'Clear reasoning',
+      improvements: 'Name edge cases earlier',
+      wouldPairAgain: true,
+      createdAt: new Date('2026-04-01T00:00:00Z'),
+    },
+  ],
+};
+
+const FEEDBACK_BODY = {
+  candidateId: 'candidate-1',
+  problemSolvingRating: 4,
+  communicationRating: 5,
+  codeQualityRating: 4,
+  debuggingRating: 3,
+  overallRating: 4,
+  strengths: 'Clear reasoning',
+  improvements: 'Name edge cases earlier',
+  wouldPairAgain: true,
+};
+
+function createFixture() {
+  const feedbackService: Pick<
+    FeedbackService,
+    'isAdmin' | 'submitSessionFeedback' | 'getSessionFeedback'
+  > = {
+    isAdmin: vi.fn(async () => false),
+    submitSessionFeedback: vi.fn(async () => FEEDBACK_RESULT),
+    getSessionFeedback: vi.fn(async () => FEEDBACK_RESULT),
+  };
+
+  return {
+    controller: new FeedbackController(feedbackService as FeedbackService),
+    feedbackService,
+  };
+}
+
+describe('FeedbackController', () => {
+  it('GIVEN structured feedback WHEN submitting THEN serializes createdAt and returns visibility state', async () => {
+    const { controller, feedbackService } = createFixture();
+
+    const result = await controller.submitSessionFeedback(AUTH_USER, 'session-1', FEEDBACK_BODY);
+
+    expect(feedbackService.submitSessionFeedback).toHaveBeenCalledWith(
+      'session-1',
+      'reviewer-1',
+      FEEDBACK_BODY,
+      false,
+    );
+    expect(result.allSubmitted).toBe(false);
+    expect(result.data[0].createdAt).toBe('2026-04-01T00:00:00.000Z');
+  });
+
+  it('GIVEN a session id WHEN retrieving feedback THEN serializes createdAt and returns entries', async () => {
+    const { controller, feedbackService } = createFixture();
+
+    const result = await controller.getSessionFeedback(AUTH_USER, 'session-1');
+
+    expect(feedbackService.getSessionFeedback).toHaveBeenCalledWith(
+      'session-1',
+      'reviewer-1',
+      false,
+    );
+    expect(result.data[0].reviewerName).toBe('Reviewer');
+    expect(result.data[0].createdAt).toBe('2026-04-01T00:00:00.000Z');
+  });
+});

--- a/apps/control-plane/src/modules/feedback/feedback.controller.ts
+++ b/apps/control-plane/src/modules/feedback/feedback.controller.ts
@@ -1,0 +1,77 @@
+import { Body, Controller, Get, HttpCode, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { CONTROL_API } from '@syncode/contracts';
+import { CurrentUser } from '@/common/decorators/current-user.decorator.js';
+import { ErrorResponseDto } from '@/common/dto/error-response.dto.js';
+import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard.js';
+import type { AuthUser } from '@/modules/auth/auth.types.js';
+import { SessionFeedbackResponseDto, SubmitSessionFeedbackDto } from './dto/feedback.dto.js';
+import { FeedbackService } from './feedback.service.js';
+import type { SessionFeedbackResult } from './feedback.types.js';
+
+@ApiTags('feedback')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller()
+export class FeedbackController {
+  constructor(private readonly feedbackService: FeedbackService) {}
+
+  @Post(CONTROL_API.FEEDBACK.SUBMIT_SESSION.route)
+  @HttpCode(201)
+  @ApiOperation({ summary: 'Submit peer feedback for a session' })
+  @ApiParam({ name: 'id', description: 'Session ID (UUID)' })
+  @ApiBody({ type: SubmitSessionFeedbackDto })
+  @ApiResponse({ status: 201, type: SessionFeedbackResponseDto })
+  @ApiResponse({ status: 400, type: ErrorResponseDto, description: 'Validation error' })
+  @ApiResponse({ status: 401, type: ErrorResponseDto, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, type: ErrorResponseDto, description: 'Not a participant' })
+  @ApiResponse({ status: 404, type: ErrorResponseDto, description: 'Session not found' })
+  @ApiResponse({ status: 409, type: ErrorResponseDto, description: 'Feedback already submitted' })
+  async submitSessionFeedback(
+    @CurrentUser() user: AuthUser,
+    @Param('id') sessionId: string,
+    @Body() body: SubmitSessionFeedbackDto,
+  ): Promise<SessionFeedbackResponseDto> {
+    const isAdmin = await this.feedbackService.isAdmin(user.id);
+    const result = await this.feedbackService.submitSessionFeedback(
+      sessionId,
+      user.id,
+      body,
+      isAdmin,
+    );
+    return serializeFeedback(result);
+  }
+
+  @Get(CONTROL_API.FEEDBACK.GET_SESSION.route)
+  @ApiOperation({ summary: 'Get peer feedback for a session' })
+  @ApiParam({ name: 'id', description: 'Session ID (UUID)' })
+  @ApiResponse({ status: 200, type: SessionFeedbackResponseDto })
+  @ApiResponse({ status: 401, type: ErrorResponseDto, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, type: ErrorResponseDto, description: 'Not a participant' })
+  @ApiResponse({ status: 404, type: ErrorResponseDto, description: 'Session not found' })
+  async getSessionFeedback(
+    @CurrentUser() user: AuthUser,
+    @Param('id') sessionId: string,
+  ): Promise<SessionFeedbackResponseDto> {
+    const isAdmin = await this.feedbackService.isAdmin(user.id);
+    const result = await this.feedbackService.getSessionFeedback(sessionId, user.id, isAdmin);
+    return serializeFeedback(result);
+  }
+}
+
+function serializeFeedback(result: SessionFeedbackResult): SessionFeedbackResponseDto {
+  return {
+    allSubmitted: result.allSubmitted,
+    data: result.data.map((entry) => ({
+      ...entry,
+      createdAt: entry.createdAt.toISOString(),
+    })),
+  };
+}

--- a/apps/control-plane/src/modules/feedback/feedback.module.ts
+++ b/apps/control-plane/src/modules/feedback/feedback.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { FeedbackController } from './feedback.controller.js';
+import { FeedbackService } from './feedback.service.js';
+
+@Module({
+  controllers: [FeedbackController],
+  providers: [FeedbackService],
+})
+export class FeedbackModule {}

--- a/apps/control-plane/src/modules/feedback/feedback.service.integration.spec.ts
+++ b/apps/control-plane/src/modules/feedback/feedback.service.integration.spec.ts
@@ -146,12 +146,31 @@ describe('FeedbackService', () => {
     );
   });
 
+  it('GIVEN observer WHEN submitting feedback THEN throws forbidden', async () => {
+    const { observer, candidate, session } = await seedPeerSession();
+
+    await expect(
+      service.submitSessionFeedback(
+        session.id,
+        observer.id,
+        { ...FEEDBACK_INPUT, candidateId: candidate.id },
+        false,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
   it('GIVEN partial submissions WHEN reading feedback THEN hides other reviewers until all expected feedback is submitted', async () => {
-    const { reviewer, candidate, session, room } = await seedPeerSession();
+    const { reviewer, candidate, observer, session, room } = await seedPeerSession();
     await insertPeerFeedbackRow(db, {
       sessionId: session.id,
       roomId: room.id,
       reviewerId: reviewer.id,
+      candidateId: candidate.id,
+    });
+    await insertPeerFeedbackRow(db, {
+      sessionId: session.id,
+      roomId: room.id,
+      reviewerId: observer.id,
       candidateId: candidate.id,
     });
 

--- a/apps/control-plane/src/modules/feedback/feedback.service.integration.spec.ts
+++ b/apps/control-plane/src/modules/feedback/feedback.service.integration.spec.ts
@@ -1,0 +1,201 @@
+import { BadRequestException, ConflictException, ForbiddenException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ERROR_CODES } from '@syncode/contracts';
+import type { Database } from '@syncode/db';
+import { peerFeedback } from '@syncode/db';
+import { and, eq } from 'drizzle-orm';
+import { DB_CLIENT } from '@/modules/db/db.module.js';
+import {
+  createTestDb,
+  insertPeerFeedbackRow,
+  insertRoom,
+  insertSession,
+  insertSessionParticipant,
+  insertUser,
+} from '@/test/integration-setup.js';
+import { FeedbackService } from './feedback.service.js';
+
+let db: Database;
+let cleanup: () => Promise<void>;
+let service: FeedbackService;
+
+const FEEDBACK_INPUT = {
+  candidateId: '',
+  problemSolvingRating: 4,
+  communicationRating: 5,
+  codeQualityRating: 4,
+  debuggingRating: 3,
+  overallRating: 4,
+  strengths: 'Explained the approach clearly',
+  improvements: 'Call out edge cases earlier',
+  wouldPairAgain: true,
+};
+
+beforeEach(async () => {
+  const testDb = await createTestDb();
+  db = testDb.db;
+  cleanup = testDb.cleanup;
+
+  const module = await Test.createTestingModule({
+    providers: [FeedbackService, { provide: DB_CLIENT, useValue: db }],
+  }).compile();
+
+  service = module.get(FeedbackService);
+});
+
+afterEach(async () => {
+  await cleanup();
+});
+
+async function seedPeerSession() {
+  const reviewer = await insertUser(db, { displayName: 'Reviewer' });
+  const candidate = await insertUser(db, { displayName: 'Candidate' });
+  const observer = await insertUser(db, { displayName: 'Observer' });
+  const room = await insertRoom(db, reviewer.id);
+  const session = await insertSession(db, room.id);
+  await insertSessionParticipant(db, session.id, reviewer.id, 'interviewer');
+  await insertSessionParticipant(db, session.id, candidate.id, 'candidate');
+  await insertSessionParticipant(db, session.id, observer.id, 'observer');
+
+  return { reviewer, candidate, observer, room, session };
+}
+
+describe('FeedbackService', () => {
+  it('GIVEN participant feedback WHEN submitting THEN inserts row and returns reviewer-visible feedback', async () => {
+    const { reviewer, candidate, session, room } = await seedPeerSession();
+
+    const result = await service.submitSessionFeedback(
+      session.id,
+      reviewer.id,
+      { ...FEEDBACK_INPUT, candidateId: candidate.id },
+      false,
+    );
+
+    expect(result.allSubmitted).toBe(false);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toMatchObject({
+      sessionId: session.id,
+      roomId: room.id,
+      reviewerId: reviewer.id,
+      reviewerName: 'Reviewer',
+      candidateId: candidate.id,
+      candidateName: 'Candidate',
+      problemSolvingRating: 4,
+      communicationRating: 5,
+      codeQualityRating: 4,
+      debuggingRating: 3,
+      overallRating: 4,
+      strengths: 'Explained the approach clearly',
+      improvements: 'Call out edge cases earlier',
+      wouldPairAgain: true,
+    });
+
+    const rows = await db
+      .select()
+      .from(peerFeedback)
+      .where(and(eq(peerFeedback.sessionId, session.id), eq(peerFeedback.reviewerId, reviewer.id)));
+    expect(rows).toHaveLength(1);
+  });
+
+  it('GIVEN existing reviewer-candidate feedback WHEN submitting again THEN throws conflict', async () => {
+    const { reviewer, candidate, session } = await seedPeerSession();
+    await service.submitSessionFeedback(
+      session.id,
+      reviewer.id,
+      { ...FEEDBACK_INPUT, candidateId: candidate.id },
+      false,
+    );
+
+    await expect(
+      service.submitSessionFeedback(
+        session.id,
+        reviewer.id,
+        { ...FEEDBACK_INPUT, candidateId: candidate.id },
+        false,
+      ),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('GIVEN reviewer targets themselves WHEN submitting THEN rejects validation', async () => {
+    const { reviewer, session } = await seedPeerSession();
+
+    await expect(
+      service.submitSessionFeedback(
+        session.id,
+        reviewer.id,
+        { ...FEEDBACK_INPUT, candidateId: reviewer.id },
+        false,
+      ),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('GIVEN non-participant WHEN submitting or reading feedback THEN throws forbidden', async () => {
+    const { candidate, session } = await seedPeerSession();
+    const stranger = await insertUser(db);
+
+    await expect(
+      service.submitSessionFeedback(
+        session.id,
+        stranger.id,
+        { ...FEEDBACK_INPUT, candidateId: candidate.id },
+        false,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+    await expect(service.getSessionFeedback(session.id, stranger.id, false)).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('GIVEN partial submissions WHEN reading feedback THEN hides other reviewers until all expected feedback is submitted', async () => {
+    const { reviewer, candidate, session, room } = await seedPeerSession();
+    await insertPeerFeedbackRow(db, {
+      sessionId: session.id,
+      roomId: room.id,
+      reviewerId: reviewer.id,
+      candidateId: candidate.id,
+    });
+
+    const candidateView = await service.getSessionFeedback(session.id, candidate.id, false);
+    expect(candidateView.allSubmitted).toBe(false);
+    expect(candidateView.data).toHaveLength(0);
+
+    await insertPeerFeedbackRow(db, {
+      sessionId: session.id,
+      roomId: room.id,
+      reviewerId: candidate.id,
+      candidateId: reviewer.id,
+    });
+
+    const completedView = await service.getSessionFeedback(session.id, candidate.id, false);
+    expect(completedView.allSubmitted).toBe(true);
+    expect(completedView.data).toHaveLength(2);
+  });
+
+  it('GIVEN partial submissions WHEN admin reads feedback THEN returns all existing entries', async () => {
+    const { reviewer, candidate, session, room } = await seedPeerSession();
+    const admin = await insertUser(db, { role: 'admin' });
+    await insertPeerFeedbackRow(db, {
+      sessionId: session.id,
+      roomId: room.id,
+      reviewerId: reviewer.id,
+      candidateId: candidate.id,
+    });
+
+    const result = await service.getSessionFeedback(session.id, admin.id, true);
+
+    expect(result.allSubmitted).toBe(false);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].reviewerId).toBe(reviewer.id);
+  });
+
+  it('GIVEN ongoing session WHEN reading feedback THEN reports session not found', async () => {
+    const reviewer = await insertUser(db);
+    const room = await insertRoom(db, reviewer.id);
+    const session = await insertSession(db, room.id, { status: 'ongoing' });
+    await insertSessionParticipant(db, session.id, reviewer.id, 'interviewer');
+
+    await expect(service.getSessionFeedback(session.id, reviewer.id, false)).rejects.toMatchObject({
+      response: { code: ERROR_CODES.SESSION_NOT_FOUND },
+    });
+  });
+});

--- a/apps/control-plane/src/modules/feedback/feedback.service.ts
+++ b/apps/control-plane/src/modules/feedback/feedback.service.ts
@@ -202,10 +202,13 @@ export class FeedbackService {
 }
 
 function isUniqueViolation(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    (error as { code?: unknown }).code === '23505'
-  );
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  if ('code' in error && (error as { code?: unknown }).code === '23505') {
+    return true;
+  }
+
+  return 'cause' in error && isUniqueViolation((error as { cause?: unknown }).cause);
 }

--- a/apps/control-plane/src/modules/feedback/feedback.service.ts
+++ b/apps/control-plane/src/modules/feedback/feedback.service.ts
@@ -9,7 +9,7 @@ import {
 import { ERROR_CODES, type SubmitSessionFeedbackInput } from '@syncode/contracts';
 import type { Database } from '@syncode/db';
 import { peerFeedback, sessionParticipants, sessions, users } from '@syncode/db';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, asc, eq, inArray } from 'drizzle-orm';
 import { DB_CLIENT } from '@/modules/db/db.module.js';
 import type { SessionFeedbackEntryResult, SessionFeedbackResult } from './feedback.types.js';
 
@@ -25,9 +25,7 @@ export class FeedbackService {
   ): Promise<SessionFeedbackResult> {
     const session = await this.getFinishedSession(sessionId);
 
-    if (!isAdmin) {
-      await this.assertParticipant(sessionId, reviewerId);
-    }
+    await this.assertReviewParticipant(sessionId, reviewerId);
 
     if (reviewerId === input.candidateId) {
       throw new BadRequestException({
@@ -36,7 +34,7 @@ export class FeedbackService {
       });
     }
 
-    await this.assertParticipant(sessionId, input.candidateId);
+    await this.assertReviewParticipant(sessionId, input.candidateId);
 
     try {
       await this.db.insert(peerFeedback).values({
@@ -83,10 +81,16 @@ export class FeedbackService {
       this.getFeedbackRows(sessionId),
     ]);
 
-    const expectedCount = participants.length * Math.max(participants.length - 1, 0);
-    const allSubmitted = expectedCount > 0 && feedback.length >= expectedCount;
-    const visibleFeedback =
-      isAdmin || allSubmitted ? feedback : feedback.filter((entry) => entry.reviewerId === userId);
+    const reviewParticipantIds = new Set(participants.map((participant) => participant.userId));
+    const reviewFeedback = feedback.filter(
+      (entry) =>
+        reviewParticipantIds.has(entry.reviewerId) && reviewParticipantIds.has(entry.candidateId),
+    );
+    const expectedCount = reviewParticipantIds.size * Math.max(reviewParticipantIds.size - 1, 0);
+    const allSubmitted = expectedCount > 0 && reviewFeedback.length >= expectedCount;
+    const visibleFeedback = isAdmin
+      ? feedback
+      : reviewFeedback.filter((entry) => allSubmitted || entry.reviewerId === userId);
 
     return { allSubmitted, data: visibleFeedback };
   }
@@ -129,6 +133,25 @@ export class FeedbackService {
     }
   }
 
+  private async assertReviewParticipant(sessionId: string, userId: string): Promise<void> {
+    const participant = await this.db.query.sessionParticipants.findFirst({
+      columns: { userId: true },
+      where: (table, { and, eq, inArray }) =>
+        and(
+          eq(table.sessionId, sessionId),
+          eq(table.userId, userId),
+          inArray(table.role, ['candidate', 'interviewer']),
+        ),
+    });
+
+    if (!participant) {
+      throw new ForbiddenException({
+        message: 'Only candidates and interviewers can submit peer feedback',
+        code: ERROR_CODES.FORBIDDEN,
+      });
+    }
+  }
+
   private async getReviewParticipants(sessionId: string) {
     return this.db
       .select({ userId: sessionParticipants.userId })
@@ -163,7 +186,8 @@ export class FeedbackService {
       })
       .from(peerFeedback)
       .innerJoin(users, eq(users.id, peerFeedback.reviewerId))
-      .where(eq(peerFeedback.sessionId, sessionId));
+      .where(eq(peerFeedback.sessionId, sessionId))
+      .orderBy(asc(peerFeedback.createdAt));
 
     const candidateNames = await this.getUserNames(rows.map((row) => row.candidateId));
 

--- a/apps/control-plane/src/modules/feedback/feedback.service.ts
+++ b/apps/control-plane/src/modules/feedback/feedback.service.ts
@@ -1,0 +1,211 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { ERROR_CODES, type SubmitSessionFeedbackInput } from '@syncode/contracts';
+import type { Database } from '@syncode/db';
+import { peerFeedback, sessionParticipants, sessions, users } from '@syncode/db';
+import { and, eq, inArray } from 'drizzle-orm';
+import { DB_CLIENT } from '@/modules/db/db.module.js';
+import type { SessionFeedbackEntryResult, SessionFeedbackResult } from './feedback.types.js';
+
+@Injectable()
+export class FeedbackService {
+  constructor(@Inject(DB_CLIENT) private readonly db: Database) {}
+
+  async submitSessionFeedback(
+    sessionId: string,
+    reviewerId: string,
+    input: SubmitSessionFeedbackInput,
+    isAdmin: boolean,
+  ): Promise<SessionFeedbackResult> {
+    const session = await this.getFinishedSession(sessionId);
+
+    if (!isAdmin) {
+      await this.assertParticipant(sessionId, reviewerId);
+    }
+
+    if (reviewerId === input.candidateId) {
+      throw new BadRequestException({
+        message: 'Reviewer and candidate must be different users',
+        code: ERROR_CODES.VALIDATION_FAILED,
+      });
+    }
+
+    await this.assertParticipant(sessionId, input.candidateId);
+
+    try {
+      await this.db.insert(peerFeedback).values({
+        sessionId,
+        roomId: session.roomId,
+        reviewerId,
+        candidateId: input.candidateId,
+        problemSolvingRating: input.problemSolvingRating,
+        communicationRating: input.communicationRating,
+        codeQualityRating: input.codeQualityRating,
+        debuggingRating: input.debuggingRating,
+        overallRating: input.overallRating,
+        strengths: input.strengths,
+        improvements: input.improvements,
+        wouldPairAgain: input.wouldPairAgain,
+      });
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new ConflictException({
+          message: 'Feedback already submitted for this participant',
+          code: ERROR_CODES.FEEDBACK_ALREADY_SUBMITTED,
+        });
+      }
+
+      throw error;
+    }
+
+    return this.getSessionFeedback(sessionId, reviewerId, isAdmin);
+  }
+
+  async getSessionFeedback(
+    sessionId: string,
+    userId: string,
+    isAdmin: boolean,
+  ): Promise<SessionFeedbackResult> {
+    await this.getFinishedSession(sessionId);
+
+    if (!isAdmin) {
+      await this.assertParticipant(sessionId, userId);
+    }
+
+    const [participants, feedback] = await Promise.all([
+      this.getReviewParticipants(sessionId),
+      this.getFeedbackRows(sessionId),
+    ]);
+
+    const expectedCount = participants.length * Math.max(participants.length - 1, 0);
+    const allSubmitted = expectedCount > 0 && feedback.length >= expectedCount;
+    const visibleFeedback =
+      isAdmin || allSubmitted ? feedback : feedback.filter((entry) => entry.reviewerId === userId);
+
+    return { allSubmitted, data: visibleFeedback };
+  }
+
+  async isAdmin(userId: string): Promise<boolean> {
+    const user = await this.db.query.users.findFirst({
+      columns: { role: true },
+      where: (table, { eq }) => eq(table.id, userId),
+    });
+    return user?.role === 'admin';
+  }
+
+  private async getFinishedSession(sessionId: string) {
+    const [session] = await this.db
+      .select({ id: sessions.id, roomId: sessions.roomId })
+      .from(sessions)
+      .where(and(eq(sessions.id, sessionId), eq(sessions.status, 'finished')));
+
+    if (!session) {
+      throw new NotFoundException({
+        message: 'Session not found',
+        code: ERROR_CODES.SESSION_NOT_FOUND,
+      });
+    }
+
+    return session;
+  }
+
+  private async assertParticipant(sessionId: string, userId: string): Promise<void> {
+    const participant = await this.db.query.sessionParticipants.findFirst({
+      columns: { userId: true },
+      where: (table, { and, eq }) => and(eq(table.sessionId, sessionId), eq(table.userId, userId)),
+    });
+
+    if (!participant) {
+      throw new ForbiddenException({
+        message: 'Not a participant of this session',
+        code: ERROR_CODES.SESSION_NOT_PARTICIPANT,
+      });
+    }
+  }
+
+  private async getReviewParticipants(sessionId: string) {
+    return this.db
+      .select({ userId: sessionParticipants.userId })
+      .from(sessionParticipants)
+      .where(
+        and(
+          eq(sessionParticipants.sessionId, sessionId),
+          inArray(sessionParticipants.role, ['candidate', 'interviewer']),
+        ),
+      );
+  }
+
+  private async getFeedbackRows(sessionId: string): Promise<SessionFeedbackEntryResult[]> {
+    const rows = await this.db
+      .select({
+        id: peerFeedback.id,
+        sessionId: peerFeedback.sessionId,
+        roomId: peerFeedback.roomId,
+        reviewerId: peerFeedback.reviewerId,
+        reviewerUsername: users.username,
+        reviewerDisplayName: users.displayName,
+        candidateId: peerFeedback.candidateId,
+        problemSolvingRating: peerFeedback.problemSolvingRating,
+        communicationRating: peerFeedback.communicationRating,
+        codeQualityRating: peerFeedback.codeQualityRating,
+        debuggingRating: peerFeedback.debuggingRating,
+        overallRating: peerFeedback.overallRating,
+        strengths: peerFeedback.strengths,
+        improvements: peerFeedback.improvements,
+        wouldPairAgain: peerFeedback.wouldPairAgain,
+        createdAt: peerFeedback.createdAt,
+      })
+      .from(peerFeedback)
+      .innerJoin(users, eq(users.id, peerFeedback.reviewerId))
+      .where(eq(peerFeedback.sessionId, sessionId));
+
+    const candidateNames = await this.getUserNames(rows.map((row) => row.candidateId));
+
+    return rows.map((row) => ({
+      id: row.id,
+      sessionId: row.sessionId ?? sessionId,
+      roomId: row.roomId,
+      reviewerId: row.reviewerId,
+      reviewerName: row.reviewerDisplayName ?? row.reviewerUsername,
+      candidateId: row.candidateId,
+      candidateName: candidateNames.get(row.candidateId) ?? row.candidateId,
+      problemSolvingRating: row.problemSolvingRating,
+      communicationRating: row.communicationRating,
+      codeQualityRating: row.codeQualityRating,
+      debuggingRating: row.debuggingRating,
+      overallRating: row.overallRating,
+      strengths: row.strengths,
+      improvements: row.improvements,
+      wouldPairAgain: row.wouldPairAgain,
+      createdAt: row.createdAt,
+    }));
+  }
+
+  private async getUserNames(userIds: string[]): Promise<Map<string, string>> {
+    if (userIds.length === 0) {
+      return new Map();
+    }
+
+    const rows = await this.db
+      .select({ id: users.id, username: users.username, displayName: users.displayName })
+      .from(users)
+      .where(inArray(users.id, [...new Set(userIds)]));
+
+    return new Map(rows.map((row) => [row.id, row.displayName ?? row.username]));
+  }
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === '23505'
+  );
+}

--- a/apps/control-plane/src/modules/feedback/feedback.service.ts
+++ b/apps/control-plane/src/modules/feedback/feedback.service.ts
@@ -11,6 +11,10 @@ import type { Database } from '@syncode/db';
 import { peerFeedback, sessionParticipants, sessions, users } from '@syncode/db';
 import { and, asc, eq, inArray } from 'drizzle-orm';
 import { DB_CLIENT } from '@/modules/db/db.module.js';
+import {
+  filterReviewFeedback,
+  isAllReviewFeedbackSubmitted,
+} from '@/modules/sessions/session-feedback-utils.js';
 import type { SessionFeedbackEntryResult, SessionFeedbackResult } from './feedback.types.js';
 
 @Injectable()
@@ -82,12 +86,11 @@ export class FeedbackService {
     ]);
 
     const reviewParticipantIds = new Set(participants.map((participant) => participant.userId));
-    const reviewFeedback = feedback.filter(
-      (entry) =>
-        reviewParticipantIds.has(entry.reviewerId) && reviewParticipantIds.has(entry.candidateId),
+    const reviewFeedback = filterReviewFeedback(feedback, reviewParticipantIds);
+    const allSubmitted = isAllReviewFeedbackSubmitted(
+      reviewParticipantIds.size,
+      reviewFeedback.length,
     );
-    const expectedCount = reviewParticipantIds.size * Math.max(reviewParticipantIds.size - 1, 0);
-    const allSubmitted = expectedCount > 0 && reviewFeedback.length >= expectedCount;
     const visibleFeedback = isAdmin
       ? feedback
       : reviewFeedback.filter((entry) => allSubmitted || entry.reviewerId === userId);

--- a/apps/control-plane/src/modules/feedback/feedback.types.ts
+++ b/apps/control-plane/src/modules/feedback/feedback.types.ts
@@ -1,0 +1,23 @@
+export interface SessionFeedbackEntryResult {
+  id: string;
+  sessionId: string;
+  roomId: string;
+  reviewerId: string;
+  reviewerName: string;
+  candidateId: string;
+  candidateName: string;
+  problemSolvingRating: number;
+  communicationRating: number;
+  codeQualityRating: number;
+  debuggingRating: number;
+  overallRating: number;
+  strengths: string;
+  improvements: string;
+  wouldPairAgain: boolean;
+  createdAt: Date;
+}
+
+export interface SessionFeedbackResult {
+  allSubmitted: boolean;
+  data: SessionFeedbackEntryResult[];
+}

--- a/apps/control-plane/src/modules/sessions/session-feedback-utils.ts
+++ b/apps/control-plane/src/modules/sessions/session-feedback-utils.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared utilities for session-feedback aggregation.
+ *
+ * Used by both the feedback module (PR #282) and the sessions detail page
+ * (PR #281). Keeping these in a single place ensures the
+ * "all reviewers submitted" calculation stays consistent across endpoints.
+ */
+
+export interface FeedbackEntry {
+  reviewerId: string;
+  candidateId: string;
+}
+
+/**
+ * Compute the expected number of peer-feedback rows for a given set of review
+ * participants. Each reviewer must submit one feedback per other reviewer, so
+ * the expected count is `n * (n - 1)`.
+ */
+export function expectedReviewFeedbackCount(reviewParticipantCount: number): number {
+  return reviewParticipantCount * Math.max(reviewParticipantCount - 1, 0);
+}
+
+/**
+ * Filter raw feedback rows down to entries where both the reviewer and the
+ * candidate are in the supplied review-participant set.
+ */
+export function filterReviewFeedback<T extends FeedbackEntry>(
+  feedback: readonly T[],
+  reviewParticipantIds: ReadonlySet<string>,
+): T[] {
+  return feedback.filter(
+    (entry) =>
+      reviewParticipantIds.has(entry.reviewerId) && reviewParticipantIds.has(entry.candidateId),
+  );
+}
+
+/**
+ * Determine whether every expected reviewer pairing has produced a feedback
+ * row.
+ */
+export function isAllReviewFeedbackSubmitted(
+  reviewParticipantCount: number,
+  reviewFeedbackCount: number,
+): boolean {
+  const expected = expectedReviewFeedbackCount(reviewParticipantCount);
+  return expected > 0 && reviewFeedbackCount >= expected;
+}

--- a/packages/contracts/src/control/feedback.ts
+++ b/packages/contracts/src/control/feedback.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+const ratingSchema = z.number().int().min(1).max(5);
+
+export const submitSessionFeedbackSchema = z.object({
+  candidateId: z.uuid(),
+  problemSolvingRating: ratingSchema,
+  communicationRating: ratingSchema,
+  codeQualityRating: ratingSchema,
+  debuggingRating: ratingSchema,
+  overallRating: ratingSchema,
+  strengths: z.string().trim().min(1).max(2000),
+  improvements: z.string().trim().min(1).max(2000),
+  wouldPairAgain: z.boolean(),
+});
+
+export const sessionFeedbackEntrySchema = submitSessionFeedbackSchema.extend({
+  id: z.uuid(),
+  sessionId: z.uuid(),
+  roomId: z.uuid(),
+  reviewerId: z.uuid(),
+  reviewerName: z.string(),
+  candidateName: z.string(),
+  createdAt: z.iso.datetime(),
+});
+
+export const sessionFeedbackResponseSchema = z.object({
+  allSubmitted: z.boolean(),
+  data: z.array(sessionFeedbackEntrySchema),
+});
+
+export type SubmitSessionFeedbackInput = z.infer<typeof submitSessionFeedbackSchema>;
+export type SessionFeedbackEntry = z.infer<typeof sessionFeedbackEntrySchema>;
+export type SessionFeedbackResponse = z.infer<typeof sessionFeedbackResponseSchema>;

--- a/packages/contracts/src/control/index.ts
+++ b/packages/contracts/src/control/index.ts
@@ -2,6 +2,7 @@ export * from './auth.js';
 export * from './bookmarks.js';
 export * from './error.js';
 export * from './execution.js';
+export * from './feedback.js';
 export * from './health.js';
 export * from './pagination.js';
 export * from './problems.js';

--- a/packages/contracts/src/control/routes.ts
+++ b/packages/contracts/src/control/routes.ts
@@ -13,6 +13,7 @@ import type {
   executionResultResponseSchema,
   jobStatusResponseSchema,
 } from './execution.js';
+import type { sessionFeedbackResponseSchema, submitSessionFeedbackSchema } from './feedback.js';
 import type { healthCheckResponseSchema } from './health.js';
 import type {
   problemDetailSchema,
@@ -170,6 +171,16 @@ export const CONTROL_API = {
     >()('sessions', 'GET'),
     GET: defineRoute<void, z.infer<typeof sessionDetailSchema>>()('sessions/:id', 'GET'),
     DELETE: defineRoute<void, void>()('sessions/:id', 'DELETE'),
+  },
+  FEEDBACK: {
+    SUBMIT_SESSION: defineRoute<
+      z.infer<typeof submitSessionFeedbackSchema>,
+      z.infer<typeof sessionFeedbackResponseSchema>
+    >()('sessions/:id/feedback', 'POST'),
+    GET_SESSION: defineRoute<void, z.infer<typeof sessionFeedbackResponseSchema>>()(
+      'sessions/:id/feedback',
+      'GET',
+    ),
   },
   HEALTH: defineRoute<void, z.infer<typeof healthCheckResponseSchema>>()('health', 'GET'),
 };


### PR DESCRIPTION
Closes #158

## Summary
- Adds POST/GET endpoints for structured session peer feedback.
- Validates feedback payloads with shared contract schemas.
- Enforces reviewer/candidate permissions and duplicate submission handling.
- Adds controller unit tests and service integration coverage.

## Verification
- corepack pnpm --filter @syncode/control-plane build
- corepack pnpm --filter @syncode/control-plane test -- src/modules/feedback
- corepack pnpm --filter @syncode/control-plane exec vitest run --config vitest.integration.config.ts src/modules/feedback/feedback.service.integration.spec.ts
