### PR TITLE
feat(web): add inline comment UI

### DIFF
--- a/apps/web/src/components/collaborative-editor.tsx
+++ b/apps/web/src/components/collaborative-editor.tsx
@@ -36,6 +36,7 @@ interface EditorLike {
   onDidChangeCursorPosition: (
     listener: (event: { position: { lineNumber: number } }) => void,
   ) => void;
+  onMouseDown: (listener: (event: EditorMouseEvent) => void) => void;
   deltaDecorations: (
     oldDecorations: string[],
     newDecorations: Array<{
@@ -48,6 +49,13 @@ interface EditorLike {
       options: Record<string, unknown>;
     }>,
   ) => string[];
+}
+
+interface EditorMouseEvent {
+  target: {
+    type: number;
+    position: { lineNumber: number } | null;
+  };
 }
 
 interface MonacoLike {
@@ -106,6 +114,15 @@ export function CollaborativeEditor({
     onActiveLineChangeRef.current(editorInstance.getPosition()?.lineNumber ?? 1);
     editorInstance.onDidChangeCursorPosition((event) => {
       onActiveLineChangeRef.current(event.position.lineNumber);
+    });
+
+    // MouseTargetType.GUTTER_GLYPH_MARGIN === 2 in Monaco's enum.
+    // Clicking the glyph icon sets the active comment line directly so the
+    // panel jumps to that line's thread even when the cursor hasn't moved.
+    editorInstance.onMouseDown((event) => {
+      if (event.target.type === 2 && event.target.position) {
+        onActiveLineChangeRef.current(event.target.position.lineNumber);
+      }
     });
 
     setEditor(editorInstance);

--- a/apps/web/src/hooks/use-inline-comments.spec.ts
+++ b/apps/web/src/hooks/use-inline-comments.spec.ts
@@ -1,0 +1,107 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
+import { CODE_TEXT_KEY } from '@/lib/yjs-collab-provider.js';
+import { useInlineComments } from './use-inline-comments.js';
+
+function makeDoc(code = 'line1\nline2\nline3') {
+  const doc = new Y.Doc();
+  doc.getText(CODE_TEXT_KEY).insert(0, code);
+  return doc;
+}
+
+describe('useInlineComments', () => {
+  it('GIVEN null doc WHEN rendered THEN returns empty state', () => {
+    const { result } = renderHook(() => useInlineComments(null));
+    expect(result.current.comments).toEqual([]);
+    expect(result.current.commentLineNumbers).toEqual([]);
+  });
+
+  it('GIVEN a doc WHEN a comment is added THEN comments list updates reactively', async () => {
+    const doc = makeDoc();
+    const { result } = renderHook(() => useInlineComments(doc));
+
+    expect(result.current.comments).toHaveLength(0);
+
+    act(() => {
+      result.current.addComment({
+        authorId: 'u1',
+        authorName: 'Alice',
+        content: 'Nice',
+        lineNumber: 1,
+      });
+    });
+
+    expect(result.current.comments).toHaveLength(1);
+    expect(result.current.comments[0]?.content).toBe('Nice');
+    expect(result.current.commentLineNumbers).toEqual([1]);
+    doc.destroy();
+  });
+
+  it('GIVEN a comment WHEN updated THEN content is reflected', () => {
+    const doc = makeDoc();
+    const { result } = renderHook(() => useInlineComments(doc));
+
+    act(() => {
+      result.current.addComment({
+        authorId: 'u1',
+        authorName: 'Alice',
+        content: 'Original',
+        lineNumber: 2,
+      });
+    });
+
+    const id = result.current.comments[0]?.id ?? '';
+
+    act(() => {
+      result.current.updateComment(id, { content: 'Revised' });
+    });
+
+    expect(result.current.comments[0]?.content).toBe('Revised');
+    doc.destroy();
+  });
+
+  it('GIVEN a comment WHEN deleted THEN list is empty', () => {
+    const doc = makeDoc();
+    const { result } = renderHook(() => useInlineComments(doc));
+
+    act(() => {
+      result.current.addComment({
+        authorId: 'u1',
+        authorName: 'Alice',
+        content: 'Remove me',
+        lineNumber: 3,
+      });
+    });
+
+    const id = result.current.comments[0]?.id ?? '';
+
+    act(() => {
+      result.current.deleteComment(id);
+    });
+
+    expect(result.current.comments).toHaveLength(0);
+    doc.destroy();
+  });
+
+  it('GIVEN code insertion above a comment WHEN code changes THEN line number tracks with CRDT anchor', async () => {
+    const doc = makeDoc('alpha\nbeta');
+    const { result } = renderHook(() => useInlineComments(doc));
+
+    act(() => {
+      result.current.addComment({
+        authorId: 'u1',
+        authorName: 'Alice',
+        content: 'On beta',
+        lineNumber: 2,
+      });
+    });
+
+    act(() => {
+      doc.getText(CODE_TEXT_KEY).insert(0, 'prefix\n');
+    });
+
+    expect(result.current.comments[0]?.lineNumber).toBe(3);
+    doc.destroy();
+  });
+});

--- a/apps/web/src/hooks/use-inline-comments.spec.ts
+++ b/apps/web/src/hooks/use-inline-comments.spec.ts
@@ -1,12 +1,14 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import * as Y from 'yjs';
-import { CODE_TEXT_KEY } from '@/lib/yjs-collab-provider.js';
+import { codeTextKey } from '@/lib/yjs-collab-provider.js';
 import { useInlineComments } from './use-inline-comments.js';
+
+const TEST_LANGUAGE = 'python';
 
 function makeDoc(code = 'line1\nline2\nline3') {
   const doc = new Y.Doc();
-  doc.getText(CODE_TEXT_KEY).insert(0, code);
+  doc.getText(codeTextKey(TEST_LANGUAGE)).insert(0, code);
   return doc;
 }
 
@@ -98,7 +100,7 @@ describe('useInlineComments', () => {
     });
 
     act(() => {
-      doc.getText(CODE_TEXT_KEY).insert(0, 'prefix\n');
+      doc.getText(codeTextKey(TEST_LANGUAGE)).insert(0, 'prefix\n');
     });
 
     expect(result.current.comments[0]?.lineNumber).toBe(3);

--- a/apps/web/src/hooks/use-livekit.ts
+++ b/apps/web/src/hooks/use-livekit.ts
@@ -497,7 +497,7 @@ export function useLiveKit({
           }
         }
       })
-      .catch((err) => {
+      .catch((err: unknown) => {
         if (disposed) return;
         console.error('[LiveKit] Connection failed:', err);
         setConnectionState('failed');


### PR DESCRIPTION
Implements inline comment interaction in the Monaco editor for issue #126 .
Adds gutter click handling so clicking a comment marker selects the related line, and includes hook-level tests for the inline comments flow.