### PR TITLE
fix(web): let local user mute their own microphone

### DIFF
--- a/apps/web/src/components/room-lobby.tsx
+++ b/apps/web/src/components/room-lobby.tsx
@@ -43,6 +43,8 @@ interface RoomLobbyProps {
     muteSet: ReadonlySet<string>;
     videoHiddenSet: ReadonlySet<string>;
   };
+  selfMicrophoneEnabled?: boolean;
+  onSelfMicrophoneToggle?: () => void;
 }
 
 export function RoomLobby({
@@ -68,6 +70,8 @@ export function RoomLobby({
   mediaConnectedSet,
   mediaMutedMap,
   participantMediaControls,
+  selfMicrophoneEnabled,
+  onSelfMicrophoneToggle,
 }: RoomLobbyProps) {
   const { t } = useTranslation('rooms');
   const { copied, copy } = useClipboard();
@@ -152,6 +156,8 @@ export function RoomLobby({
                     participantMediaControls?.videoHiddenSet.has(participant.userId) ?? false
                   }
                   localVolume={participantMediaControls?.volumeMap.get(participant.userId)}
+                  isSelfMicrophoneEnabled={selfMicrophoneEnabled}
+                  onSelfMicrophoneToggle={onSelfMicrophoneToggle}
                   onLocalMuteToggle={
                     participantMediaControls
                       ? (muted) => participantMediaControls.setMuted(participant.userId, muted)

--- a/apps/web/src/components/room-participant-card.tsx
+++ b/apps/web/src/components/room-participant-card.tsx
@@ -298,16 +298,11 @@ export function RoomParticipantCard({
                   className="min-w-44 rounded-xl border-border/60"
                 >
                   {hasSelfMicAction ? (
-                    <DropdownMenuItem onSelect={() => onSelfMicrophoneToggle?.()}>
-                      {isSelfMicrophoneEnabled ? (
-                        <MicOff className="size-3.5 text-muted-foreground" />
-                      ) : (
-                        <Mic className="size-3.5 text-muted-foreground" />
-                      )}
-                      {isSelfMicrophoneEnabled
-                        ? t('workspace.muteMyMicrophone')
-                        : t('workspace.unmuteMyMicrophone')}
-                    </DropdownMenuItem>
+                    <SelfMicMenuItem
+                      enabled={isSelfMicrophoneEnabled}
+                      onToggle={() => onSelfMicrophoneToggle?.()}
+                      t={t}
+                    />
                   ) : null}
                   {hasMediaActions ? (
                     <MediaActionsContent
@@ -433,16 +428,11 @@ export function RoomParticipantCard({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="min-w-44 rounded-xl border-border/60">
               {hasSelfMicAction ? (
-                <DropdownMenuItem onSelect={() => onSelfMicrophoneToggle?.()}>
-                  {isSelfMicrophoneEnabled ? (
-                    <MicOff className="size-3.5 text-muted-foreground" />
-                  ) : (
-                    <Mic className="size-3.5 text-muted-foreground" />
-                  )}
-                  {isSelfMicrophoneEnabled
-                    ? t('workspace.muteMyMicrophone')
-                    : t('workspace.unmuteMyMicrophone')}
-                </DropdownMenuItem>
+                <SelfMicMenuItem
+                  enabled={isSelfMicrophoneEnabled}
+                  onToggle={() => onSelfMicrophoneToggle?.()}
+                  t={t}
+                />
               ) : null}
               {hasMediaActions ? (
                 <MediaActionsContent
@@ -474,5 +464,26 @@ export function RoomParticipantCard({
         ) : null}
       </div>
     </div>
+  );
+}
+
+function SelfMicMenuItem({
+  enabled,
+  onToggle,
+  t,
+}: {
+  enabled: boolean;
+  onToggle: () => void;
+  t: (key: string) => string;
+}) {
+  return (
+    <DropdownMenuItem onSelect={onToggle}>
+      {enabled ? (
+        <MicOff className="size-3.5 text-muted-foreground" />
+      ) : (
+        <Mic className="size-3.5 text-muted-foreground" />
+      )}
+      {t(enabled ? 'workspace.muteMyMicrophone' : 'workspace.unmuteMyMicrophone')}
+    </DropdownMenuItem>
   );
 }

--- a/apps/web/src/components/room-participant-card.tsx
+++ b/apps/web/src/components/room-participant-card.tsx
@@ -20,6 +20,7 @@ import {
   Crown,
   EllipsisVertical,
   Loader2,
+  Mic,
   MicOff,
   Signal,
   SignalLow,
@@ -174,6 +175,8 @@ interface RoomParticipantCardProps {
   isLocallyMuted?: boolean;
   isVideoHidden?: boolean;
   localVolume?: number;
+  isSelfMicrophoneEnabled?: boolean;
+  onSelfMicrophoneToggle?: () => void;
   onLocalMuteToggle?: (muted: boolean) => void;
   onLocalVolumeChange?: (volume: number) => void;
   onVideoHiddenToggle?: (hidden: boolean) => void;
@@ -198,6 +201,8 @@ export function RoomParticipantCard({
   isLocallyMuted = false,
   isVideoHidden = false,
   localVolume,
+  isSelfMicrophoneEnabled = false,
+  onSelfMicrophoneToggle,
   onLocalMuteToggle,
   onLocalVolumeChange,
   onVideoHiddenToggle,
@@ -214,7 +219,8 @@ export function RoomParticipantCard({
   const hasManageActions =
     canManageParticipants && !isHost && (onTransferOwnership || onRemoveParticipant);
   const hasMediaActions = !isMe && isMediaConnected && (onLocalMuteToggle || onVideoHiddenToggle);
-  const showParticipantActions = Boolean(hasManageActions || hasMediaActions);
+  const hasSelfMicAction = isMe && isMediaConnected && Boolean(onSelfMicrophoneToggle);
+  const showParticipantActions = Boolean(hasManageActions || hasMediaActions || hasSelfMicAction);
   const [isParticipantMenuOpen, setIsParticipantMenuOpen] = useState(false);
 
   if (compact) {
@@ -291,6 +297,18 @@ export function RoomParticipantCard({
                   side="bottom"
                   className="min-w-44 rounded-xl border-border/60"
                 >
+                  {hasSelfMicAction ? (
+                    <DropdownMenuItem onSelect={() => onSelfMicrophoneToggle?.()}>
+                      {isSelfMicrophoneEnabled ? (
+                        <MicOff className="size-3.5 text-muted-foreground" />
+                      ) : (
+                        <Mic className="size-3.5 text-muted-foreground" />
+                      )}
+                      {isSelfMicrophoneEnabled
+                        ? t('workspace.muteMyMicrophone')
+                        : t('workspace.unmuteMyMicrophone')}
+                    </DropdownMenuItem>
+                  ) : null}
                   {hasMediaActions ? (
                     <MediaActionsContent
                       isLocallyMuted={isLocallyMuted}
@@ -414,6 +432,18 @@ export function RoomParticipantCard({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="min-w-44 rounded-xl border-border/60">
+              {hasSelfMicAction ? (
+                <DropdownMenuItem onSelect={() => onSelfMicrophoneToggle?.()}>
+                  {isSelfMicrophoneEnabled ? (
+                    <MicOff className="size-3.5 text-muted-foreground" />
+                  ) : (
+                    <Mic className="size-3.5 text-muted-foreground" />
+                  )}
+                  {isSelfMicrophoneEnabled
+                    ? t('workspace.muteMyMicrophone')
+                    : t('workspace.unmuteMyMicrophone')}
+                </DropdownMenuItem>
+              ) : null}
               {hasMediaActions ? (
                 <MediaActionsContent
                   isLocallyMuted={isLocallyMuted}

--- a/apps/web/src/components/room-workspace.tsx
+++ b/apps/web/src/components/room-workspace.tsx
@@ -90,6 +90,8 @@ interface RoomWorkspaceProps {
     muteSet: ReadonlySet<string>;
     videoHiddenSet: ReadonlySet<string>;
   };
+  selfMicrophoneEnabled?: boolean;
+  onSelfMicrophoneToggle?: () => void;
   dockedVideoPanel?: React.ReactNode;
 }
 
@@ -116,6 +118,8 @@ export function RoomWorkspace({
   mediaMutedMap,
   connectionQualityMap,
   participantMediaControls,
+  selfMicrophoneEnabled,
+  onSelfMicrophoneToggle,
   dockedVideoPanel,
 }: RoomWorkspaceProps) {
   const { t } = useTranslation('rooms');
@@ -903,6 +907,8 @@ export function RoomWorkspace({
                         participantMediaControls?.videoHiddenSet.has(participant.userId) ?? false
                       }
                       localVolume={participantMediaControls?.volumeMap.get(participant.userId)}
+                      isSelfMicrophoneEnabled={selfMicrophoneEnabled}
+                      onSelfMicrophoneToggle={onSelfMicrophoneToggle}
                       onLocalMuteToggle={
                         participantMediaControls
                           ? (muted) => participantMediaControls.setMuted(participant.userId, muted)

--- a/apps/web/src/locales/en/rooms.json
+++ b/apps/web/src/locales/en/rooms.json
@@ -192,6 +192,8 @@
     "emptyStderr": "(no stderr)",
     "participantsHeading": "Participants",
     "participantActions": "Participant actions",
+    "muteMyMicrophone": "Mute my microphone",
+    "unmuteMyMicrophone": "Unmute my microphone",
     "transferOwnership": "Make host",
     "removeParticipant": "Remove participant",
     "removeParticipantTitle": "Remove Participant",

--- a/apps/web/src/locales/zh/rooms.json
+++ b/apps/web/src/locales/zh/rooms.json
@@ -192,6 +192,8 @@
     "emptyStderr": "（无 stderr）",
     "participantsHeading": "参与者",
     "participantActions": "参与者操作",
+    "muteMyMicrophone": "静音我的麦克风",
+    "unmuteMyMicrophone": "取消静音我的麦克风",
     "transferOwnership": "转移主持人",
     "removeParticipant": "移除参与者",
     "removeParticipantTitle": "移除参与者",

--- a/apps/web/src/routes/_app/rooms.$roomId.tsx
+++ b/apps/web/src/routes/_app/rooms.$roomId.tsx
@@ -692,6 +692,8 @@ function RoomPage() {
             muteSet: localMuteSet,
             videoHiddenSet,
           }}
+          selfMicrophoneEnabled={isMicrophoneEnabled}
+          onSelfMicrophoneToggle={() => void toggleMicrophone()}
           dockedVideoPanel={
             showMediaPanel && videoPanelMode === 'docked' ? (
               <DockedVideoPanel tiles={videoTiles} onUndock={() => setVideoPanelMode('floating')} />
@@ -744,6 +746,8 @@ function RoomPage() {
           muteSet: localMuteSet,
           videoHiddenSet,
         }}
+        selfMicrophoneEnabled={isMicrophoneEnabled}
+        onSelfMicrophoneToggle={() => void toggleMicrophone()}
       />
     </>
   );

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -93,7 +93,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        'relative flex min-h-9 w-full cursor-default select-none items-center whitespace-nowrap rounded-md border border-transparent py-2 pl-9 pr-3 text-sm font-medium text-foreground/88 shadow-none outline-none transition-colors focus:outline-none focus-visible:outline-none focus-visible:ring-0 data-disabled:pointer-events-none data-highlighted:border-transparent data-highlighted:bg-muted data-highlighted:text-foreground data-[state=checked]:border-transparent data-[state=checked]:bg-primary/10 data-[state=checked]:text-foreground data-disabled:opacity-50',
+        'relative flex min-h-9 w-full cursor-default select-none items-center whitespace-normal break-words rounded-md border border-transparent py-2 pl-9 pr-3 text-sm font-medium text-foreground/88 shadow-none outline-none transition-colors focus:outline-none focus-visible:outline-none focus-visible:ring-0 data-disabled:pointer-events-none data-highlighted:border-transparent data-highlighted:bg-muted data-highlighted:text-foreground data-[state=checked]:border-transparent data-[state=checked]:bg-primary/10 data-[state=checked]:text-foreground data-disabled:opacity-50',
         className,
       )}
       {...props}


### PR DESCRIPTION
Adds a self-mute entry to the local user's participant card menu, alongside the existing media controls bar. Also fixes Select items overflowing their trigger width by switching to whitespace-normal break-words.