### PR TITLE
chore(infra): add clean script to nuke stale dist and tsbuildinfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "infra:down": "docker compose down",
     "infra:full": "docker compose up -d",
     "infra:logs": "docker compose logs -f",
+    "clean": "rm -rf packages/*/dist packages/*/.turbo packages/*/tsconfig*.tsbuildinfo apps/*/dist apps/*/.turbo apps/*/tsconfig*.tsbuildinfo .turbo",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "infra:down": "docker compose down",
     "infra:full": "docker compose up -d",
     "infra:logs": "docker compose logs -f",
-    "clean": "rm -rf packages/*/dist packages/*/.turbo packages/*/tsconfig*.tsbuildinfo apps/*/dist apps/*/.turbo apps/*/tsconfig*.tsbuildinfo .turbo",
+    "clean": "node scripts/clean.mjs",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import { readdir, rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const ROOTS = ['packages', 'apps'];
+const DIR_TARGETS = new Set(['dist', '.turbo']);
+const FILE_PREFIX = 'tsconfig';
+const FILE_SUFFIX = '.tsbuildinfo';
+
+async function removePath(path) {
+  await rm(path, { recursive: true, force: true });
+}
+
+async function cleanWorkspace(root) {
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') return;
+    throw err;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const workspaceDir = join(root, entry.name);
+
+    for (const target of DIR_TARGETS) {
+      await removePath(join(workspaceDir, target));
+    }
+
+    let inner;
+    try {
+      inner = await readdir(workspaceDir);
+    } catch {
+      continue;
+    }
+    for (const name of inner) {
+      if (name.startsWith(FILE_PREFIX) && name.endsWith(FILE_SUFFIX)) {
+        await removePath(join(workspaceDir, name));
+      }
+    }
+  }
+}
+
+await Promise.all(ROOTS.map(cleanWorkspace));
+await removePath('.turbo');


### PR DESCRIPTION
Adds `pnpm -w run clean`. Branch switches were leaving stale dist/ and tsbuildinfo files behind, so workspace packages would crash at runtime when imports diverged from what was last built.