### PR TITLE
feat(web): add grant camera and microphone buttons in media settings

### DIFF
--- a/apps/web/src/components/media-settings-panel.spec.tsx
+++ b/apps/web/src/components/media-settings-panel.spec.tsx
@@ -1,0 +1,204 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MediaSettingsPanel } from './media-settings-panel.js';
+
+interface MockPermissionStatus {
+  state: 'granted' | 'prompt' | 'denied';
+}
+
+function setupNavigatorMocks(opts: {
+  cameraState?: MockPermissionStatus['state'];
+  micState?: MockPermissionStatus['state'];
+  devices?: { kind: string; deviceId: string; label: string }[];
+  getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+}) {
+  const query = vi.fn().mockImplementation(async ({ name }: { name: string }) => {
+    if (name === 'camera') return { state: opts.cameraState ?? 'prompt' };
+    if (name === 'microphone') return { state: opts.micState ?? 'prompt' };
+    throw new TypeError('unsupported');
+  });
+
+  const enumerateDevices = vi.fn().mockResolvedValue(opts.devices ?? []);
+  const addEventListener = vi.fn();
+  const removeEventListener = vi.fn();
+  const defaultGetUserMedia = vi.fn().mockRejectedValue(new Error('not mocked'));
+  const getUserMedia = opts.getUserMedia ?? defaultGetUserMedia;
+
+  Object.defineProperty(navigator, 'permissions', {
+    configurable: true,
+    value: { query },
+  });
+
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: {
+      enumerateDevices,
+      getUserMedia,
+      addEventListener,
+      removeEventListener,
+    },
+  });
+
+  return { query, enumerateDevices, getUserMedia };
+}
+
+const baseProps = {
+  audioInputDevices: [],
+  videoInputDevices: [],
+  activeAudioDeviceId: null,
+  activeVideoDeviceId: null,
+  onSwitchDevice: vi.fn(),
+  outputVolume: 1,
+  onOutputVolumeChange: vi.fn(),
+  audioProcessing: { noiseSuppression: true, echoCancellation: true, autoGainControl: false },
+  onAudioProcessingChange: vi.fn(),
+  onVideoFilterChange: vi.fn(),
+  videoQuality: 'medium' as const,
+  onVideoQualityChange: vi.fn(),
+  isPushToTalkMode: false,
+  onTogglePushToTalkMode: vi.fn(),
+};
+
+describe('MediaSettingsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GIVEN no prior permissions WHEN panel opened THEN shows both grant buttons', async () => {
+    setupNavigatorMocks({ cameraState: 'prompt', micState: 'prompt', devices: [] });
+    const user = userEvent.setup();
+
+    render(<MediaSettingsPanel {...baseProps} />);
+    await user.click(screen.getByRole('button', { name: /media settings/i }));
+
+    expect(
+      await screen.findByRole('button', { name: /grant camera permission/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /grant microphone permission/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('GIVEN camera already granted via Permissions API WHEN opened THEN camera section shows device picker and no grant button', async () => {
+    setupNavigatorMocks({
+      cameraState: 'granted',
+      micState: 'prompt',
+      devices: [{ kind: 'videoinput', deviceId: 'cam-1', label: 'FaceTime HD' }],
+    });
+    const user = userEvent.setup();
+
+    render(<MediaSettingsPanel {...baseProps} />);
+    await user.click(screen.getByRole('button', { name: /media settings/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: /grant camera permission/i }),
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole('button', { name: /grant microphone permission/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('GIVEN Permissions API unsupported but devices have labels WHEN opened THEN treats kind as granted', async () => {
+    setupNavigatorMocks({
+      devices: [{ kind: 'audioinput', deviceId: 'mic-1', label: 'Built-in Mic' }],
+    });
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: {
+        query: vi.fn().mockRejectedValue(new TypeError('unsupported')),
+      },
+    });
+    const user = userEvent.setup();
+
+    render(<MediaSettingsPanel {...baseProps} />);
+    await user.click(screen.getByRole('button', { name: /media settings/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: /grant microphone permission/i }),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /grant camera permission/i })).toBeInTheDocument();
+  });
+
+  it('GIVEN grant button clicked AND getUserMedia succeeds THEN stops tracks and re-renders with devices', async () => {
+    const stopTrack = vi.fn();
+    const track = { stop: stopTrack } as unknown as MediaStreamTrack;
+    const fakeStream = { getTracks: () => [track] } as unknown as MediaStream;
+
+    const enumerateCalls: number[] = [];
+    const enumerate = vi.fn().mockImplementation(() => {
+      const idx = enumerateCalls.push(enumerateCalls.length) - 1;
+      if (idx === 0) return Promise.resolve([]);
+      return Promise.resolve([{ kind: 'videoinput', deviceId: 'cam-1', label: 'My Webcam' }]);
+    });
+    const getUserMedia = vi.fn().mockResolvedValue(fakeStream);
+
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: {
+        query: vi.fn().mockResolvedValue({ state: 'prompt' }),
+      },
+    });
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        enumerateDevices: enumerate,
+        getUserMedia,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+    });
+
+    const user = userEvent.setup();
+    render(<MediaSettingsPanel {...baseProps} />);
+    await user.click(screen.getByRole('button', { name: /media settings/i }));
+
+    const grantBtn = await screen.findByRole('button', { name: /grant camera permission/i });
+    await user.click(grantBtn);
+
+    await waitFor(() => {
+      expect(getUserMedia).toHaveBeenCalledWith({ video: true });
+    });
+    expect(stopTrack).toHaveBeenCalled();
+  });
+
+  it('GIVEN grant button clicked AND getUserMedia rejects THEN shows friendly denial message and keeps button', async () => {
+    const getUserMedia = vi.fn().mockRejectedValue(new DOMException('denied', 'NotAllowedError'));
+
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: {
+        query: vi.fn().mockResolvedValue({ state: 'prompt' }),
+      },
+    });
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        enumerateDevices: vi.fn().mockResolvedValue([]),
+        getUserMedia,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+    });
+
+    const user = userEvent.setup();
+    render(<MediaSettingsPanel {...baseProps} />);
+    await user.click(screen.getByRole('button', { name: /media settings/i }));
+
+    const grantBtn = await screen.findByRole('button', { name: /grant microphone permission/i });
+    await user.click(grantBtn);
+
+    expect(await screen.findByText(/permission denied/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /grant microphone permission/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/media-settings-panel.tsx
+++ b/apps/web/src/components/media-settings-panel.tsx
@@ -141,35 +141,27 @@ function useMediaPermissions(
     };
   }, [open, detect]);
 
-  const requestAudio = useCallback(async () => {
-    setRequestingAudio(true);
-    setAudioError(null);
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      for (const t of stream.getTracks()) t.stop();
-      const signal = { cancelled: false };
-      await detect(signal);
-    } catch {
-      setAudioError('Permission denied. Update browser settings to allow.');
-    } finally {
-      setRequestingAudio(false);
-    }
-  }, [detect]);
-
-  const requestVideo = useCallback(async () => {
-    setRequestingVideo(true);
-    setVideoError(null);
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({ video: true });
-      for (const t of stream.getTracks()) t.stop();
-      const signal = { cancelled: false };
-      await detect(signal);
-    } catch {
-      setVideoError('Permission denied. Update browser settings to allow.');
-    } finally {
-      setRequestingVideo(false);
-    }
-  }, [detect]);
+  const request = useCallback(
+    async (kind: 'audio' | 'video') => {
+      const setRequesting = kind === 'audio' ? setRequestingAudio : setRequestingVideo;
+      const setError = kind === 'audio' ? setAudioError : setVideoError;
+      setRequesting(true);
+      setError(null);
+      try {
+        const constraints: MediaStreamConstraints =
+          kind === 'audio' ? { audio: true } : { video: true };
+        const stream = await navigator.mediaDevices.getUserMedia(constraints);
+        for (const t of stream.getTracks()) t.stop();
+        const signal = { cancelled: false };
+        await detect(signal);
+      } catch {
+        setError('Permission denied. Update browser settings to allow.');
+      } finally {
+        setRequesting(false);
+      }
+    },
+    [detect],
+  );
 
   return {
     audioDevices: hasLiveAudio ? existingAudio : probed.audio,
@@ -180,8 +172,7 @@ function useMediaPermissions(
     videoError,
     requestingAudio,
     requestingVideo,
-    requestAudio,
-    requestVideo,
+    request,
   };
 }
 
@@ -328,6 +319,47 @@ function VideoPreview({
   );
 }
 
+function GrantPermissionPrompt({
+  kind,
+  icon: Icon,
+  onRequest,
+  requesting,
+  error,
+}: {
+  kind: 'audio' | 'video';
+  icon: React.ComponentType<{ className?: string }>;
+  onRequest: () => void;
+  requesting: boolean;
+  error: string | null;
+}) {
+  const isAudio = kind === 'audio';
+  return (
+    <div className="space-y-2">
+      <p className="text-[11px] text-muted-foreground">
+        {isAudio
+          ? 'Allow microphone access to pick a device and tune audio processing.'
+          : 'Allow camera access to preview video and pick a device before going live.'}
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-7 w-full gap-1.5 text-xs"
+        onClick={onRequest}
+        disabled={requesting}
+      >
+        <Icon className="size-3" />
+        {requesting
+          ? 'Requesting...'
+          : isAudio
+            ? 'Grant Microphone Permission'
+            : 'Grant Camera Permission'}
+      </Button>
+      {error ? <p className="text-[10px] text-destructive">{error}</p> : null}
+    </div>
+  );
+}
+
 function ToggleChip({
   label,
   icon: Icon,
@@ -387,8 +419,7 @@ export function MediaSettingsPanel({
     videoError,
     requestingAudio,
     requestingVideo,
-    requestAudio,
-    requestVideo,
+    request,
   } = useMediaPermissions(open, audioInputDevices, videoInputDevices);
 
   const effectiveAudioId =
@@ -511,23 +542,13 @@ export function MediaSettingsPanel({
                 ) : null}
               </>
             ) : (
-              <div className="space-y-2">
-                <p className="text-[11px] text-muted-foreground">
-                  Allow camera access to preview video and pick a device before going live.
-                </p>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-7 w-full gap-1.5 text-xs"
-                  onClick={() => void requestVideo()}
-                  disabled={requestingVideo}
-                >
-                  <Camera className="size-3" />
-                  {requestingVideo ? 'Requesting...' : 'Grant Camera Permission'}
-                </Button>
-                {videoError ? <p className="text-[10px] text-destructive">{videoError}</p> : null}
-              </div>
+              <GrantPermissionPrompt
+                kind="video"
+                icon={Camera}
+                onRequest={() => void request('video')}
+                requesting={requestingVideo}
+                error={videoError}
+              />
             )}
           </div>
 
@@ -602,23 +623,13 @@ export function MediaSettingsPanel({
                 </div>
               </>
             ) : (
-              <div className="space-y-2">
-                <p className="text-[11px] text-muted-foreground">
-                  Allow microphone access to pick a device and tune audio processing.
-                </p>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-7 w-full gap-1.5 text-xs"
-                  onClick={() => void requestAudio()}
-                  disabled={requestingAudio}
-                >
-                  <Mic className="size-3" />
-                  {requestingAudio ? 'Requesting...' : 'Grant Microphone Permission'}
-                </Button>
-                {audioError ? <p className="text-[10px] text-destructive">{audioError}</p> : null}
-              </div>
+              <GrantPermissionPrompt
+                kind="audio"
+                icon={Mic}
+                onRequest={() => void request('audio')}
+                requesting={requestingAudio}
+                error={audioError}
+              />
             )}
           </div>
 

--- a/apps/web/src/components/media-settings-panel.tsx
+++ b/apps/web/src/components/media-settings-panel.tsx
@@ -110,14 +110,15 @@ function useMediaPermissions(
 
   const hasLiveAudio = existingAudio.length > 0;
   const hasLiveVideo = existingVideo.length > 0;
+  const cancelledRef = useRef(false);
 
-  const detect = useCallback(async (signal: { cancelled: boolean }) => {
+  const detect = useCallback(async (cancelled: { current: boolean }) => {
     const [camPerm, micPerm, devices] = await Promise.all([
       queryPermission('camera'),
       queryPermission('microphone'),
       enumerateByKind().catch(() => ({ audio: [], video: [] }) as LocalDevices),
     ]);
-    if (signal.cancelled) return;
+    if (cancelled.current) return;
 
     // Non-placeholder labels indicate the browser has already granted access this session.
     const audioHasLabels = devices.audio.some((d) => d.label && !/^Microphone \d+$/.test(d.label));
@@ -134,10 +135,10 @@ function useMediaPermissions(
       setVideoError(null);
       return;
     }
-    const signal = { cancelled: false };
-    void detect(signal);
+    cancelledRef.current = false;
+    void detect(cancelledRef);
     return () => {
-      signal.cancelled = true;
+      cancelledRef.current = true;
     };
   }, [open, detect]);
 
@@ -152,12 +153,13 @@ function useMediaPermissions(
           kind === 'audio' ? { audio: true } : { video: true };
         const stream = await navigator.mediaDevices.getUserMedia(constraints);
         for (const t of stream.getTracks()) t.stop();
-        const signal = { cancelled: false };
-        await detect(signal);
+        if (cancelledRef.current) return;
+        await detect(cancelledRef);
       } catch {
+        if (cancelledRef.current) return;
         setError('Permission denied. Update browser settings to allow.');
       } finally {
-        setRequesting(false);
+        if (!cancelledRef.current) setRequesting(false);
       }
     },
     [detect],

--- a/apps/web/src/components/media-settings-panel.tsx
+++ b/apps/web/src/components/media-settings-panel.tsx
@@ -153,6 +153,11 @@ function useMediaPermissions(
     if (!open) {
       setAudioError(null);
       setVideoError(null);
+      // Reset in-flight flags so a request that started before the panel
+      // closed doesn't leave the grant button stuck on "Requesting..."
+      // when the panel is reopened.
+      setRequestingAudio(false);
+      setRequestingVideo(false);
       return;
     }
     cancelledRef.current = false;
@@ -175,11 +180,13 @@ function useMediaPermissions(
         for (const t of stream.getTracks()) t.stop();
         if (cancelledRef.current) return;
         await detect(cancelledRef);
-      } catch {
+      } catch (error) {
         if (cancelledRef.current) return;
-        setError('Permission denied. Update browser settings to allow.');
+        setError(formatMediaError(error, kind));
       } finally {
-        if (!cancelledRef.current) setRequesting(false);
+        // Always clear the requesting flag, even after cancel: otherwise the
+        // panel may reopen with the button stuck disabled.
+        setRequesting(false);
       }
     },
     [detect],
@@ -338,6 +345,55 @@ function VideoPreview({
       className="aspect-video w-full rounded-lg bg-black/90 object-cover scale-x-[-1]"
       style={{ filter: `brightness(${brightness}) contrast(${contrast})` }}
     />
+  );
+}
+
+function formatMediaError(error: unknown, kind: 'audio' | 'video'): string {
+  const device = kind === 'audio' ? 'microphone' : 'camera';
+  if (error instanceof DOMException) {
+    switch (error.name) {
+      case 'NotAllowedError':
+      case 'SecurityError':
+        return 'Permission denied. Update browser settings to allow.';
+      case 'NotFoundError':
+      case 'OverconstrainedError':
+        return `No ${device} found.`;
+      case 'NotReadableError':
+        return `${device.charAt(0).toUpperCase() + device.slice(1)} is in use by another application.`;
+    }
+  }
+  return `Unable to access ${device}.`;
+}
+
+function NoDevicesPrompt({
+  kind,
+  icon: Icon,
+  onRefresh,
+  refreshing,
+}: {
+  kind: 'audio' | 'video';
+  icon: React.ComponentType<{ className?: string }>;
+  onRefresh: () => void;
+  refreshing: boolean;
+}) {
+  const device = kind === 'audio' ? 'microphone' : 'camera';
+  return (
+    <div className="space-y-2">
+      <p className="text-[11px] text-muted-foreground">
+        Permission granted, but no {device} is connected. Plug in a device and refresh.
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-7 w-full gap-1.5 text-xs"
+        onClick={onRefresh}
+        disabled={refreshing}
+      >
+        <Icon className="size-3" />
+        {refreshing ? 'Refreshing...' : 'Refresh devices'}
+      </Button>
+    </div>
   );
 }
 
@@ -563,13 +619,20 @@ export function MediaSettingsPanel({
                   </button>
                 ) : null}
               </>
-            ) : (
+            ) : !videoGranted ? (
               <GrantPermissionPrompt
                 kind="video"
                 icon={Camera}
                 onRequest={() => void request('video')}
                 requesting={requestingVideo}
                 error={videoError}
+              />
+            ) : (
+              <NoDevicesPrompt
+                kind="video"
+                icon={Camera}
+                onRefresh={() => void request('video')}
+                refreshing={requestingVideo}
               />
             )}
           </div>
@@ -644,13 +707,20 @@ export function MediaSettingsPanel({
                   />
                 </div>
               </>
-            ) : (
+            ) : !audioGranted ? (
               <GrantPermissionPrompt
                 kind="audio"
                 icon={Mic}
                 onRequest={() => void request('audio')}
                 requesting={requestingAudio}
                 error={audioError}
+              />
+            ) : (
+              <NoDevicesPrompt
+                kind="audio"
+                icon={Mic}
+                onRefresh={() => void request('audio')}
+                refreshing={requestingAudio}
               />
             )}
           </div>

--- a/apps/web/src/components/media-settings-panel.tsx
+++ b/apps/web/src/components/media-settings-panel.tsx
@@ -12,8 +12,8 @@ import {
   Separator,
 } from '@syncode/ui';
 import {
+  Camera,
   Gauge,
-  Loader2,
   Mic,
   Radio,
   Settings,
@@ -23,7 +23,7 @@ import {
   Video,
   Volume2,
 } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MediaDeviceOption } from '@/hooks/use-livekit.js';
 
 export interface AudioProcessingSettings {
@@ -63,85 +63,125 @@ interface MediaSettingsPanelProps {
 const LEVEL_BAR_COUNT = 16;
 const LEVEL_BAR_KEYS = Array.from({ length: LEVEL_BAR_COUNT }, (_, i) => `bar-${String(i)}`);
 
+type PermissionStatusValue = 'granted' | 'prompt' | 'denied' | 'unknown';
+
 interface LocalDevices {
   audio: MediaDeviceOption[];
   video: MediaDeviceOption[];
 }
 
-function useDeviceProbe(
+async function queryPermission(name: 'camera' | 'microphone'): Promise<PermissionStatusValue> {
+  if (typeof navigator === 'undefined' || !navigator.permissions?.query) return 'unknown';
+  try {
+    const status = await navigator.permissions.query({
+      name: name as PermissionName,
+    });
+    return status.state as PermissionStatusValue;
+  } catch {
+    // Firefox and Safari throw TypeError for camera/microphone permission queries.
+    return 'unknown';
+  }
+}
+
+async function enumerateByKind(): Promise<LocalDevices> {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  return {
+    audio: devices
+      .filter((d) => d.kind === 'audioinput' && d.deviceId)
+      .map((d, i) => ({ deviceId: d.deviceId, label: d.label || `Microphone ${i + 1}` })),
+    video: devices
+      .filter((d) => d.kind === 'videoinput' && d.deviceId)
+      .map((d, i) => ({ deviceId: d.deviceId, label: d.label || `Camera ${i + 1}` })),
+  };
+}
+
+function useMediaPermissions(
   open: boolean,
   existingAudio: MediaDeviceOption[],
   existingVideo: MediaDeviceOption[],
 ) {
-  const [probed, setProbed] = useState<LocalDevices | null>(null);
-  const [probing, setProbing] = useState(false);
-  const [denied, setDenied] = useState(false);
-  const [retryKey, setRetryKey] = useState(0);
+  const [audioGranted, setAudioGranted] = useState(false);
+  const [videoGranted, setVideoGranted] = useState(false);
+  const [probed, setProbed] = useState<LocalDevices>({ audio: [], video: [] });
+  const [audioError, setAudioError] = useState<string | null>(null);
+  const [videoError, setVideoError] = useState<string | null>(null);
+  const [requestingAudio, setRequestingAudio] = useState(false);
+  const [requestingVideo, setRequestingVideo] = useState(false);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: retryKey triggers re-probe on user retry
+  const hasLiveAudio = existingAudio.length > 0;
+  const hasLiveVideo = existingVideo.length > 0;
+
+  const detect = useCallback(async (signal: { cancelled: boolean }) => {
+    const [camPerm, micPerm, devices] = await Promise.all([
+      queryPermission('camera'),
+      queryPermission('microphone'),
+      enumerateByKind().catch(() => ({ audio: [], video: [] }) as LocalDevices),
+    ]);
+    if (signal.cancelled) return;
+
+    // Non-placeholder labels indicate the browser has already granted access this session.
+    const audioHasLabels = devices.audio.some((d) => d.label && !/^Microphone \d+$/.test(d.label));
+    const videoHasLabels = devices.video.some((d) => d.label && !/^Camera \d+$/.test(d.label));
+
+    setAudioGranted(micPerm === 'granted' || (micPerm === 'unknown' && audioHasLabels));
+    setVideoGranted(camPerm === 'granted' || (camPerm === 'unknown' && videoHasLabels));
+    setProbed(devices);
+  }, []);
+
   useEffect(() => {
     if (!open) {
-      setProbed(null);
-      setDenied(false);
-      setProbing(false);
+      setAudioError(null);
+      setVideoError(null);
       return;
     }
-
-    if (existingAudio.length > 0 || existingVideo.length > 0) return;
-
-    let cancelled = false;
-    setProbing(true);
-    setDenied(false);
-
-    (async () => {
-      let stream: MediaStream | null = null;
-      try {
-        stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
-      } catch {
-        try {
-          stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-        } catch {
-          if (!cancelled) {
-            setDenied(true);
-            setProbing(false);
-          }
-          return;
-        }
-      }
-
-      if (cancelled) {
-        if (stream) for (const t of stream.getTracks()) t.stop();
-        return;
-      }
-
-      const devices = await navigator.mediaDevices.enumerateDevices();
-      if (stream) for (const t of stream.getTracks()) t.stop();
-      if (cancelled) return;
-
-      setProbed({
-        audio: devices
-          .filter((d) => d.kind === 'audioinput' && d.deviceId)
-          .map((d, i) => ({ deviceId: d.deviceId, label: d.label || `Microphone ${i + 1}` })),
-        video: devices
-          .filter((d) => d.kind === 'videoinput' && d.deviceId)
-          .map((d, i) => ({ deviceId: d.deviceId, label: d.label || `Camera ${i + 1}` })),
-      });
-      setProbing(false);
-    })();
-
+    const signal = { cancelled: false };
+    void detect(signal);
     return () => {
-      cancelled = true;
+      signal.cancelled = true;
     };
-  }, [open, existingAudio.length, existingVideo.length, retryKey]);
+  }, [open, detect]);
 
-  const retry = () => setRetryKey((n) => n + 1);
+  const requestAudio = useCallback(async () => {
+    setRequestingAudio(true);
+    setAudioError(null);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      for (const t of stream.getTracks()) t.stop();
+      const signal = { cancelled: false };
+      await detect(signal);
+    } catch {
+      setAudioError('Permission denied. Update browser settings to allow.');
+    } finally {
+      setRequestingAudio(false);
+    }
+  }, [detect]);
+
+  const requestVideo = useCallback(async () => {
+    setRequestingVideo(true);
+    setVideoError(null);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+      for (const t of stream.getTracks()) t.stop();
+      const signal = { cancelled: false };
+      await detect(signal);
+    } catch {
+      setVideoError('Permission denied. Update browser settings to allow.');
+    } finally {
+      setRequestingVideo(false);
+    }
+  }, [detect]);
 
   return {
-    audioDevices: existingAudio.length > 0 ? existingAudio : (probed?.audio ?? []),
-    videoDevices: existingVideo.length > 0 ? existingVideo : (probed?.video ?? []),
-    probing,
-    denied,
-    retry,
+    audioDevices: hasLiveAudio ? existingAudio : probed.audio,
+    videoDevices: hasLiveVideo ? existingVideo : probed.video,
+    audioGranted: hasLiveAudio || audioGranted,
+    videoGranted: hasLiveVideo || videoGranted,
+    audioError,
+    videoError,
+    requestingAudio,
+    requestingVideo,
+    requestAudio,
+    requestVideo,
   };
 }
 
@@ -338,11 +378,18 @@ export function MediaSettingsPanel({
   const [selectedAudioId, setSelectedAudioId] = useState<string | null>(null);
   const [selectedVideoId, setSelectedVideoId] = useState<string | null>(null);
 
-  const { audioDevices, videoDevices, probing, denied, retry } = useDeviceProbe(
-    open,
-    audioInputDevices,
-    videoInputDevices,
-  );
+  const {
+    audioDevices,
+    videoDevices,
+    audioGranted,
+    videoGranted,
+    audioError,
+    videoError,
+    requestingAudio,
+    requestingVideo,
+    requestAudio,
+    requestVideo,
+  } = useMediaPermissions(open, audioInputDevices, videoInputDevices);
 
   const effectiveAudioId =
     activeAudioDeviceId ?? selectedAudioId ?? audioDevices[0]?.deviceId ?? null;
@@ -369,40 +416,15 @@ export function MediaSettingsPanel({
           </span>
         </div>
 
-        {probing ? (
-          <div className="flex items-center justify-center gap-2 py-8">
-            <Loader2 className="size-4 animate-spin text-muted-foreground" />
-            <span className="text-xs text-muted-foreground">Requesting device access...</span>
-          </div>
-        ) : denied ? (
-          <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
-            <div className="flex size-10 items-center justify-center rounded-full bg-destructive/10">
-              <Mic className="size-4 text-destructive" />
+        <div className="space-y-1 p-1.5">
+          <div className="space-y-2 rounded-lg bg-muted/20 p-2.5">
+            <div className="flex items-center gap-1.5">
+              <Video className="size-3 text-muted-foreground" />
+              <span className="text-xs font-medium text-foreground">Camera</span>
             </div>
-            <div className="space-y-1">
-              <p className="text-xs font-medium text-foreground">Permission denied</p>
-              <p className="text-[11px] text-muted-foreground">
-                Allow camera and microphone access in your browser settings, then try again.
-              </p>
-            </div>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-7 text-xs"
-              onClick={retry}
-            >
-              Try again
-            </Button>
-          </div>
-        ) : (
-          <div className="space-y-1 p-1.5">
-            {videoDevices.length > 0 ? (
-              <div className="space-y-2 rounded-lg bg-muted/20 p-2.5">
-                <div className="flex items-center gap-1.5">
-                  <Video className="size-3 text-muted-foreground" />
-                  <span className="text-xs font-medium text-foreground">Camera</span>
-                </div>
+
+            {videoGranted && videoDevices.length > 0 ? (
+              <>
                 <VideoPreview
                   deviceId={effectiveVideoId}
                   brightness={brightness}
@@ -487,16 +509,36 @@ export function MediaSettingsPanel({
                     Reset adjustments
                   </button>
                 ) : null}
+              </>
+            ) : (
+              <div className="space-y-2">
+                <p className="text-[11px] text-muted-foreground">
+                  Allow camera access to preview video and pick a device before going live.
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 w-full gap-1.5 text-xs"
+                  onClick={() => void requestVideo()}
+                  disabled={requestingVideo}
+                >
+                  <Camera className="size-3" />
+                  {requestingVideo ? 'Requesting...' : 'Grant Camera Permission'}
+                </Button>
+                {videoError ? <p className="text-[10px] text-destructive">{videoError}</p> : null}
               </div>
-            ) : null}
+            )}
+          </div>
 
-            {audioDevices.length > 0 ? (
-              <div className="space-y-2 rounded-lg bg-muted/20 p-2.5">
-                <div className="flex items-center gap-1.5">
-                  <Mic className="size-3 text-muted-foreground" />
-                  <span className="text-xs font-medium text-foreground">Microphone</span>
-                </div>
+          <div className="space-y-2 rounded-lg bg-muted/20 p-2.5">
+            <div className="flex items-center gap-1.5">
+              <Mic className="size-3 text-muted-foreground" />
+              <span className="text-xs font-medium text-foreground">Microphone</span>
+            </div>
 
+            {audioGranted && audioDevices.length > 0 ? (
+              <>
                 <AudioLevelMeter deviceId={effectiveAudioId} />
 
                 {audioDevices.length > 1 ? (
@@ -558,91 +600,103 @@ export function MediaSettingsPanel({
                     }
                   />
                 </div>
+              </>
+            ) : (
+              <div className="space-y-2">
+                <p className="text-[11px] text-muted-foreground">
+                  Allow microphone access to pick a device and tune audio processing.
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 w-full gap-1.5 text-xs"
+                  onClick={() => void requestAudio()}
+                  disabled={requestingAudio}
+                >
+                  <Mic className="size-3" />
+                  {requestingAudio ? 'Requesting...' : 'Grant Microphone Permission'}
+                </Button>
+                {audioError ? <p className="text-[10px] text-destructive">{audioError}</p> : null}
               </div>
-            ) : null}
+            )}
+          </div>
 
-            <div className="space-y-2 rounded-lg bg-muted/20 p-2.5">
-              <div className="flex items-center gap-1.5">
-                <Volume2 className="size-3 text-muted-foreground" />
-                <span className="text-xs font-medium text-foreground">Speaker volume</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <input
-                  type="range"
-                  min="0"
-                  max="1"
-                  step="0.05"
-                  value={outputVolume}
-                  onChange={(e) => onOutputVolumeChange(Number(e.target.value))}
-                  className="h-1 flex-1 cursor-pointer appearance-none rounded-full bg-muted accent-primary"
-                />
-                <span className="w-8 text-right font-mono text-[10px] text-muted-foreground/60">
-                  {Math.round(outputVolume * 100)}%
-                </span>
-              </div>
+          <div className="space-y-2 rounded-lg bg-muted/20 p-2.5">
+            <div className="flex items-center gap-1.5">
+              <Volume2 className="size-3 text-muted-foreground" />
+              <span className="text-xs font-medium text-foreground">Speaker volume</span>
             </div>
-
-            <div className="space-y-2 rounded-lg bg-muted/20 p-2.5">
-              <div className="flex items-center gap-1.5">
-                <Gauge className="size-3 text-muted-foreground" />
-                <span className="text-xs font-medium text-foreground">Video quality</span>
-              </div>
-              <div className="flex gap-1">
-                {(
-                  Object.entries(VIDEO_QUALITY_PRESETS) as [
-                    VideoQualityPreset,
-                    (typeof VIDEO_QUALITY_PRESETS)[VideoQualityPreset],
-                  ][]
-                ).map(([key, preset]) => (
-                  <button
-                    key={key}
-                    type="button"
-                    onClick={() => onVideoQualityChange(key)}
-                    className={cn(
-                      'flex-1 rounded-md border px-2 py-1.5 text-center text-[10px] font-medium transition-colors',
-                      videoQuality === key
-                        ? 'border-primary/30 bg-primary/10 text-primary'
-                        : 'border-border/60 text-muted-foreground hover:bg-muted/50',
-                    )}
-                  >
-                    {preset.label.split(' ')[0]}
-                  </button>
-                ))}
-              </div>
-              <span className="font-mono text-[9px] text-muted-foreground/60">
-                {VIDEO_QUALITY_PRESETS[videoQuality].width}x
-                {VIDEO_QUALITY_PRESETS[videoQuality].height} @{' '}
-                {VIDEO_QUALITY_PRESETS[videoQuality].frameRate}fps
+            <div className="flex items-center gap-2">
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.05"
+                value={outputVolume}
+                onChange={(e) => onOutputVolumeChange(Number(e.target.value))}
+                className="h-1 flex-1 cursor-pointer appearance-none rounded-full bg-muted accent-primary"
+              />
+              <span className="w-8 text-right font-mono text-[10px] text-muted-foreground/60">
+                {Math.round(outputVolume * 100)}%
               </span>
             </div>
+          </div>
 
-            <div className="space-y-2 rounded-lg bg-muted/20 p-2.5">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-1.5">
-                  <Radio className="size-3 text-muted-foreground" />
-                  <span className="text-xs font-medium text-foreground">Push to talk</span>
-                </div>
-                <ToggleChip
-                  label={isPushToTalkMode ? 'On' : 'Off'}
-                  icon={Radio}
-                  active={isPushToTalkMode}
-                  onClick={onTogglePushToTalkMode}
-                />
-              </div>
-              {isPushToTalkMode ? (
-                <span className="font-mono text-[9px] text-muted-foreground/60">
-                  Hold Space to talk
-                </span>
-              ) : null}
+          <div className="space-y-2 rounded-lg bg-muted/20 p-2.5">
+            <div className="flex items-center gap-1.5">
+              <Gauge className="size-3 text-muted-foreground" />
+              <span className="text-xs font-medium text-foreground">Video quality</span>
             </div>
+            <div className="flex gap-1">
+              {(
+                Object.entries(VIDEO_QUALITY_PRESETS) as [
+                  VideoQualityPreset,
+                  (typeof VIDEO_QUALITY_PRESETS)[VideoQualityPreset],
+                ][]
+              ).map(([key, preset]) => (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => onVideoQualityChange(key)}
+                  className={cn(
+                    'flex-1 rounded-md border px-2 py-1.5 text-center text-[10px] font-medium transition-colors',
+                    videoQuality === key
+                      ? 'border-primary/30 bg-primary/10 text-primary'
+                      : 'border-border/60 text-muted-foreground hover:bg-muted/50',
+                  )}
+                >
+                  {preset.label.split(' ')[0]}
+                </button>
+              ))}
+            </div>
+            <span className="font-mono text-[9px] text-muted-foreground/60">
+              {VIDEO_QUALITY_PRESETS[videoQuality].width}x
+              {VIDEO_QUALITY_PRESETS[videoQuality].height} @{' '}
+              {VIDEO_QUALITY_PRESETS[videoQuality].frameRate}fps
+            </span>
+          </div>
 
-            {audioDevices.length === 0 && videoDevices.length === 0 ? (
-              <p className="py-4 text-center font-mono text-xs text-muted-foreground">
-                No media devices found
-              </p>
+          <div className="space-y-2 rounded-lg bg-muted/20 p-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-1.5">
+                <Radio className="size-3 text-muted-foreground" />
+                <span className="text-xs font-medium text-foreground">Push to talk</span>
+              </div>
+              <ToggleChip
+                label={isPushToTalkMode ? 'On' : 'Off'}
+                icon={Radio}
+                active={isPushToTalkMode}
+                onClick={onTogglePushToTalkMode}
+              />
+            </div>
+            {isPushToTalkMode ? (
+              <span className="font-mono text-[9px] text-muted-foreground/60">
+                Hold Space to talk
+              </span>
             ) : null}
           </div>
-        )}
+        </div>
       </PopoverContent>
     </Popover>
   );

--- a/apps/web/src/components/media-settings-panel.tsx
+++ b/apps/web/src/components/media-settings-panel.tsx
@@ -83,15 +83,29 @@ async function queryPermission(name: 'camera' | 'microphone'): Promise<Permissio
   }
 }
 
-async function enumerateByKind(): Promise<LocalDevices> {
+interface EnumerationResult {
+  devices: LocalDevices;
+  audioHasNativeLabels: boolean;
+  videoHasNativeLabels: boolean;
+}
+
+async function enumerateByKind(): Promise<EnumerationResult> {
   const devices = await navigator.mediaDevices.enumerateDevices();
+  const rawAudio = devices.filter((d) => d.kind === 'audioinput' && d.deviceId);
+  const rawVideo = devices.filter((d) => d.kind === 'videoinput' && d.deviceId);
   return {
-    audio: devices
-      .filter((d) => d.kind === 'audioinput' && d.deviceId)
-      .map((d, i) => ({ deviceId: d.deviceId, label: d.label || `Microphone ${i + 1}` })),
-    video: devices
-      .filter((d) => d.kind === 'videoinput' && d.deviceId)
-      .map((d, i) => ({ deviceId: d.deviceId, label: d.label || `Camera ${i + 1}` })),
+    devices: {
+      audio: rawAudio.map((d, i) => ({
+        deviceId: d.deviceId,
+        label: d.label || `Microphone ${i + 1}`,
+      })),
+      video: rawVideo.map((d, i) => ({
+        deviceId: d.deviceId,
+        label: d.label || `Camera ${i + 1}`,
+      })),
+    },
+    audioHasNativeLabels: rawAudio.some((d) => d.label.length > 0),
+    videoHasNativeLabels: rawVideo.some((d) => d.label.length > 0),
   };
 }
 
@@ -113,20 +127,26 @@ function useMediaPermissions(
   const cancelledRef = useRef(false);
 
   const detect = useCallback(async (cancelled: { current: boolean }) => {
-    const [camPerm, micPerm, devices] = await Promise.all([
+    const emptyEnum: EnumerationResult = {
+      devices: { audio: [], video: [] },
+      audioHasNativeLabels: false,
+      videoHasNativeLabels: false,
+    };
+    const [camPerm, micPerm, enumeration] = await Promise.all([
       queryPermission('camera'),
       queryPermission('microphone'),
-      enumerateByKind().catch(() => ({ audio: [], video: [] }) as LocalDevices),
+      enumerateByKind().catch(() => emptyEnum),
     ]);
     if (cancelled.current) return;
 
-    // Non-placeholder labels indicate the browser has already granted access this session.
-    const audioHasLabels = devices.audio.some((d) => d.label && !/^Microphone \d+$/.test(d.label));
-    const videoHasLabels = devices.video.some((d) => d.label && !/^Camera \d+$/.test(d.label));
-
-    setAudioGranted(micPerm === 'granted' || (micPerm === 'unknown' && audioHasLabels));
-    setVideoGranted(camPerm === 'granted' || (camPerm === 'unknown' && videoHasLabels));
-    setProbed(devices);
+    // Native browsers return empty labels until permission has been granted this session.
+    setAudioGranted(
+      micPerm === 'granted' || (micPerm === 'unknown' && enumeration.audioHasNativeLabels),
+    );
+    setVideoGranted(
+      camPerm === 'granted' || (camPerm === 'unknown' && enumeration.videoHasNativeLabels),
+    );
+    setProbed(enumeration.devices);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Explicit permission-request buttons in the Media Settings panel via a shared GrantPermissionPrompt. Detection now uses an empty device label (the actual native signal) instead of a fragile placeholder regex. A cancel ref prevents setState after the panel unmounts.