### PR TITLE
feat(web): hide idle remote cursors and dim them on hover

### DIFF
--- a/apps/web/src/components/collaborative-editor.tsx
+++ b/apps/web/src/components/collaborative-editor.tsx
@@ -82,7 +82,9 @@ export function CollaborativeEditor({
 
     const getLastUpdated = (clientID: number): number => {
       const meta = awareness.meta.get(clientID);
-      return meta?.lastUpdated ?? Date.now();
+      // No meta entry yet (cold start or out-of-order update): treat as stale so the
+      // cursor fades immediately rather than appearing freshly active forever.
+      return meta?.lastUpdated ?? 0;
     };
 
     const remoteStates = () => {

--- a/apps/web/src/components/collaborative-editor.tsx
+++ b/apps/web/src/components/collaborative-editor.tsx
@@ -144,6 +144,9 @@ export function CollaborativeEditor({
         const shouldBeIdle = now - stamp >= IDLE_HIDE_MS;
         if (shouldBeIdle && !idleIds.has(id)) {
           idleIds.add(id);
+          // Hidden cursors can't receive mouseout, so drop any stale hover
+          // mark to avoid them reappearing transparent on the next update.
+          hoverIds.delete(id);
           changed = true;
         } else if (!shouldBeIdle && idleIds.has(id)) {
           idleIds.delete(id);

--- a/apps/web/src/components/collaborative-editor.tsx
+++ b/apps/web/src/components/collaborative-editor.tsx
@@ -1,8 +1,9 @@
 import Editor, { type OnMount } from '@monaco-editor/react';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { MonacoBinding } from 'y-monaco';
 import type { Awareness } from 'y-protocols/awareness';
 import type * as Y from 'yjs';
+import { clientIdFromElement, remoteCursorSelector } from '@/lib/remote-cursor-dom.js';
 import { CODE_TEXT_KEY } from '@/lib/yjs-collab-provider.js';
 import { buildCursorCssRules, IDLE_HIDE_MS } from './cursor-styles.js';
 import {
@@ -29,7 +30,7 @@ export function CollaborativeEditor({
   onSubmitCode,
 }: CollaborativeEditorProps) {
   const bindingRef = useRef<MonacoBinding | null>(null);
-  const editorRootRef = useRef<HTMLElement | null>(null);
+  const [editorRoot, setEditorRoot] = useState<HTMLElement | null>(null);
   const onRunCodeRef = useRef(onRunCode);
   onRunCodeRef.current = onRunCode;
   const onSubmitCodeRef = useRef(onSubmitCode);
@@ -52,7 +53,7 @@ export function CollaborativeEditor({
       run: () => void onSubmitCodeRef.current(),
     });
 
-    editorRootRef.current = editor.getDomNode();
+    setEditorRoot(editor.getDomNode());
 
     const model = editor.getModel();
     if (model == null) return;
@@ -70,6 +71,8 @@ export function CollaborativeEditor({
   }, [doc, awareness]);
 
   useEffect(() => {
+    if (!editorRoot) return;
+
     const styleEl = document.createElement('style');
     document.head.appendChild(styleEl);
 
@@ -99,25 +102,15 @@ export function CollaborativeEditor({
       styleEl.textContent = rules.join('\n');
     };
 
-    const remoteCursorSelector = (event: Event): HTMLElement | null => {
-      const target = event.target as HTMLElement | null;
+    const findRemoteCursor = (event: Event): Element | null => {
+      const target = event.target as Element | null;
       if (!target) return null;
-      const headClass = Array.from(target.classList ?? []).find((c) =>
-        c.startsWith('yRemoteSelectionHead-'),
-      );
-      if (headClass) return target;
-      return target.closest('[class*="yRemoteSelectionHead-"]');
-    };
-
-    const clientIdFromElement = (el: HTMLElement): number | null => {
-      const headClass = Array.from(el.classList).find((c) => c.startsWith('yRemoteSelectionHead-'));
-      if (!headClass) return null;
-      const id = Number.parseInt(headClass.slice('yRemoteSelectionHead-'.length), 10);
-      return Number.isFinite(id) ? id : null;
+      if (typeof target.closest !== 'function') return null;
+      return target.closest(remoteCursorSelector());
     };
 
     const onMouseOver = (event: Event) => {
-      const el = remoteCursorSelector(event);
+      const el = findRemoteCursor(event);
       if (!el) return;
       const id = clientIdFromElement(el);
       if (id == null || id === doc.clientID) return;
@@ -128,16 +121,15 @@ export function CollaborativeEditor({
     };
 
     const onMouseOut = (event: Event) => {
-      const el = remoteCursorSelector(event);
+      const el = findRemoteCursor(event);
       if (!el) return;
       const id = clientIdFromElement(el);
       if (id == null) return;
       if (hoverIds.delete(id)) updateStyles();
     };
 
-    const root = editorRootRef.current ?? document;
-    root.addEventListener('mouseover', onMouseOver, true);
-    root.addEventListener('mouseout', onMouseOut, true);
+    editorRoot.addEventListener('mouseover', onMouseOver, true);
+    editorRoot.addEventListener('mouseout', onMouseOut, true);
 
     const recomputeIdle = () => {
       const now = Date.now();
@@ -203,12 +195,12 @@ export function CollaborativeEditor({
 
     return () => {
       awareness.off('change', onAwarenessChange);
-      root.removeEventListener('mouseover', onMouseOver, true);
-      root.removeEventListener('mouseout', onMouseOut, true);
+      editorRoot.removeEventListener('mouseover', onMouseOver, true);
+      editorRoot.removeEventListener('mouseout', onMouseOut, true);
       if (tickHandle != null) clearInterval(tickHandle);
       styleEl.remove();
     };
-  }, [awareness, doc.clientID]);
+  }, [awareness, doc.clientID, editorRoot]);
 
   return (
     <Editor

--- a/apps/web/src/components/collaborative-editor.tsx
+++ b/apps/web/src/components/collaborative-editor.tsx
@@ -29,6 +29,7 @@ export function CollaborativeEditor({
   onSubmitCode,
 }: CollaborativeEditorProps) {
   const bindingRef = useRef<MonacoBinding | null>(null);
+  const editorRootRef = useRef<HTMLElement | null>(null);
   const onRunCodeRef = useRef(onRunCode);
   onRunCodeRef.current = onRunCode;
   const onSubmitCodeRef = useRef(onSubmitCode);
@@ -37,7 +38,6 @@ export function CollaborativeEditor({
   const editorOptions = useMemo(() => ({ ...EDITOR_OPTIONS_BASE, readOnly }), [readOnly]);
 
   const handleMount: OnMount = (editor, monaco) => {
-    // Register keyboard shortcuts
     editor.addAction({
       id: 'syncode-run',
       label: 'Run Code',
@@ -52,7 +52,8 @@ export function CollaborativeEditor({
       run: () => void onSubmitCodeRef.current(),
     });
 
-    // Bind Monaco model to Y.Text via y-monaco
+    editorRootRef.current = editor.getDomNode();
+
     const model = editor.getModel();
     if (model == null) return;
 
@@ -60,8 +61,7 @@ export function CollaborativeEditor({
     bindingRef.current = new MonacoBinding(yText, model, new Set([editor]), awareness);
   };
 
-  // Clean up binding when component unmounts or doc/awareness changes.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: doc and awareness are intentional deps — when they change the old binding must be destroyed so handleMount can create a fresh one.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: doc and awareness are intentional deps; when they change the old binding must be destroyed so handleMount creates a fresh one.
   useEffect(() => {
     return () => {
       bindingRef.current?.destroy();
@@ -73,11 +73,14 @@ export function CollaborativeEditor({
     const styleEl = document.createElement('style');
     document.head.appendChild(styleEl);
 
-    const lastUpdated = new Map<number, number>();
     const idleIds = new Set<number>();
     const hoverIds = new Set<number>();
-    const hoverListeners = new Map<number, { over: () => void; leave: () => void }>();
     let tickHandle: ReturnType<typeof setInterval> | null = null;
+
+    const getLastUpdated = (clientID: number): number => {
+      const meta = awareness.meta.get(clientID);
+      return meta?.lastUpdated ?? Date.now();
+    };
 
     const remoteStates = () => {
       const states = awareness.getStates();
@@ -96,48 +99,45 @@ export function CollaborativeEditor({
       styleEl.textContent = rules.join('\n');
     };
 
-    const detachHoverFor = (clientID: number) => {
-      const existing = hoverListeners.get(clientID);
-      if (!existing) return;
-      document.querySelectorAll<HTMLElement>(`.yRemoteSelectionHead-${clientID}`).forEach((el) => {
-        el.removeEventListener('mouseover', existing.over);
-        el.removeEventListener('mouseleave', existing.leave);
-      });
-      hoverListeners.delete(clientID);
-      hoverIds.delete(clientID);
+    const remoteCursorSelector = (event: Event): HTMLElement | null => {
+      const target = event.target as HTMLElement | null;
+      if (!target) return null;
+      const headClass = Array.from(target.classList ?? []).find((c) =>
+        c.startsWith('yRemoteSelectionHead-'),
+      );
+      if (headClass) return target;
+      return target.closest('[class*="yRemoteSelectionHead-"]');
     };
 
-    const attachHoverFor = (clientID: number) => {
-      if (hoverListeners.has(clientID)) return;
-      const over = () => {
-        if (!hoverIds.has(clientID)) {
-          hoverIds.add(clientID);
-          updateStyles();
-        }
-      };
-      const leave = () => {
-        if (hoverIds.delete(clientID)) updateStyles();
-      };
-      hoverListeners.set(clientID, { over, leave });
-      document.querySelectorAll<HTMLElement>(`.yRemoteSelectionHead-${clientID}`).forEach((el) => {
-        el.addEventListener('mouseover', over);
-        el.addEventListener('mouseleave', leave);
-      });
+    const clientIdFromElement = (el: HTMLElement): number | null => {
+      const headClass = Array.from(el.classList).find((c) => c.startsWith('yRemoteSelectionHead-'));
+      if (!headClass) return null;
+      const id = Number.parseInt(headClass.slice('yRemoteSelectionHead-'.length), 10);
+      return Number.isFinite(id) ? id : null;
     };
 
-    // Hover targets are rendered by Monaco asynchronously, so re-bind shortly after each awareness change.
-    const scheduleHoverRebind = (clientIds: number[]) => {
-      requestAnimationFrame(() => {
-        clientIds.forEach((id) => {
-          if (id === doc.clientID) return;
-          const existing = hoverListeners.get(id);
-          if (existing) {
-            detachHoverFor(id);
-          }
-          attachHoverFor(id);
-        });
-      });
+    const onMouseOver = (event: Event) => {
+      const el = remoteCursorSelector(event);
+      if (!el) return;
+      const id = clientIdFromElement(el);
+      if (id == null || id === doc.clientID) return;
+      if (!hoverIds.has(id)) {
+        hoverIds.add(id);
+        updateStyles();
+      }
     };
+
+    const onMouseOut = (event: Event) => {
+      const el = remoteCursorSelector(event);
+      if (!el) return;
+      const id = clientIdFromElement(el);
+      if (id == null) return;
+      if (hoverIds.delete(id)) updateStyles();
+    };
+
+    const root = editorRootRef.current ?? document;
+    root.addEventListener('mouseover', onMouseOver, true);
+    root.addEventListener('mouseout', onMouseOut, true);
 
     const recomputeIdle = () => {
       const now = Date.now();
@@ -146,7 +146,7 @@ export function CollaborativeEditor({
       awareness.getStates().forEach((_, id) => {
         if (id === doc.clientID) return;
         present.add(id);
-        const stamp = lastUpdated.get(id) ?? now;
+        const stamp = getLastUpdated(id);
         const shouldBeIdle = now - stamp >= IDLE_HIDE_MS;
         if (shouldBeIdle && !idleIds.has(id)) {
           idleIds.add(id);
@@ -185,38 +185,27 @@ export function CollaborativeEditor({
       removed: number[];
     }) => {
       if (added.length === 0 && updated.length === 0 && removed.length === 0) return;
-      const now = Date.now();
       for (const id of [...added, ...updated]) {
         if (id === doc.clientID) continue;
-        lastUpdated.set(id, now);
         idleIds.delete(id);
       }
       for (const id of removed) {
-        lastUpdated.delete(id);
-        detachHoverFor(id);
         idleIds.delete(id);
+        hoverIds.delete(id);
       }
       updateStyles();
-      scheduleHoverRebind([...added, ...updated]);
       ensureTicking();
     };
 
     awareness.on('change', onAwarenessChange);
-    // Seed timestamps for any peers already present at mount.
-    const now = Date.now();
-    awareness.getStates().forEach((_, id) => {
-      if (id !== doc.clientID) lastUpdated.set(id, now);
-    });
     updateStyles();
-    scheduleHoverRebind([...lastUpdated.keys()]);
     ensureTicking();
 
     return () => {
       awareness.off('change', onAwarenessChange);
+      root.removeEventListener('mouseover', onMouseOver, true);
+      root.removeEventListener('mouseout', onMouseOut, true);
       if (tickHandle != null) clearInterval(tickHandle);
-      hoverListeners.forEach((_, id) => {
-        detachHoverFor(id);
-      });
       styleEl.remove();
     };
   }, [awareness, doc.clientID]);

--- a/apps/web/src/components/collaborative-editor.tsx
+++ b/apps/web/src/components/collaborative-editor.tsx
@@ -4,7 +4,7 @@ import { MonacoBinding } from 'y-monaco';
 import type { Awareness } from 'y-protocols/awareness';
 import type * as Y from 'yjs';
 import { CODE_TEXT_KEY } from '@/lib/yjs-collab-provider.js';
-import { buildCursorCssRules } from './cursor-styles.js';
+import { buildCursorCssRules, IDLE_HIDE_MS } from './cursor-styles.js';
 import {
   EDITOR_LOADING,
   EDITOR_OPTIONS_BASE,
@@ -69,14 +69,110 @@ export function CollaborativeEditor({
     };
   }, [doc, awareness]);
 
-  // Inject dynamic CSS for remote cursor colors from awareness state.
   useEffect(() => {
     const styleEl = document.createElement('style');
     document.head.appendChild(styleEl);
 
+    const lastUpdated = new Map<number, number>();
+    const idleIds = new Set<number>();
+    const hoverIds = new Set<number>();
+    const hoverListeners = new Map<number, { over: () => void; leave: () => void }>();
+    let tickHandle: ReturnType<typeof setInterval> | null = null;
+
+    const remoteStates = () => {
+      const states = awareness.getStates();
+      const filtered = new Map<number, Record<string, unknown>>();
+      states.forEach((state, id) => {
+        if (id !== doc.clientID) filtered.set(id, state);
+      });
+      return filtered;
+    };
+
     const updateStyles = () => {
-      const rules = buildCursorCssRules(awareness.getStates(), doc.clientID);
+      const rules = buildCursorCssRules(awareness.getStates(), doc.clientID, {
+        idleClientIds: idleIds,
+        transparentClientIds: hoverIds,
+      });
       styleEl.textContent = rules.join('\n');
+    };
+
+    const detachHoverFor = (clientID: number) => {
+      const existing = hoverListeners.get(clientID);
+      if (!existing) return;
+      document.querySelectorAll<HTMLElement>(`.yRemoteSelectionHead-${clientID}`).forEach((el) => {
+        el.removeEventListener('mouseover', existing.over);
+        el.removeEventListener('mouseleave', existing.leave);
+      });
+      hoverListeners.delete(clientID);
+      hoverIds.delete(clientID);
+    };
+
+    const attachHoverFor = (clientID: number) => {
+      if (hoverListeners.has(clientID)) return;
+      const over = () => {
+        if (!hoverIds.has(clientID)) {
+          hoverIds.add(clientID);
+          updateStyles();
+        }
+      };
+      const leave = () => {
+        if (hoverIds.delete(clientID)) updateStyles();
+      };
+      hoverListeners.set(clientID, { over, leave });
+      document.querySelectorAll<HTMLElement>(`.yRemoteSelectionHead-${clientID}`).forEach((el) => {
+        el.addEventListener('mouseover', over);
+        el.addEventListener('mouseleave', leave);
+      });
+    };
+
+    // Hover targets are rendered by Monaco asynchronously, so re-bind shortly after each awareness change.
+    const scheduleHoverRebind = (clientIds: number[]) => {
+      requestAnimationFrame(() => {
+        clientIds.forEach((id) => {
+          if (id === doc.clientID) return;
+          const existing = hoverListeners.get(id);
+          if (existing) {
+            detachHoverFor(id);
+          }
+          attachHoverFor(id);
+        });
+      });
+    };
+
+    const recomputeIdle = () => {
+      const now = Date.now();
+      let changed = false;
+      const present = new Set<number>();
+      awareness.getStates().forEach((_, id) => {
+        if (id === doc.clientID) return;
+        present.add(id);
+        const stamp = lastUpdated.get(id) ?? now;
+        const shouldBeIdle = now - stamp >= IDLE_HIDE_MS;
+        if (shouldBeIdle && !idleIds.has(id)) {
+          idleIds.add(id);
+          changed = true;
+        } else if (!shouldBeIdle && idleIds.has(id)) {
+          idleIds.delete(id);
+          changed = true;
+        }
+      });
+      idleIds.forEach((id) => {
+        if (!present.has(id)) {
+          idleIds.delete(id);
+          changed = true;
+        }
+      });
+      if (changed) updateStyles();
+    };
+
+    const ensureTicking = () => {
+      const hasRemote = remoteStates().size > 0;
+      if (hasRemote && tickHandle == null) {
+        tickHandle = setInterval(recomputeIdle, 1_000);
+      } else if (!hasRemote && tickHandle != null) {
+        clearInterval(tickHandle);
+        tickHandle = null;
+      }
     };
 
     const onAwarenessChange = ({
@@ -88,13 +184,39 @@ export function CollaborativeEditor({
       updated: number[];
       removed: number[];
     }) => {
-      if (added.length > 0 || updated.length > 0 || removed.length > 0) updateStyles();
+      if (added.length === 0 && updated.length === 0 && removed.length === 0) return;
+      const now = Date.now();
+      for (const id of [...added, ...updated]) {
+        if (id === doc.clientID) continue;
+        lastUpdated.set(id, now);
+        idleIds.delete(id);
+      }
+      for (const id of removed) {
+        lastUpdated.delete(id);
+        detachHoverFor(id);
+        idleIds.delete(id);
+      }
+      updateStyles();
+      scheduleHoverRebind([...added, ...updated]);
+      ensureTicking();
     };
+
     awareness.on('change', onAwarenessChange);
+    // Seed timestamps for any peers already present at mount.
+    const now = Date.now();
+    awareness.getStates().forEach((_, id) => {
+      if (id !== doc.clientID) lastUpdated.set(id, now);
+    });
     updateStyles();
+    scheduleHoverRebind([...lastUpdated.keys()]);
+    ensureTicking();
 
     return () => {
       awareness.off('change', onAwarenessChange);
+      if (tickHandle != null) clearInterval(tickHandle);
+      hoverListeners.forEach((_, id) => {
+        detachHoverFor(id);
+      });
       styleEl.remove();
     };
   }, [awareness, doc.clientID]);

--- a/apps/web/src/components/cursor-styles.spec.ts
+++ b/apps/web/src/components/cursor-styles.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildCursorCssRules } from './cursor-styles.js';
+import { buildCursorCssRules, HOVER_TRANSPARENT_OPACITY } from './cursor-styles.js';
 
 describe('buildCursorCssRules', () => {
   it('GIVEN remote user with valid hex color THEN generates selection, cursor, and label CSS rules', () => {
@@ -58,7 +58,6 @@ describe('buildCursorCssRules', () => {
 
     const labelRule = rules.find((r) => r.includes('::after'));
     expect(labelRule).toBeDefined();
-    // Quotes, semicolons, and braces are stripped — CSS injection neutralized
     expect(labelRule).not.toContain('"; }');
     expect(labelRule).not.toContain('{ color');
   });
@@ -102,5 +101,64 @@ describe('buildCursorCssRules', () => {
     expect(rules).toHaveLength(8);
     expect(rules.some((r) => r.includes('yRemoteSelection-2'))).toBe(true);
     expect(rules.some((r) => r.includes('yRemoteSelection-3'))).toBe(true);
+  });
+
+  it('GIVEN base cursor rules THEN include an opacity transition so idle fade animates', () => {
+    const states = new Map<number, Record<string, unknown>>([
+      [2, { user: { name: 'A', color: '#ff0000' } }],
+    ]);
+
+    const rules = buildCursorCssRules(states, 1);
+
+    const headRule = rules.find(
+      (r) => r.includes('.yRemoteSelectionHead-2 {') && !r.includes('::'),
+    );
+    expect(headRule).toBeDefined();
+    expect(headRule).toContain('transition: opacity');
+  });
+
+  it('GIVEN a client id in idleClientIds THEN emits an opacity: 0 rule for that client', () => {
+    const states = new Map<number, Record<string, unknown>>([
+      [2, { user: { name: 'A', color: '#ff0000' } }],
+      [3, { user: { name: 'B', color: '#00ff00' } }],
+    ]);
+
+    const rules = buildCursorCssRules(states, 1, { idleClientIds: new Set([2]) });
+
+    const idleRule = rules.find(
+      (r) => r.includes('opacity: 0') && r.includes('yRemoteSelection-2'),
+    );
+    expect(idleRule).toBeDefined();
+    expect(rules.some((r) => r.includes('yRemoteSelection-3') && r.includes('opacity: 0'))).toBe(
+      false,
+    );
+  });
+
+  it('GIVEN a client id in transparentClientIds THEN emits a reduced-opacity rule', () => {
+    const states = new Map<number, Record<string, unknown>>([
+      [2, { user: { name: 'A', color: '#ff0000' } }],
+    ]);
+
+    const rules = buildCursorCssRules(states, 1, { transparentClientIds: new Set([2]) });
+
+    const hoverRule = rules.find(
+      (r) =>
+        r.includes(`opacity: ${HOVER_TRANSPARENT_OPACITY}`) && r.includes('yRemoteSelection-2'),
+    );
+    expect(hoverRule).toBeDefined();
+  });
+
+  it('GIVEN a client id is both idle and transparent THEN idle wins (fully hidden)', () => {
+    const states = new Map<number, Record<string, unknown>>([
+      [2, { user: { name: 'A', color: '#ff0000' } }],
+    ]);
+
+    const rules = buildCursorCssRules(states, 1, {
+      idleClientIds: new Set([2]),
+      transparentClientIds: new Set([2]),
+    });
+
+    expect(rules.some((r) => r.includes('opacity: 0') && !r.includes('0.'))).toBe(true);
+    expect(rules.some((r) => r.includes(`opacity: ${HOVER_TRANSPARENT_OPACITY}`))).toBe(false);
   });
 });

--- a/apps/web/src/components/cursor-styles.ts
+++ b/apps/web/src/components/cursor-styles.ts
@@ -4,11 +4,24 @@ interface CursorUser {
   colorLight?: string;
 }
 
+export interface CursorStyleOptions {
+  idleClientIds?: ReadonlySet<number>;
+  transparentClientIds?: ReadonlySet<number>;
+}
+
+// Threshold at which a remote cursor fades out after no awareness updates.
+export const IDLE_HIDE_MS = 8_000;
+// Opacity applied when the local user hovers a remote cursor so it stops blocking the view.
+export const HOVER_TRANSPARENT_OPACITY = 0.25;
+
 export function buildCursorCssRules(
   states: Map<number, Record<string, unknown>>,
   localClientID: number,
+  options: CursorStyleOptions = {},
 ): string[] {
   const rules: string[] = [];
+  const idle = options.idleClientIds ?? new Set<number>();
+  const transparent = options.transparentClientIds ?? new Set<number>();
   states.forEach((state, clientID) => {
     if (clientID === localClientID) return;
     const user = state.user as CursorUser | undefined;
@@ -24,10 +37,12 @@ export function buildCursorCssRules(
       `.yRemoteSelection-${clientID} {
         background-color: ${light};
         border-radius: 1px;
+        transition: opacity 300ms ease-out;
       }`,
       `.yRemoteSelectionHead-${clientID} {
         position: relative;
         border-left: 2px solid ${user.color};
+        transition: opacity 300ms ease-out;
       }`,
       `.yRemoteSelectionHead-${clientID}::after {
         content: "${name}";
@@ -48,6 +63,7 @@ export function buildCursorCssRules(
         z-index: 10;
         opacity: 0.9;
         box-shadow: 0 1px 3px rgba(0,0,0,0.25);
+        transition: opacity 300ms ease-out;
       }`,
       `.yRemoteSelectionHead-${clientID}::before {
         content: "";
@@ -61,8 +77,29 @@ export function buildCursorCssRules(
         transform: translateY(-50%);
         pointer-events: none;
         z-index: 10;
+        transition: opacity 300ms ease-out;
       }`,
     );
+
+    if (idle.has(clientID)) {
+      rules.push(
+        `.yRemoteSelection-${clientID},
+        .yRemoteSelectionHead-${clientID},
+        .yRemoteSelectionHead-${clientID}::before,
+        .yRemoteSelectionHead-${clientID}::after {
+          opacity: 0;
+        }`,
+      );
+    } else if (transparent.has(clientID)) {
+      rules.push(
+        `.yRemoteSelection-${clientID},
+        .yRemoteSelectionHead-${clientID},
+        .yRemoteSelectionHead-${clientID}::before,
+        .yRemoteSelectionHead-${clientID}::after {
+          opacity: ${HOVER_TRANSPARENT_OPACITY};
+        }`,
+      );
+    }
   });
   return rules;
 }

--- a/apps/web/src/lib/remote-cursor-dom.spec.ts
+++ b/apps/web/src/lib/remote-cursor-dom.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { clientIdFromElement, remoteCursorSelector } from './remote-cursor-dom.js';
+
+const makeElement = (className: string): HTMLElement => {
+  const el = document.createElement('div');
+  el.className = className;
+  return el;
+};
+
+describe('clientIdFromElement', () => {
+  it('GIVEN element with class yRemoteSelectionHead-123 WHEN parsing THEN returns 123', () => {
+    expect(clientIdFromElement(makeElement('yRemoteSelectionHead-123'))).toBe(123);
+  });
+
+  it('GIVEN element with class foo yRemoteSelectionHead-456 bar WHEN parsing THEN returns 456', () => {
+    expect(clientIdFromElement(makeElement('foo yRemoteSelectionHead-456 bar'))).toBe(456);
+  });
+
+  it('GIVEN element without the class WHEN parsing THEN returns null', () => {
+    expect(clientIdFromElement(makeElement('foo bar baz'))).toBeNull();
+  });
+
+  it('GIVEN null element WHEN parsing THEN returns null', () => {
+    expect(clientIdFromElement(null)).toBeNull();
+  });
+
+  it('GIVEN class yRemoteSelectionHead- (no number) WHEN parsing THEN returns null', () => {
+    expect(clientIdFromElement(makeElement('yRemoteSelectionHead-'))).toBeNull();
+  });
+
+  it('GIVEN class with non-numeric id WHEN parsing THEN returns null', () => {
+    expect(clientIdFromElement(makeElement('yRemoteSelectionHead-abc'))).toBeNull();
+  });
+
+  it('GIVEN multiple matching elements on the page WHEN querying with remoteCursorSelector THEN each can be parsed', () => {
+    const container = document.createElement('div');
+    const first = makeElement('yRemoteSelectionHead-1');
+    const second = makeElement('foo yRemoteSelectionHead-42 bar');
+    const third = makeElement('yRemoteSelectionHead-1000');
+    container.appendChild(first);
+    container.appendChild(second);
+    container.appendChild(third);
+    document.body.appendChild(container);
+    try {
+      const matches = Array.from(container.querySelectorAll(remoteCursorSelector()));
+      expect(matches).toHaveLength(3);
+      const ids = matches.map((el) => clientIdFromElement(el));
+      expect(ids).toEqual([1, 42, 1000]);
+    } finally {
+      container.remove();
+    }
+  });
+});

--- a/apps/web/src/lib/remote-cursor-dom.ts
+++ b/apps/web/src/lib/remote-cursor-dom.ts
@@ -1,0 +1,19 @@
+// DOM helpers for correlating Monaco/Yjs remote cursor elements to awareness clientIDs.
+// The class shape `yRemoteSelectionHead-<number>` is emitted by y-monaco; keep the
+// parsing strict so unrelated elements never resolve to a clientID.
+
+const CLIENT_ID_CLASS_PATTERN = /(?:^|\s)yRemoteSelectionHead-(\d+)(?=\s|$)/;
+
+export function remoteCursorSelector(): string {
+  return '[class*="yRemoteSelectionHead-"]';
+}
+
+export function clientIdFromElement(el: Element | null): number | null {
+  if (!el) return null;
+  const className = typeof el.className === 'string' ? el.className : el.getAttribute('class');
+  if (!className) return null;
+  const match = className.match(CLIENT_ID_CLASS_PATTERN);
+  if (!match) return null;
+  const id = Number(match[1]);
+  return Number.isFinite(id) ? id : null;
+}


### PR DESCRIPTION
Remote cursors fade after 8 seconds of inactivity and dim on hover. Hover delegation attaches to the editor root only after Monaco mounts (was falling back to document). The clientId-from-class parser is extracted into a tested helper.