### PR TITLE
feat(web): render problem statements as markdown

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,6 +43,7 @@
     "react-i18next": "^17.0.2",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.9.0",
+    "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,6 +43,7 @@
     "react-i18next": "^17.0.2",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.9.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.1",
     "sonner": "^2.0.7",

--- a/apps/web/src/components/problems/constraints-block.tsx
+++ b/apps/web/src/components/problems/constraints-block.tsx
@@ -1,0 +1,32 @@
+import { cn } from '@syncode/ui';
+import { ProblemMarkdown } from './problem-markdown.js';
+
+interface ConstraintsBlockProps {
+  content: string;
+  compact?: boolean;
+  className?: string;
+  title?: string;
+}
+
+export function ConstraintsBlock({
+  content,
+  compact = false,
+  className,
+  title,
+}: ConstraintsBlockProps) {
+  return (
+    <section
+      className={cn(
+        'rounded-lg border border-amber-500/20 border-l-[3px] border-l-amber-400/70 bg-amber-500/5 px-4 py-3',
+        className,
+      )}
+    >
+      {title ? (
+        <h3 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-amber-300/80">
+          {title}
+        </h3>
+      ) : null}
+      <ProblemMarkdown content={content} compact={compact} />
+    </section>
+  );
+}

--- a/apps/web/src/components/problems/problem-detail-layout.tsx
+++ b/apps/web/src/components/problems/problem-detail-layout.tsx
@@ -5,10 +5,10 @@ import { Bookmark, LoaderCircle } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import Markdown from 'react-markdown';
 import i18n from '@/lib/i18n.js';
 import { useToggleProblemBookmarkMutation } from '@/lib/problems/problem-bookmark.js';
 import { useAuthStore } from '@/stores/auth.store.js';
+import { ProblemMarkdown } from './problem-markdown.js';
 import { StarterCodeBlock } from './starter-code-block.js';
 import { formatStarterLanguageLabel } from './starter-code-language.js';
 
@@ -55,12 +55,14 @@ export function ProblemDetailLayout({ problem }: { problem: ProblemDetail }) {
         <div className="grid gap-7 xl:grid-cols-[minmax(0,1fr)_320px]">
           <div className="space-y-5">
             <SectionSurface title={t('detail.description')}>
-              <MarkdownBlock value={problem.description} />
+              <ProblemMarkdown content={problem.description} />
             </SectionSurface>
 
-            <SectionSurface title={t('detail.constraints')}>
-              <MarkdownBlock value={problem.constraints ?? t('detail.noConstraints')} />
-            </SectionSurface>
+            <ConstraintsSurface
+              title={t('detail.constraints')}
+              constraints={problem.constraints}
+              emptyMessage={t('detail.noConstraints')}
+            />
 
             <SectionSurface title={t('detail.examples', { count: problem.examples.length })}>
               <div className="space-y-3">
@@ -250,7 +252,7 @@ function ExamplePanel({ example, index }: { example: ProblemExample; index: numb
         <LabeledCodeBlock label={t('detail.input')} value={example.input} />
         <LabeledCodeBlock label={t('detail.output')} value={example.output} />
         {example.explanation ? (
-          <LabeledTextBlock label={t('detail.explanation')} value={example.explanation} />
+          <LabeledMarkdownBlock label={t('detail.explanation')} value={example.explanation} />
         ) : null}
       </div>
     </div>
@@ -268,7 +270,7 @@ function PublicTestCasePanel({ testCase, index }: { testCase: ProblemTestCase; i
         <LabeledCodeBlock label={t('detail.input')} value={testCase.input} />
         <LabeledCodeBlock label={t('detail.expectedOutput')} value={testCase.expectedOutput} />
         {testCase.description ? (
-          <LabeledTextBlock label={t('detail.explanation')} value={testCase.description} />
+          <LabeledMarkdownBlock label={t('detail.explanation')} value={testCase.description} />
         ) : null}
         <div className="grid gap-2.5 sm:grid-cols-2">
           <InlineStat
@@ -298,24 +300,41 @@ function LabeledCodeBlock({ label, value }: { label: string; value: string }) {
   );
 }
 
-function LabeledTextBlock({ label, value }: { label: string; value: string }) {
+function LabeledMarkdownBlock({ label, value }: { label: string; value: string }) {
   return (
     <div>
       <p className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
         {label}
       </p>
-      <p className="mt-1 rounded-lg border border-border/60 bg-muted/50 px-3.5 py-2 text-sm leading-[1.625rem] text-foreground">
-        {value}
-      </p>
+      <div className="mt-1 rounded-lg border border-border/60 bg-muted/50 px-3.5 py-2">
+        <ProblemMarkdown content={value} />
+      </div>
     </div>
   );
 }
 
-function MarkdownBlock({ value }: { value: string }) {
+function ConstraintsSurface({
+  title,
+  constraints,
+  emptyMessage,
+}: {
+  title: string;
+  constraints: string | null;
+  emptyMessage: string;
+}) {
   return (
-    <div className="prose prose-sm prose-invert max-w-none text-foreground prose-headings:text-foreground prose-strong:text-foreground prose-code:rounded prose-code:bg-muted/70 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-foreground prose-pre:bg-muted/70 prose-li:marker:text-muted-foreground">
-      <Markdown>{value}</Markdown>
-    </div>
+    <section className="overflow-hidden rounded-2xl border border-border/60 bg-card/60 border-l-4 border-l-amber-400/70">
+      <div className="border-b border-border/60 bg-amber-500/5 px-4 py-2.5">
+        <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+      </div>
+      <div className="px-4 py-3">
+        {constraints ? (
+          <ProblemMarkdown content={constraints} />
+        ) : (
+          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+        )}
+      </div>
+    </section>
   );
 }
 

--- a/apps/web/src/components/problems/problem-detail-layout.tsx
+++ b/apps/web/src/components/problems/problem-detail-layout.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import i18n from '@/lib/i18n.js';
 import { useToggleProblemBookmarkMutation } from '@/lib/problems/problem-bookmark.js';
 import { useAuthStore } from '@/stores/auth.store.js';
+import { ConstraintsBlock } from './constraints-block.js';
 import { ProblemMarkdown } from './problem-markdown.js';
 import { StarterCodeBlock } from './starter-code-block.js';
 import { formatStarterLanguageLabel } from './starter-code-language.js';
@@ -58,11 +59,13 @@ export function ProblemDetailLayout({ problem }: { problem: ProblemDetail }) {
               <ProblemMarkdown content={problem.description} />
             </SectionSurface>
 
-            <ConstraintsSurface
-              title={t('detail.constraints')}
-              constraints={problem.constraints}
-              emptyMessage={t('detail.noConstraints')}
-            />
+            {problem.constraints ? (
+              <ConstraintsBlock title={t('detail.constraints')} content={problem.constraints} />
+            ) : (
+              <SectionSurface title={t('detail.constraints')}>
+                <EmptySurfaceCopy message={t('detail.noConstraints')} />
+              </SectionSurface>
+            )}
 
             <SectionSurface title={t('detail.examples', { count: problem.examples.length })}>
               <div className="space-y-3">
@@ -310,31 +313,6 @@ function LabeledMarkdownBlock({ label, value }: { label: string; value: string }
         <ProblemMarkdown content={value} />
       </div>
     </div>
-  );
-}
-
-function ConstraintsSurface({
-  title,
-  constraints,
-  emptyMessage,
-}: {
-  title: string;
-  constraints: string | null;
-  emptyMessage: string;
-}) {
-  return (
-    <section className="overflow-hidden rounded-2xl border border-border/60 bg-card/60 border-l-4 border-l-amber-400/70">
-      <div className="border-b border-border/60 bg-amber-500/5 px-4 py-2.5">
-        <h2 className="text-lg font-semibold text-foreground">{title}</h2>
-      </div>
-      <div className="px-4 py-3">
-        {constraints ? (
-          <ProblemMarkdown content={constraints} />
-        ) : (
-          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
-        )}
-      </div>
-    </section>
   );
 }
 

--- a/apps/web/src/components/problems/problem-markdown.spec.tsx
+++ b/apps/web/src/components/problems/problem-markdown.spec.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ProblemMarkdown } from './problem-markdown.js';
+
+describe('ProblemMarkdown', () => {
+  it('GIVEN valid markdown with bold and lists THEN renders structured HTML', () => {
+    const content = '# Heading\n\n**bold text**\n\n- item one\n- item two';
+    const { container } = render(<ProblemMarkdown content={content} />);
+
+    expect(container.querySelector('h1')).not.toBeNull();
+    expect(container.querySelector('strong')).not.toBeNull();
+    expect(container.querySelectorAll('li')).toHaveLength(2);
+    expect(screen.getByText('Heading')).toBeInTheDocument();
+    expect(screen.getByText('bold text')).toBeInTheDocument();
+    expect(screen.getByText('item one')).toBeInTheDocument();
+    expect(screen.getByText('item two')).toBeInTheDocument();
+  });
+
+  it('GIVEN markdown containing raw <script> THEN the script tag is not rendered in the DOM', () => {
+    const content = 'safe prefix\n\n<script>window.__xss = true;</script>\n\nsafe suffix';
+    const { container } = render(<ProblemMarkdown content={content} />);
+
+    expect(container.querySelector('script')).toBeNull();
+  });
+
+  it('GIVEN a markdown table WHEN rendered THEN the table element is in the DOM', () => {
+    const content = '| name | value |\n| --- | --- |\n| foo | 1 |\n| bar | 2 |';
+    const { container } = render(<ProblemMarkdown content={content} />);
+
+    expect(container.querySelector('table')).not.toBeNull();
+    expect(container.querySelectorAll('tr').length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByText('foo')).toBeInTheDocument();
+    expect(screen.getByText('bar')).toBeInTheDocument();
+  });
+
+  it('GIVEN a link WHEN rendered THEN the anchor has target="_blank" and rel contains "noopener" and "noreferrer"', () => {
+    const content = '[external link](https://example.com)';
+    render(<ProblemMarkdown content={content} />);
+
+    const link = screen.getByRole('link', { name: 'external link' });
+    expect(link).toHaveAttribute('target', '_blank');
+    const rel = link.getAttribute('rel') ?? '';
+    expect(rel).toContain('noopener');
+    expect(rel).toContain('noreferrer');
+  });
+
+  it('GIVEN compact prop THEN the rendered element has a class differentiating it from default', () => {
+    const { container: defaultContainer } = render(<ProblemMarkdown content="hello" />);
+    const { container: compactContainer } = render(<ProblemMarkdown content="hello" compact />);
+
+    const defaultWrapper = defaultContainer.firstElementChild;
+    const compactWrapper = compactContainer.firstElementChild;
+
+    expect(defaultWrapper).not.toBeNull();
+    expect(compactWrapper).not.toBeNull();
+    expect(compactWrapper?.className).not.toBe(defaultWrapper?.className);
+    expect(compactWrapper?.className).toContain('text-xs');
+    expect(defaultWrapper?.className).not.toContain('text-xs');
+  });
+});

--- a/apps/web/src/components/problems/problem-markdown.tsx
+++ b/apps/web/src/components/problems/problem-markdown.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@syncode/ui';
 import type { ComponentPropsWithoutRef } from 'react';
 import Markdown from 'react-markdown';
+import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 
 type ProblemMarkdownProps = {
@@ -36,7 +37,7 @@ export function ProblemMarkdown({ content, className, compact = false }: Problem
         className,
       )}
     >
-      <Markdown remarkPlugins={[remarkGfm]} components={components}>
+      <Markdown remarkPlugins={[remarkGfm, remarkBreaks]} components={components}>
         {content}
       </Markdown>
     </div>

--- a/apps/web/src/components/problems/problem-markdown.tsx
+++ b/apps/web/src/components/problems/problem-markdown.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@syncode/ui';
+import type { ComponentPropsWithoutRef } from 'react';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+type ProblemMarkdownProps = {
+  content: string;
+  className?: string;
+  compact?: boolean;
+};
+
+const anchorComponent = ({
+  node: _node,
+  ...props
+}: ComponentPropsWithoutRef<'a'> & { node?: unknown }) => (
+  <a {...props} target="_blank" rel="noopener noreferrer" />
+);
+
+const components = {
+  a: anchorComponent,
+};
+
+export function ProblemMarkdown({ content, className, compact = false }: ProblemMarkdownProps) {
+  return (
+    <div
+      className={cn(
+        'prose prose-sm prose-invert max-w-none text-foreground',
+        compact &&
+          'prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-headings:my-2 text-xs leading-relaxed',
+        'prose-headings:text-foreground prose-strong:text-foreground',
+        'prose-a:text-primary prose-a:underline-offset-2 hover:prose-a:text-primary/80',
+        'prose-code:rounded prose-code:bg-muted/70 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-foreground prose-code:before:content-none prose-code:after:content-none',
+        'prose-pre:border prose-pre:border-border/60 prose-pre:bg-[#1e1e1e] prose-pre:text-foreground',
+        'prose-li:marker:text-muted-foreground',
+        'prose-blockquote:border-l-primary/60 prose-blockquote:text-muted-foreground',
+        className,
+      )}
+    >
+      <Markdown remarkPlugins={[remarkGfm]} components={components}>
+        {content}
+      </Markdown>
+    </div>
+  );
+}

--- a/apps/web/src/components/problems/problem-markdown.tsx
+++ b/apps/web/src/components/problems/problem-markdown.tsx
@@ -19,22 +19,23 @@ const anchorComponent = ({
 
 const components = {
   a: anchorComponent,
+  img: () => null,
 };
 
 export function ProblemMarkdown({ content, className, compact = false }: ProblemMarkdownProps) {
   return (
     <div
       className={cn(
-        'prose prose-sm prose-invert max-w-none text-foreground',
+        'prose prose-sm prose-invert max-w-none',
         compact &&
           'prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-headings:my-2 text-xs leading-relaxed',
         'prose-headings:text-foreground prose-strong:text-foreground',
         'prose-a:text-primary prose-a:underline-offset-2 hover:prose-a:text-primary/80',
         'prose-code:rounded prose-code:bg-muted/70 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-foreground prose-code:before:content-none prose-code:after:content-none',
-        'prose-pre:border prose-pre:border-border/60 prose-pre:bg-[#1e1e1e] prose-pre:text-foreground',
+        'prose-pre:border prose-pre:border-border/60 prose-pre:bg-muted prose-pre:text-foreground',
         'prose-li:marker:text-muted-foreground',
         'prose-blockquote:border-l-primary/60 prose-blockquote:text-muted-foreground',
-        className,
+        className || 'text-foreground',
       )}
     >
       <Markdown remarkPlugins={[remarkGfm, remarkBreaks]} components={components}>

--- a/apps/web/src/components/room-problem-panel.tsx
+++ b/apps/web/src/components/room-problem-panel.tsx
@@ -1,6 +1,7 @@
 import { Badge } from '@syncode/ui';
 import { FileText, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { ProblemMarkdown } from './problems/problem-markdown.js';
 
 export interface ProblemData {
   title: string;
@@ -33,14 +34,12 @@ export function RoomProblemPanel({ problem, loading, error, hasProblem }: RoomPr
 
   return (
     <div className="flex h-full flex-col bg-card">
-      {/* Header */}
       <div className="flex h-8 shrink-0 items-center border-b border-border px-3">
         <span className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
           {t('problem.heading')}
         </span>
       </div>
 
-      {/* Content */}
       <div className="flex-1 overflow-y-auto p-4">
         {!hasProblem ? (
           <div className="flex flex-col items-center justify-center py-12 text-center">
@@ -68,7 +67,6 @@ function ProblemContent({ problem }: { problem: ProblemData }) {
 
   return (
     <div className="space-y-4">
-      {/* Title + difficulty */}
       <div>
         <h2 className="text-sm font-semibold text-foreground">{problem.title}</h2>
         <div className="mt-2 flex flex-wrap items-center gap-1.5">
@@ -85,12 +83,8 @@ function ProblemContent({ problem }: { problem: ProblemData }) {
 
       <div className="h-px bg-border" />
 
-      {/* Description */}
-      <div className="text-xs leading-relaxed text-muted-foreground whitespace-pre-wrap">
-        {problem.description}
-      </div>
+      <ProblemMarkdown content={problem.description} compact />
 
-      {/* Examples */}
       {problem.examples.length > 0 ? (
         <div className="space-y-2.5">
           <h3 className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
@@ -118,21 +112,22 @@ function ProblemContent({ problem }: { problem: ProblemData }) {
                 </pre>
               </div>
               {example.explanation ? (
-                <p className="text-[11px] italic text-muted-foreground">{example.explanation}</p>
+                <div className="text-[11px] italic text-muted-foreground">
+                  <ProblemMarkdown content={example.explanation} compact />
+                </div>
               ) : null}
             </div>
           ))}
         </div>
       ) : null}
 
-      {/* Constraints */}
       {problem.constraints ? (
-        <div>
-          <h3 className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+        <div className="rounded border-l-2 border-amber-400/60 bg-amber-500/5 p-2.5">
+          <h3 className="font-mono text-[10px] uppercase tracking-widest text-amber-300/90">
             {t('problem.constraints')}
           </h3>
-          <div className="mt-1.5 text-xs leading-relaxed text-muted-foreground whitespace-pre-wrap">
-            {problem.constraints}
+          <div className="mt-1.5">
+            <ProblemMarkdown content={problem.constraints} compact />
           </div>
         </div>
       ) : null}

--- a/apps/web/src/components/room-problem-panel.tsx
+++ b/apps/web/src/components/room-problem-panel.tsx
@@ -1,6 +1,7 @@
 import { Badge } from '@syncode/ui';
 import { FileText, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { ConstraintsBlock } from './problems/constraints-block.js';
 import { ProblemMarkdown } from './problems/problem-markdown.js';
 
 export interface ProblemData {
@@ -122,14 +123,7 @@ function ProblemContent({ problem }: { problem: ProblemData }) {
       ) : null}
 
       {problem.constraints ? (
-        <div className="rounded border-l-2 border-amber-400/60 bg-amber-500/5 p-2.5">
-          <h3 className="font-mono text-[10px] uppercase tracking-widest text-amber-300/90">
-            {t('problem.constraints')}
-          </h3>
-          <div className="mt-1.5">
-            <ProblemMarkdown content={problem.constraints} compact />
-          </div>
-        </div>
+        <ConstraintsBlock title={t('problem.constraints')} content={problem.constraints} compact />
       ) : null}
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -636,6 +636,9 @@ importers:
       react-resizable-panels:
         specifier: ^4.9.0
         version: 4.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       shadcn:
         specifier: ^4.1.1
         version: 4.1.1(@types/node@25.3.3)(typescript@5.9.2)
@@ -5759,6 +5762,10 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -6808,6 +6815,9 @@ packages:
     resolution: {integrity: sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marked@14.0.0:
     resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
     engines: {node: '>= 18'}
@@ -6817,8 +6827,29 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -6881,6 +6912,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -7668,11 +7720,17 @@ packages:
     resolution: {integrity: sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==}
     engines: {node: '>=4'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -14249,6 +14307,8 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
@@ -15336,9 +15396,18 @@ snapshots:
 
   map-obj@5.0.0: {}
 
+  markdown-table@3.0.4: {}
+
   marked@14.0.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -15354,6 +15423,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -15468,6 +15594,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -16426,6 +16610,17 @@ snapshots:
     dependencies:
       es6-error: 4.1.1
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -16442,6 +16637,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -636,6 +636,9 @@ importers:
       react-resizable-panels:
         specifier: ^4.9.0
         version: 4.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -6860,6 +6863,9 @@ packages:
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
+
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
@@ -7719,6 +7725,9 @@ packages:
   release-zalgo@1.0.0:
     resolution: {integrity: sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==}
     engines: {node: '>=4'}
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -15522,6 +15531,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -16609,6 +16623,12 @@ snapshots:
   release-zalgo@1.0.0:
     dependencies:
       es6-error: 4.1.1
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
+      unified: 11.0.5
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
New ProblemMarkdown component on react-markdown plus remark-gfm. A shared ConstraintsBlock unifies the amber accent across the problem detail page and the room workspace panel. Tests cover basic rendering, GFM tables, the XSS boundary, and the link target override.