### PR TITLE
feat(web): resize floating video panel and zoom into tiles

### DIFF
--- a/apps/web/src/components/video-panel.spec.ts
+++ b/apps/web/src/components/video-panel.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  shouldClearZoomTarget,
+  type VideoPanelParticipant,
+  type ZoomTarget,
+} from './video-panel.js';
+
+function makeTile(overrides: Partial<VideoPanelParticipant> = {}): VideoPanelParticipant {
+  return {
+    identity: 'alice',
+    displayName: 'Alice',
+    avatarUrl: null,
+    hasVideo: false,
+    videoTrack: null,
+    hasScreenShare: false,
+    screenShareTrack: null,
+    isSpeaking: false,
+    isLocal: false,
+    ...overrides,
+  };
+}
+
+describe('shouldClearZoomTarget', () => {
+  it('GIVEN zoomTarget is null THEN returns false', () => {
+    const tiles = [makeTile({ identity: 'alice' })];
+    expect(shouldClearZoomTarget(null, tiles)).toBe(false);
+  });
+
+  it('GIVEN camera zoomTarget points to a participant still in tiles THEN returns false', () => {
+    const zoomTarget: ZoomTarget = { identity: 'alice', kind: 'camera' };
+    const tiles = [makeTile({ identity: 'alice' }), makeTile({ identity: 'bob' })];
+    expect(shouldClearZoomTarget(zoomTarget, tiles)).toBe(false);
+  });
+
+  it('GIVEN camera zoomTarget participant leaves the tiles list THEN returns true', () => {
+    const zoomTarget: ZoomTarget = { identity: 'alice', kind: 'camera' };
+    const tiles = [makeTile({ identity: 'bob' })];
+    expect(shouldClearZoomTarget(zoomTarget, tiles)).toBe(true);
+  });
+
+  it('GIVEN camera zoomTarget and tiles list is empty THEN returns true', () => {
+    const zoomTarget: ZoomTarget = { identity: 'alice', kind: 'camera' };
+    expect(shouldClearZoomTarget(zoomTarget, [])).toBe(true);
+  });
+
+  it('GIVEN screen zoomTarget and participant is sharing screen THEN returns false', () => {
+    const zoomTarget: ZoomTarget = { identity: 'alice', kind: 'screen' };
+    const track = {} as MediaStreamTrack;
+    const tiles = [makeTile({ identity: 'alice', hasScreenShare: true, screenShareTrack: track })];
+    expect(shouldClearZoomTarget(zoomTarget, tiles)).toBe(false);
+  });
+
+  it('GIVEN screen zoomTarget and participant stopped sharing THEN returns true', () => {
+    const zoomTarget: ZoomTarget = { identity: 'alice', kind: 'screen' };
+    const tiles = [makeTile({ identity: 'alice', hasScreenShare: false, screenShareTrack: null })];
+    expect(shouldClearZoomTarget(zoomTarget, tiles)).toBe(true);
+  });
+
+  it('GIVEN screen zoomTarget and participant has hasScreenShare flag but no track THEN returns true', () => {
+    const zoomTarget: ZoomTarget = { identity: 'alice', kind: 'screen' };
+    const tiles = [makeTile({ identity: 'alice', hasScreenShare: true, screenShareTrack: null })];
+    expect(shouldClearZoomTarget(zoomTarget, tiles)).toBe(true);
+  });
+
+  it('GIVEN screen zoomTarget participant left the tiles list THEN returns true', () => {
+    const zoomTarget: ZoomTarget = { identity: 'alice', kind: 'screen' };
+    const tiles = [makeTile({ identity: 'bob' })];
+    expect(shouldClearZoomTarget(zoomTarget, tiles)).toBe(true);
+  });
+});

--- a/apps/web/src/components/video-panel.tsx
+++ b/apps/web/src/components/video-panel.tsx
@@ -7,9 +7,10 @@ import {
   PanelRight,
   PanelRightClose,
   Video,
+  X,
 } from 'lucide-react';
 import { AnimatePresence, motion, useMotionValue, useSpring } from 'motion/react';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useVideoTrack } from '@/hooks/use-video-track.js';
 
@@ -25,6 +26,11 @@ export interface VideoPanelParticipant {
   isLocal: boolean;
 }
 
+interface ParticipantTileProps extends Omit<VideoPanelParticipant, 'identity'> {
+  onZoom?: () => void;
+  fit?: 'cover' | 'contain';
+}
+
 function ParticipantTile({
   displayName,
   avatarUrl,
@@ -32,17 +38,35 @@ function ParticipantTile({
   videoTrack,
   isSpeaking,
   isLocal,
-}: Omit<VideoPanelParticipant, 'identity'>) {
+  onZoom,
+  fit = 'cover',
+}: ParticipantTileProps) {
   const { t } = useTranslation('rooms');
   const videoRef = useVideoTrack(videoTrack);
   const initial = displayName.charAt(0).toUpperCase();
 
+  const handleDoubleClick = onZoom
+    ? (e: React.MouseEvent) => {
+        e.preventDefault();
+        onZoom();
+      }
+    : undefined;
+
+  const interactiveProps = onZoom
+    ? {
+        role: 'button' as const,
+        tabIndex: -1,
+        onDoubleClick: handleDoubleClick,
+      }
+    : undefined;
+
   return (
     <div
       className={cn(
-        'relative aspect-video overflow-hidden rounded-lg bg-muted/80 transition-shadow duration-200',
+        'group relative aspect-video overflow-hidden rounded-lg bg-muted/80 transition-shadow duration-200',
         isSpeaking && 'ring-2 ring-emerald-400/70 shadow-[0_0_12px_-3px_oklch(0.75_0.18_155/0.4)]',
       )}
+      {...interactiveProps}
     >
       {hasVideo && videoTrack ? (
         <video
@@ -50,7 +74,11 @@ function ParticipantTile({
           autoPlay
           playsInline
           muted
-          className={cn('h-full w-full object-cover', isLocal && 'scale-x-[-1]')}
+          className={cn(
+            'h-full w-full',
+            fit === 'contain' ? 'object-contain' : 'object-cover',
+            isLocal && 'scale-x-[-1]',
+          )}
         />
       ) : (
         <div className="flex h-full w-full items-center justify-center bg-muted/60">
@@ -62,6 +90,22 @@ function ParticipantTile({
           </Avatar>
         </div>
       )}
+
+      {onZoom ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="absolute right-1 top-1 size-5 bg-black/40 text-white/80 opacity-0 backdrop-blur-sm hover:bg-black/60 hover:text-white focus-visible:opacity-100 group-hover:opacity-100"
+          onClick={(e) => {
+            e.stopPropagation();
+            onZoom();
+          }}
+          aria-label="Zoom in"
+        >
+          <Maximize2 className="size-3" />
+        </Button>
+      ) : null}
 
       <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent px-2 pb-1.5 pt-5">
         <div className="flex items-center gap-1.5">
@@ -78,25 +122,67 @@ function ParticipantTile({
   );
 }
 
+interface ScreenShareTileProps {
+  displayName: string;
+  screenShareTrack: MediaStreamTrack;
+  onZoom?: () => void;
+  fill?: boolean;
+}
+
 function ScreenShareTile({
   displayName,
   screenShareTrack,
-}: {
-  displayName: string;
-  screenShareTrack: MediaStreamTrack;
-}) {
+  onZoom,
+  fill = false,
+}: ScreenShareTileProps) {
   const videoRef = useVideoTrack(screenShareTrack);
 
+  const handleDoubleClick = onZoom
+    ? (e: React.MouseEvent) => {
+        e.preventDefault();
+        onZoom();
+      }
+    : undefined;
+
+  const interactiveProps = onZoom
+    ? {
+        role: 'button' as const,
+        tabIndex: -1,
+        onDoubleClick: handleDoubleClick,
+      }
+    : undefined;
+
   return (
-    <div className="relative overflow-hidden rounded-lg bg-black/95 ring-1 ring-primary/30">
+    <div
+      className={cn(
+        'group relative overflow-hidden rounded-lg bg-black/95 ring-1 ring-primary/30',
+        fill && 'h-full',
+      )}
+      {...interactiveProps}
+    >
       <video
         ref={videoRef}
         autoPlay
         playsInline
         muted
-        className="w-full object-contain"
-        style={{ maxHeight: '40vh' }}
+        className={cn('w-full object-contain', fill && 'h-full')}
+        style={fill ? undefined : { maxHeight: '40vh' }}
       />
+      {onZoom ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="absolute right-1.5 top-1.5 size-6 bg-black/50 text-white/80 opacity-0 backdrop-blur-sm hover:bg-black/70 hover:text-white focus-visible:opacity-100 group-hover:opacity-100"
+          onClick={(e) => {
+            e.stopPropagation();
+            onZoom();
+          }}
+          aria-label="Zoom in"
+        >
+          <Maximize2 className="size-3" />
+        </Button>
+      ) : null}
       <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent px-2.5 pb-2 pt-5">
         <div className="flex items-center gap-1.5">
           <MonitorUp className="size-3 text-primary" />
@@ -106,6 +192,81 @@ function ScreenShareTile({
         </div>
       </div>
     </div>
+  );
+}
+
+type ZoomTarget = { identity: string; kind: 'camera' | 'screen' };
+
+interface ZoomOverlayProps {
+  tile: VideoPanelParticipant;
+  kind: 'camera' | 'screen';
+  onClose: () => void;
+}
+
+function ZoomOverlay({ tile, kind, onClose }: ZoomOverlayProps) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const isScreen = kind === 'screen' && tile.hasScreenShare && tile.screenShareTrack;
+
+  return (
+    <motion.div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.18 }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Zoomed video"
+    >
+      <button
+        type="button"
+        aria-label="Close zoom"
+        className="absolute inset-0 cursor-default bg-transparent"
+        onClick={onClose}
+      />
+      <div className="relative flex h-[min(88vh,calc(88vw*9/16))] w-[min(92vw,calc(88vh*16/9))] items-center justify-center">
+        {isScreen && tile.screenShareTrack ? (
+          <ScreenShareTile
+            displayName={tile.displayName}
+            screenShareTrack={tile.screenShareTrack}
+            fill
+          />
+        ) : (
+          <div className="h-full w-full">
+            <ParticipantTile {...tile} fit="contain" />
+          </div>
+        )}
+        <div className="absolute right-2 top-2 flex items-center gap-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="size-8 bg-black/50 text-white/90 backdrop-blur-sm hover:bg-black/70 hover:text-white"
+            onClick={onClose}
+            aria-label="Exit zoom"
+          >
+            <Minimize2 className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="size-8 bg-black/50 text-white/90 backdrop-blur-sm hover:bg-black/70 hover:text-white"
+            onClick={onClose}
+            aria-label="Close zoom"
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+      </div>
+    </motion.div>
   );
 }
 
@@ -130,6 +291,10 @@ interface FloatingVideoPanelProps {
 const SPRING_CONFIG = { stiffness: 300, damping: 30 };
 const EDGE_PADDING = 8;
 const FLOATING_WIDTH = 220;
+const FLOATING_DEFAULT_HEIGHT = 140;
+const FLOATING_MIN_WIDTH = 200;
+const FLOATING_MIN_HEIGHT = 150;
+const VIEWPORT_PADDING = 32;
 
 export function FloatingVideoPanel({
   tiles,
@@ -150,7 +315,17 @@ export function FloatingVideoPanel({
     originY: number;
   } | null>(null);
 
-  const panelWidth = isMinimized ? 160 : FLOATING_WIDTH;
+  const [size, setSize] = useState({ width: FLOATING_WIDTH, height: FLOATING_DEFAULT_HEIGHT });
+  const [zoomTarget, setZoomTarget] = useState<ZoomTarget | null>(null);
+
+  const resizeRef = useRef<{
+    startX: number;
+    startY: number;
+    originWidth: number;
+    originHeight: number;
+  } | null>(null);
+
+  const panelWidth = isMinimized ? 160 : size.width;
   const activeTile = pickActiveTile(tiles);
 
   const clampPositionRef = useRef<((x: number, y: number) => { x: number; y: number }) | null>(
@@ -170,6 +345,15 @@ export function FloatingVideoPanel({
   );
   clampPositionRef.current = clampPosition;
 
+  const clampSize = useCallback((width: number, height: number) => {
+    const maxW = Math.max(FLOATING_MIN_WIDTH, window.innerWidth - VIEWPORT_PADDING);
+    const maxH = Math.max(FLOATING_MIN_HEIGHT, window.innerHeight - VIEWPORT_PADDING);
+    return {
+      width: Math.max(FLOATING_MIN_WIDTH, Math.min(maxW, width)),
+      height: Math.max(FLOATING_MIN_HEIGHT, Math.min(maxH, height)),
+    };
+  }, []);
+
   useEffect(() => {
     const onResize = () => {
       const fn = clampPositionRef.current;
@@ -178,10 +362,21 @@ export function FloatingVideoPanel({
       posRef.current = clamped;
       springX.set(clamped.x);
       springY.set(clamped.y);
+      setSize((prev) => clampSize(prev.width, prev.height));
     };
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
-  }, [springX, springY]);
+  }, [springX, springY, clampSize]);
+
+  useEffect(() => {
+    if (zoomTarget === null) return;
+    const stillPresent = tiles.some((t) => {
+      if (t.identity !== zoomTarget.identity) return false;
+      if (zoomTarget.kind === 'screen') return t.hasScreenShare && t.screenShareTrack !== null;
+      return true;
+    });
+    if (!stillPresent) setZoomTarget(null);
+  }, [tiles, zoomTarget]);
 
   const onPointerDown = useCallback((e: React.PointerEvent) => {
     e.preventDefault();
@@ -220,85 +415,169 @@ export function FloatingVideoPanel({
     springY.set(snapped.y);
   }, [clampPosition, springX, springY]);
 
-  return (
-    <motion.div
-      className="fixed z-50 select-none"
-      style={{
-        right: animatedX,
-        bottom: animatedY,
-        width: panelWidth,
-      }}
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
-    >
-      <div className="overflow-hidden rounded-xl border border-border/50 bg-card/95 shadow-2xl shadow-black/20 backdrop-blur-xl">
-        <div
-          className="flex h-7 cursor-grab items-center justify-between border-b border-border/30 bg-muted/40 px-2 active:cursor-grabbing"
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
-        >
-          <div className="flex items-center gap-1">
-            <GripHorizontal className="size-2.5 text-muted-foreground/40" />
-            <Video className="size-2.5 text-muted-foreground/60" />
-            <span className="rounded-full bg-muted px-1.5 py-px font-mono text-[8px] tabular-nums text-muted-foreground/70">
-              {tiles.length}
-            </span>
-          </div>
-          <div className="flex items-center gap-0.5">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              className="size-4 text-muted-foreground/60 hover:text-foreground"
-              onClick={onDock}
-              aria-label="Dock to side panel"
-            >
-              <PanelRight className="size-2.5" />
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              className="size-4 text-muted-foreground/60 hover:text-foreground"
-              onClick={onToggleMinimize}
-            >
-              {isMinimized ? (
-                <Maximize2 className="size-2.5" />
-              ) : (
-                <Minimize2 className="size-2.5" />
-              )}
-            </Button>
-          </div>
-        </div>
+  const onResizePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      resizeRef.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        originWidth: size.width,
+        originHeight: size.height,
+      };
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    },
+    [size.width, size.height],
+  );
 
-        {!isMinimized ? (
-          <div className="relative p-1">
-            <AnimatePresence mode="popLayout">
-              {activeTile ? (
-                <motion.div
-                  key={`${activeTile.identity}-${activeTile.hasScreenShare ? 'screen' : 'cam'}`}
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.2 }}
-                >
-                  {activeTile.hasScreenShare && activeTile.screenShareTrack ? (
-                    <ScreenShareTile
-                      displayName={activeTile.displayName}
-                      screenShareTrack={activeTile.screenShareTrack}
-                    />
-                  ) : (
-                    <ParticipantTile {...activeTile} />
-                  )}
-                </motion.div>
-              ) : null}
-            </AnimatePresence>
+  const onResizePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!resizeRef.current) return;
+      const dx = e.clientX - resizeRef.current.startX;
+      const dy = e.clientY - resizeRef.current.startY;
+      setSize(clampSize(resizeRef.current.originWidth + dx, resizeRef.current.originHeight + dy));
+    },
+    [clampSize],
+  );
+
+  const onResizePointerUp = useCallback(() => {
+    resizeRef.current = null;
+  }, []);
+
+  const zoomedTile = zoomTarget ? tiles.find((t) => t.identity === zoomTarget.identity) : null;
+  const showResize = !isMinimized;
+
+  return (
+    <>
+      <motion.div
+        className="fixed z-50 select-none"
+        style={{
+          right: animatedX,
+          bottom: animatedY,
+          width: panelWidth,
+        }}
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
+      >
+        <div className="relative overflow-hidden rounded-xl border border-border/50 bg-card/95 shadow-2xl shadow-black/20 backdrop-blur-xl">
+          <div
+            className="flex h-7 cursor-grab items-center justify-between border-b border-border/30 bg-muted/40 px-2 active:cursor-grabbing"
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+          >
+            <div className="flex items-center gap-1">
+              <GripHorizontal className="size-2.5 text-muted-foreground/40" />
+              <Video className="size-2.5 text-muted-foreground/60" />
+              <span className="rounded-full bg-muted px-1.5 py-px font-mono text-[8px] tabular-nums text-muted-foreground/70">
+                {tiles.length}
+              </span>
+            </div>
+            <div className="flex items-center gap-0.5">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className="size-4 text-muted-foreground/60 hover:text-foreground"
+                onClick={onDock}
+                aria-label="Dock to side panel"
+              >
+                <PanelRight className="size-2.5" />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className="size-4 text-muted-foreground/60 hover:text-foreground"
+                onClick={onToggleMinimize}
+              >
+                {isMinimized ? (
+                  <Maximize2 className="size-2.5" />
+                ) : (
+                  <Minimize2 className="size-2.5" />
+                )}
+              </Button>
+            </div>
           </div>
+
+          {!isMinimized ? (
+            <div className="relative overflow-hidden p-1" style={{ height: size.height - 28 }}>
+              <AnimatePresence mode="popLayout">
+                {activeTile ? (
+                  <motion.div
+                    key={`${activeTile.identity}-${activeTile.hasScreenShare ? 'screen' : 'cam'}`}
+                    className="h-full"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.2 }}
+                  >
+                    {activeTile.hasScreenShare && activeTile.screenShareTrack ? (
+                      <ScreenShareTile
+                        displayName={activeTile.displayName}
+                        screenShareTrack={activeTile.screenShareTrack}
+                        fill
+                        onZoom={() =>
+                          setZoomTarget({ identity: activeTile.identity, kind: 'screen' })
+                        }
+                      />
+                    ) : (
+                      <div className="h-full">
+                        <ParticipantTile
+                          {...activeTile}
+                          fit="contain"
+                          onZoom={() =>
+                            setZoomTarget({ identity: activeTile.identity, kind: 'camera' })
+                          }
+                        />
+                      </div>
+                    )}
+                  </motion.div>
+                ) : null}
+              </AnimatePresence>
+            </div>
+          ) : null}
+
+          {showResize ? (
+            <div
+              role="slider"
+              aria-label="Resize video panel"
+              aria-valuemin={FLOATING_MIN_WIDTH}
+              aria-valuemax={window.innerWidth - VIEWPORT_PADDING}
+              aria-valuenow={size.width}
+              tabIndex={0}
+              className="absolute bottom-0 right-0 z-10 flex size-4 cursor-nwse-resize items-end justify-end text-muted-foreground/50 hover:text-muted-foreground"
+              onPointerDown={onResizePointerDown}
+              onPointerMove={onResizePointerMove}
+              onPointerUp={onResizePointerUp}
+              onPointerCancel={onResizePointerUp}
+            >
+              <svg viewBox="0 0 10 10" className="size-2.5 pointer-events-none" aria-hidden="true">
+                <title>Resize</title>
+                <path
+                  d="M1 9 L9 9 M4 9 L9 4 M7 9 L9 7"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                  strokeLinecap="round"
+                  fill="none"
+                />
+              </svg>
+            </div>
+          ) : null}
+        </div>
+      </motion.div>
+      <AnimatePresence>
+        {zoomedTile ? (
+          <ZoomOverlay
+            key={`${zoomedTile.identity}-${zoomTarget?.kind}`}
+            tile={zoomedTile}
+            kind={zoomTarget?.kind ?? 'camera'}
+            onClose={() => setZoomTarget(null)}
+          />
         ) : null}
-      </div>
-    </motion.div>
+      </AnimatePresence>
+    </>
   );
 }
 
@@ -308,14 +587,29 @@ interface DockedVideoPanelProps {
 }
 
 export function DockedVideoPanel({ tiles, onUndock }: DockedVideoPanelProps) {
+  const [zoomTarget, setZoomTarget] = useState<ZoomTarget | null>(null);
+
   const hasAnyVideo = tiles.some((t) => t.hasVideo);
   const hasAnyScreenShare = tiles.some((t) => t.hasScreenShare);
+
+  useEffect(() => {
+    if (zoomTarget === null) return;
+    const stillPresent = tiles.some((t) => {
+      if (t.identity !== zoomTarget.identity) return false;
+      if (zoomTarget.kind === 'screen') return t.hasScreenShare && t.screenShareTrack !== null;
+      return true;
+    });
+    if (!stillPresent) setZoomTarget(null);
+  }, [tiles, zoomTarget]);
+
   if (tiles.length === 0 || (tiles.length <= 1 && !hasAnyVideo && !hasAnyScreenShare)) return null;
 
   const screenSharers = tiles.filter(
     (t): t is VideoPanelParticipant & { screenShareTrack: MediaStreamTrack } =>
       t.hasScreenShare && t.screenShareTrack !== null,
   );
+
+  const zoomedTile = zoomTarget ? tiles.find((t) => t.identity === zoomTarget.identity) : null;
 
   return (
     <div className="shrink-0 border-b border-border p-2 @container">
@@ -343,14 +637,29 @@ export function DockedVideoPanel({ tiles, onUndock }: DockedVideoPanelProps) {
             key={`screen-${tile.identity}`}
             displayName={tile.displayName}
             screenShareTrack={tile.screenShareTrack}
+            onZoom={() => setZoomTarget({ identity: tile.identity, kind: 'screen' })}
           />
         ))}
         <div className="grid grid-cols-1 gap-1 @[280px]:grid-cols-2">
           {tiles.map((tile) => (
-            <ParticipantTile key={tile.identity} {...tile} />
+            <ParticipantTile
+              key={tile.identity}
+              {...tile}
+              onZoom={() => setZoomTarget({ identity: tile.identity, kind: 'camera' })}
+            />
           ))}
         </div>
       </div>
+      <AnimatePresence>
+        {zoomedTile ? (
+          <ZoomOverlay
+            key={`${zoomedTile.identity}-${zoomTarget?.kind}`}
+            tile={zoomedTile}
+            kind={zoomTarget?.kind ?? 'camera'}
+            onClose={() => setZoomTarget(null)}
+          />
+        ) : null}
+      </AnimatePresence>
     </div>
   );
 }

--- a/apps/web/src/components/video-panel.tsx
+++ b/apps/web/src/components/video-panel.tsx
@@ -7,7 +7,6 @@ import {
   PanelRight,
   PanelRightClose,
   Video,
-  X,
 } from 'lucide-react';
 import { AnimatePresence, motion, useMotionValue, useSpring } from 'motion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -44,21 +43,7 @@ function ParticipantTile({
   const { t } = useTranslation('rooms');
   const videoRef = useVideoTrack(videoTrack);
   const initial = displayName.charAt(0).toUpperCase();
-
-  const handleDoubleClick = onZoom
-    ? (e: React.MouseEvent) => {
-        e.preventDefault();
-        onZoom();
-      }
-    : undefined;
-
-  const interactiveProps = onZoom
-    ? {
-        role: 'button' as const,
-        tabIndex: -1,
-        onDoubleClick: handleDoubleClick,
-      }
-    : undefined;
+  const interactiveProps = useZoomInteractiveProps(onZoom);
 
   return (
     <div
@@ -136,21 +121,7 @@ function ScreenShareTile({
   fill = false,
 }: ScreenShareTileProps) {
   const videoRef = useVideoTrack(screenShareTrack);
-
-  const handleDoubleClick = onZoom
-    ? (e: React.MouseEvent) => {
-        e.preventDefault();
-        onZoom();
-      }
-    : undefined;
-
-  const interactiveProps = onZoom
-    ? {
-        role: 'button' as const,
-        tabIndex: -1,
-        onDoubleClick: handleDoubleClick,
-      }
-    : undefined;
+  const interactiveProps = useZoomInteractiveProps(onZoom);
 
   return (
     <div
@@ -197,6 +168,34 @@ function ScreenShareTile({
 
 type ZoomTarget = { identity: string; kind: 'camera' | 'screen' };
 
+function useClearZoomWhenMissing(
+  zoomTarget: ZoomTarget | null,
+  tiles: VideoPanelParticipant[],
+  setZoomTarget: (target: ZoomTarget | null) => void,
+) {
+  useEffect(() => {
+    if (zoomTarget === null) return;
+    const stillPresent = tiles.some((t) => {
+      if (t.identity !== zoomTarget.identity) return false;
+      if (zoomTarget.kind === 'screen') return t.hasScreenShare && t.screenShareTrack !== null;
+      return true;
+    });
+    if (!stillPresent) setZoomTarget(null);
+  }, [tiles, zoomTarget, setZoomTarget]);
+}
+
+function useZoomInteractiveProps(onZoom: (() => void) | undefined) {
+  if (!onZoom) return undefined;
+  return {
+    role: 'button' as const,
+    tabIndex: -1,
+    onDoubleClick: (e: React.MouseEvent) => {
+      e.preventDefault();
+      onZoom();
+    },
+  };
+}
+
 interface ZoomOverlayProps {
   tile: VideoPanelParticipant;
   kind: 'camera' | 'screen';
@@ -239,9 +238,7 @@ function ZoomOverlay({ tile, kind, onClose }: ZoomOverlayProps) {
             fill
           />
         ) : (
-          <div className="h-full w-full">
-            <ParticipantTile {...tile} fit="contain" />
-          </div>
+          <ParticipantTile {...tile} fit="contain" />
         )}
         <div className="absolute right-2 top-2 flex items-center gap-1">
           <Button
@@ -253,16 +250,6 @@ function ZoomOverlay({ tile, kind, onClose }: ZoomOverlayProps) {
             aria-label="Exit zoom"
           >
             <Minimize2 className="size-4" />
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            className="size-8 bg-black/50 text-white/90 backdrop-blur-sm hover:bg-black/70 hover:text-white"
-            onClick={onClose}
-            aria-label="Close zoom"
-          >
-            <X className="size-4" />
           </Button>
         </div>
       </div>
@@ -370,15 +357,7 @@ export function FloatingVideoPanel({
     return () => window.removeEventListener('resize', onResize);
   }, [springX, springY, clampSize]);
 
-  useEffect(() => {
-    if (zoomTarget === null) return;
-    const stillPresent = tiles.some((t) => {
-      if (t.identity !== zoomTarget.identity) return false;
-      if (zoomTarget.kind === 'screen') return t.hasScreenShare && t.screenShareTrack !== null;
-      return true;
-    });
-    if (!stillPresent) setZoomTarget(null);
-  }, [tiles, zoomTarget]);
+  useClearZoomWhenMissing(zoomTarget, tiles, setZoomTarget);
 
   const onPointerDown = useCallback((e: React.PointerEvent) => {
     e.preventDefault();
@@ -577,7 +556,7 @@ export function FloatingVideoPanel({
               onPointerUp={onResizePointerUp}
               onPointerCancel={onResizePointerUp}
             >
-              <svg viewBox="0 0 10 10" className="size-2.5 pointer-events-none" aria-hidden="true">
+              <svg viewBox="0 0 10 10" className="size-2.5 pointer-events-none">
                 <title>Resize</title>
                 <path
                   d="M1 9 L9 9 M4 9 L9 4 M7 9 L9 7"
@@ -616,15 +595,7 @@ export function DockedVideoPanel({ tiles, onUndock }: DockedVideoPanelProps) {
   const hasAnyVideo = tiles.some((t) => t.hasVideo);
   const hasAnyScreenShare = tiles.some((t) => t.hasScreenShare);
 
-  useEffect(() => {
-    if (zoomTarget === null) return;
-    const stillPresent = tiles.some((t) => {
-      if (t.identity !== zoomTarget.identity) return false;
-      if (zoomTarget.kind === 'screen') return t.hasScreenShare && t.screenShareTrack !== null;
-      return true;
-    });
-    if (!stillPresent) setZoomTarget(null);
-  }, [tiles, zoomTarget]);
+  useClearZoomWhenMissing(zoomTarget, tiles, setZoomTarget);
 
   if (tiles.length === 0 || (tiles.length <= 1 && !hasAnyVideo && !hasAnyScreenShare)) return null;
 

--- a/apps/web/src/components/video-panel.tsx
+++ b/apps/web/src/components/video-panel.tsx
@@ -337,6 +337,8 @@ const FLOATING_MIN_WIDTH = 200;
 const FLOATING_MIN_HEIGHT = 150;
 const VIEWPORT_PADDING = 32;
 
+type ResizeCorner = 'tl' | 'tr' | 'bl' | 'br';
+
 export function FloatingVideoPanel({
   tiles,
   isMinimized,
@@ -361,12 +363,20 @@ export function FloatingVideoPanel({
   const [zoomTarget, setZoomTarget] = useState<ZoomTarget | null>(null);
 
   const resizeRef = useRef<{
+    corner: ResizeCorner;
     startX: number;
     startY: number;
     originWidth: number;
     originHeight: number;
+    originPosX: number;
+    originPosY: number;
   } | null>(null);
-  const pendingSizeRef = useRef<{ width: number; height: number } | null>(null);
+  const pendingResizeRef = useRef<{
+    width: number;
+    height: number;
+    x: number;
+    y: number;
+  } | null>(null);
   const resizeRafRef = useRef<number | null>(null);
 
   const panelWidth = isMinimized ? 160 : size.width;
@@ -465,15 +475,18 @@ export function FloatingVideoPanel({
     springY.set(snapped.y);
   }, [clampPosition, springX, springY]);
 
-  const onResizePointerDown = useCallback(
-    (e: React.PointerEvent) => {
+  const startResize = useCallback(
+    (corner: ResizeCorner) => (e: React.PointerEvent) => {
       e.preventDefault();
       e.stopPropagation();
       resizeRef.current = {
+        corner,
         startX: e.clientX,
         startY: e.clientY,
         originWidth: size.width,
         originHeight: size.height,
+        originPosX: posRef.current.x,
+        originPosY: posRef.current.y,
       };
       (e.target as HTMLElement).setPointerCapture(e.pointerId);
     },
@@ -482,39 +495,94 @@ export function FloatingVideoPanel({
 
   const onResizePointerMove = useCallback(
     (e: React.PointerEvent) => {
-      if (!resizeRef.current) return;
-      const dx = e.clientX - resizeRef.current.startX;
-      const dy = e.clientY - resizeRef.current.startY;
-      pendingSizeRef.current = clampSize(
-        resizeRef.current.originWidth + dx,
-        resizeRef.current.originHeight + dy,
-      );
+      const r = resizeRef.current;
+      if (!r) return;
+      const dx = e.clientX - r.startX;
+      const dy = e.clientY - r.startY;
+
+      // Compute requested size and position from the dragged corner.
+      let rawWidth = r.originWidth;
+      let rawHeight = r.originHeight;
+      let rawX = r.originPosX;
+      let rawY = r.originPosY;
+
+      if (r.corner === 'br') {
+        rawWidth = r.originWidth + dx;
+        rawHeight = r.originHeight + dy;
+      } else if (r.corner === 'tr') {
+        rawWidth = r.originWidth + dx;
+        rawHeight = r.originHeight - dy;
+        rawY = r.originPosY + dy;
+      } else if (r.corner === 'bl') {
+        rawWidth = r.originWidth - dx;
+        rawHeight = r.originHeight + dy;
+        rawX = r.originPosX + dx;
+      } else {
+        rawWidth = r.originWidth - dx;
+        rawHeight = r.originHeight - dy;
+        rawX = r.originPosX + dx;
+        rawY = r.originPosY + dy;
+      }
+
+      const clampedSize = clampSize(rawWidth, rawHeight);
+
+      // For top/left corners, the position must reflect the actual width/height
+      // we ended up with after clamping, otherwise the pinned edge drifts.
+      let nextX = rawX;
+      let nextY = rawY;
+      if (r.corner === 'tr' || r.corner === 'tl') {
+        nextY = r.originPosY + (r.originHeight - clampedSize.height);
+      }
+      if (r.corner === 'bl' || r.corner === 'tl') {
+        nextX = r.originPosX + (r.originWidth - clampedSize.width);
+      }
+
+      const clampedPos = clampPosition(nextX, nextY);
+
+      pendingResizeRef.current = {
+        width: clampedSize.width,
+        height: clampedSize.height,
+        x: clampedPos.x,
+        y: clampedPos.y,
+      };
       if (resizeRafRef.current !== null) return;
       resizeRafRef.current = requestAnimationFrame(() => {
         resizeRafRef.current = null;
-        if (pendingSizeRef.current) setSize(pendingSizeRef.current);
+        const pending = pendingResizeRef.current;
+        if (!pending) return;
+        setSize({ width: pending.width, height: pending.height });
+        posRef.current = { x: pending.x, y: pending.y };
+        springX.set(pending.x);
+        springY.set(pending.y);
       });
     },
-    [clampSize],
+    [clampSize, clampPosition, springX, springY],
   );
 
-  const endResize = useCallback((e?: React.PointerEvent) => {
-    resizeRef.current = null;
-    if (resizeRafRef.current !== null) {
-      cancelAnimationFrame(resizeRafRef.current);
-      resizeRafRef.current = null;
-    }
-    if (pendingSizeRef.current) {
-      setSize(pendingSizeRef.current);
-      pendingSizeRef.current = null;
-    }
-    if (e) {
-      const target = e.target as HTMLElement;
-      if (target.hasPointerCapture?.(e.pointerId)) {
-        target.releasePointerCapture(e.pointerId);
+  const endResize = useCallback(
+    (e?: React.PointerEvent) => {
+      resizeRef.current = null;
+      if (resizeRafRef.current !== null) {
+        cancelAnimationFrame(resizeRafRef.current);
+        resizeRafRef.current = null;
       }
-    }
-  }, []);
+      const pending = pendingResizeRef.current;
+      if (pending) {
+        setSize({ width: pending.width, height: pending.height });
+        posRef.current = { x: pending.x, y: pending.y };
+        springX.set(pending.x);
+        springY.set(pending.y);
+        pendingResizeRef.current = null;
+      }
+      if (e) {
+        const target = e.target as HTMLElement;
+        if (target.hasPointerCapture?.(e.pointerId)) {
+          target.releasePointerCapture(e.pointerId);
+        }
+      }
+    },
+    [springX, springY],
+  );
 
   useEffect(() => {
     return () => {
@@ -618,28 +686,69 @@ export function FloatingVideoPanel({
           ) : null}
 
           {showResize ? (
-            <button
-              type="button"
-              tabIndex={-1}
-              aria-label="Resize panel"
-              className="absolute bottom-0 right-0 z-10 flex size-4 cursor-nwse-resize items-end justify-end bg-transparent p-0 text-muted-foreground/50 hover:text-muted-foreground"
-              onPointerDown={onResizePointerDown}
-              onPointerMove={onResizePointerMove}
-              onPointerUp={endResize}
-              onPointerCancel={endResize}
-              onLostPointerCapture={endResize}
-            >
-              <svg viewBox="0 0 10 10" className="size-2.5 pointer-events-none">
-                <title>Resize</title>
-                <path
-                  d="M1 9 L9 9 M4 9 L9 4 M7 9 L9 7"
-                  stroke="currentColor"
-                  strokeWidth="1.2"
-                  strokeLinecap="round"
-                  fill="none"
-                />
-              </svg>
-            </button>
+            <>
+              <button
+                type="button"
+                tabIndex={-1}
+                aria-label="Resize panel from top left"
+                className="group/resize absolute left-0 top-0 z-10 size-3 cursor-nwse-resize bg-transparent p-0"
+                onPointerDown={startResize('tl')}
+                onPointerMove={onResizePointerMove}
+                onPointerUp={endResize}
+                onPointerCancel={endResize}
+                onLostPointerCapture={endResize}
+              >
+                <span className="pointer-events-none absolute left-0.5 top-0.5 block size-1.5 rounded-sm bg-muted-foreground/0 transition-colors group-hover/resize:bg-muted-foreground/40" />
+              </button>
+              <button
+                type="button"
+                tabIndex={-1}
+                aria-label="Resize panel from top right"
+                className="group/resize absolute right-0 top-0 z-10 size-3 cursor-nesw-resize bg-transparent p-0"
+                onPointerDown={startResize('tr')}
+                onPointerMove={onResizePointerMove}
+                onPointerUp={endResize}
+                onPointerCancel={endResize}
+                onLostPointerCapture={endResize}
+              >
+                <span className="pointer-events-none absolute right-0.5 top-0.5 block size-1.5 rounded-sm bg-muted-foreground/0 transition-colors group-hover/resize:bg-muted-foreground/40" />
+              </button>
+              <button
+                type="button"
+                tabIndex={-1}
+                aria-label="Resize panel from bottom left"
+                className="group/resize absolute bottom-0 left-0 z-10 size-3 cursor-nesw-resize bg-transparent p-0"
+                onPointerDown={startResize('bl')}
+                onPointerMove={onResizePointerMove}
+                onPointerUp={endResize}
+                onPointerCancel={endResize}
+                onLostPointerCapture={endResize}
+              >
+                <span className="pointer-events-none absolute bottom-0.5 left-0.5 block size-1.5 rounded-sm bg-muted-foreground/0 transition-colors group-hover/resize:bg-muted-foreground/40" />
+              </button>
+              <button
+                type="button"
+                tabIndex={-1}
+                aria-label="Resize panel from bottom right"
+                className="group/resize absolute bottom-0 right-0 z-10 flex size-4 cursor-nwse-resize items-end justify-end bg-transparent p-0 text-muted-foreground/50 hover:text-muted-foreground"
+                onPointerDown={startResize('br')}
+                onPointerMove={onResizePointerMove}
+                onPointerUp={endResize}
+                onPointerCancel={endResize}
+                onLostPointerCapture={endResize}
+              >
+                <svg viewBox="0 0 10 10" className="size-2.5 pointer-events-none">
+                  <title>Resize</title>
+                  <path
+                    d="M1 9 L9 9 M4 9 L9 4 M7 9 L9 7"
+                    stroke="currentColor"
+                    strokeWidth="1.2"
+                    strokeLinecap="round"
+                    fill="none"
+                  />
+                </svg>
+              </button>
+            </>
           ) : null}
         </div>
       </motion.div>

--- a/apps/web/src/components/video-panel.tsx
+++ b/apps/web/src/components/video-panel.tsx
@@ -324,6 +324,8 @@ export function FloatingVideoPanel({
     originWidth: number;
     originHeight: number;
   } | null>(null);
+  const pendingSizeRef = useRef<{ width: number; height: number } | null>(null);
+  const resizeRafRef = useRef<number | null>(null);
 
   const panelWidth = isMinimized ? 160 : size.width;
   const activeTile = pickActiveTile(tiles);
@@ -435,13 +437,35 @@ export function FloatingVideoPanel({
       if (!resizeRef.current) return;
       const dx = e.clientX - resizeRef.current.startX;
       const dy = e.clientY - resizeRef.current.startY;
-      setSize(clampSize(resizeRef.current.originWidth + dx, resizeRef.current.originHeight + dy));
+      pendingSizeRef.current = clampSize(
+        resizeRef.current.originWidth + dx,
+        resizeRef.current.originHeight + dy,
+      );
+      if (resizeRafRef.current !== null) return;
+      resizeRafRef.current = requestAnimationFrame(() => {
+        resizeRafRef.current = null;
+        if (pendingSizeRef.current) setSize(pendingSizeRef.current);
+      });
     },
     [clampSize],
   );
 
   const onResizePointerUp = useCallback(() => {
     resizeRef.current = null;
+    if (resizeRafRef.current !== null) {
+      cancelAnimationFrame(resizeRafRef.current);
+      resizeRafRef.current = null;
+    }
+    if (pendingSizeRef.current) {
+      setSize(pendingSizeRef.current);
+      pendingSizeRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (resizeRafRef.current !== null) cancelAnimationFrame(resizeRafRef.current);
+    };
   }, []);
 
   const zoomedTile = zoomTarget ? tiles.find((t) => t.identity === zoomTarget.identity) : null;

--- a/apps/web/src/components/video-panel.tsx
+++ b/apps/web/src/components/video-panel.tsx
@@ -429,7 +429,7 @@ export function FloatingVideoPanel({
     [clampSize],
   );
 
-  const onResizePointerUp = useCallback(() => {
+  const endResize = useCallback((e?: React.PointerEvent) => {
     resizeRef.current = null;
     if (resizeRafRef.current !== null) {
       cancelAnimationFrame(resizeRafRef.current);
@@ -438,6 +438,12 @@ export function FloatingVideoPanel({
     if (pendingSizeRef.current) {
       setSize(pendingSizeRef.current);
       pendingSizeRef.current = null;
+    }
+    if (e) {
+      const target = e.target as HTMLElement;
+      if (target.hasPointerCapture?.(e.pointerId)) {
+        target.releasePointerCapture(e.pointerId);
+      }
     }
   }, []);
 
@@ -553,8 +559,9 @@ export function FloatingVideoPanel({
               className="absolute bottom-0 right-0 z-10 flex size-4 cursor-nwse-resize items-end justify-end text-muted-foreground/50 hover:text-muted-foreground"
               onPointerDown={onResizePointerDown}
               onPointerMove={onResizePointerMove}
-              onPointerUp={onResizePointerUp}
-              onPointerCancel={onResizePointerUp}
+              onPointerUp={endResize}
+              onPointerCancel={endResize}
+              onLostPointerCapture={endResize}
             >
               <svg viewBox="0 0 10 10" className="size-2.5 pointer-events-none">
                 <title>Resize</title>

--- a/apps/web/src/components/video-panel.tsx
+++ b/apps/web/src/components/video-panel.tsx
@@ -596,14 +596,11 @@ export function FloatingVideoPanel({
           ) : null}
 
           {showResize ? (
-            <div
-              role="slider"
-              aria-label="Resize video panel"
-              aria-valuemin={FLOATING_MIN_WIDTH}
-              aria-valuemax={window.innerWidth - VIEWPORT_PADDING}
-              aria-valuenow={size.width}
-              tabIndex={0}
-              className="absolute bottom-0 right-0 z-10 flex size-4 cursor-nwse-resize items-end justify-end text-muted-foreground/50 hover:text-muted-foreground"
+            <button
+              type="button"
+              tabIndex={-1}
+              aria-label="Resize panel"
+              className="absolute bottom-0 right-0 z-10 flex size-4 cursor-nwse-resize items-end justify-end bg-transparent p-0 text-muted-foreground/50 hover:text-muted-foreground"
               onPointerDown={onResizePointerDown}
               onPointerMove={onResizePointerMove}
               onPointerUp={endResize}
@@ -620,7 +617,7 @@ export function FloatingVideoPanel({
                   fill="none"
                 />
               </svg>
-            </div>
+            </button>
           ) : null}
         </div>
       </motion.div>

--- a/apps/web/src/components/video-panel.tsx
+++ b/apps/web/src/components/video-panel.tsx
@@ -283,7 +283,7 @@ function ZoomOverlay({ tile, kind, onClose }: ZoomOverlayProps) {
         className="absolute inset-0 cursor-default bg-transparent"
         onClick={onClose}
       />
-      <div className="relative flex h-[min(88vh,calc(88vw*9/16))] w-[min(92vw,calc(88vh*16/9))] items-center justify-center">
+      <div className="relative flex h-[96vh] w-[96vw] items-center justify-center">
         {isScreen && tile.screenShareTrack ? (
           <ScreenShareTile
             displayName={tile.displayName}

--- a/apps/web/src/components/video-panel.tsx
+++ b/apps/web/src/components/video-panel.tsx
@@ -203,19 +203,63 @@ interface ZoomOverlayProps {
 }
 
 function ZoomOverlay({ tile, kind, onClose }: ZoomOverlayProps) {
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
   useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+    previouslyFocusedRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    closeButtonRef.current?.focus();
+    const previous = previouslyFocusedRef.current;
+    return () => {
+      if (previous && document.contains(previous)) previous.focus();
     };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose]);
+  }, []);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const root = overlayRef.current;
+      if (!root) return;
+      const focusable = root.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) {
+        e.preventDefault();
+        root.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (first === undefined || last === undefined) return;
+      const active = document.activeElement;
+      if (e.shiftKey) {
+        if (active === first || !root.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    },
+    [onClose],
+  );
 
   const isScreen = kind === 'screen' && tile.hasScreenShare && tile.screenShareTrack;
 
   return (
     <motion.div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      ref={overlayRef}
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/80 backdrop-blur-sm outline-none"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
@@ -223,6 +267,8 @@ function ZoomOverlay({ tile, kind, onClose }: ZoomOverlayProps) {
       role="dialog"
       aria-modal="true"
       aria-label="Zoomed video"
+      tabIndex={-1}
+      onKeyDown={onKeyDown}
     >
       <button
         type="button"
@@ -242,6 +288,7 @@ function ZoomOverlay({ tile, kind, onClose }: ZoomOverlayProps) {
         )}
         <div className="absolute right-2 top-2 flex items-center gap-1">
           <Button
+            ref={closeButtonRef}
             type="button"
             variant="ghost"
             size="icon-sm"

--- a/apps/web/src/components/video-panel.tsx
+++ b/apps/web/src/components/video-panel.tsx
@@ -348,6 +348,7 @@ export function FloatingVideoPanel({
   const springY = useMotionValue(16);
   const animatedX = useSpring(springX, SPRING_CONFIG);
   const animatedY = useSpring(springY, SPRING_CONFIG);
+  const didInitPosRef = useRef(false);
 
   const dragRef = useRef<{
     startX: number;
@@ -369,6 +370,7 @@ export function FloatingVideoPanel({
   const resizeRafRef = useRef<number | null>(null);
 
   const panelWidth = isMinimized ? 160 : size.width;
+  const panelHeight = isMinimized ? 28 : size.height;
   const activeTile = pickActiveTile(tiles);
 
   const clampPositionRef = useRef<((x: number, y: number) => { x: number; y: number }) | null>(
@@ -377,14 +379,14 @@ export function FloatingVideoPanel({
 
   const clampPosition = useCallback(
     (x: number, y: number) => {
-      const maxRight = window.innerWidth - panelWidth - EDGE_PADDING;
-      const maxBottom = window.innerHeight - 48 - EDGE_PADDING;
+      const maxX = Math.max(EDGE_PADDING, window.innerWidth - panelWidth - EDGE_PADDING);
+      const maxY = Math.max(EDGE_PADDING, window.innerHeight - panelHeight - EDGE_PADDING);
       return {
-        x: Math.max(EDGE_PADDING, Math.min(maxRight, x)),
-        y: Math.max(EDGE_PADDING, Math.min(maxBottom, y)),
+        x: Math.max(EDGE_PADDING, Math.min(maxX, x)),
+        y: Math.max(EDGE_PADDING, Math.min(maxY, y)),
       };
     },
-    [panelWidth],
+    [panelWidth, panelHeight],
   );
   clampPositionRef.current = clampPosition;
 
@@ -396,6 +398,19 @@ export function FloatingVideoPanel({
       height: Math.max(FLOATING_MIN_HEIGHT, Math.min(maxH, height)),
     };
   }, []);
+
+  useEffect(() => {
+    if (didInitPosRef.current) return;
+    didInitPosRef.current = true;
+    const initialX = Math.max(EDGE_PADDING, window.innerWidth - FLOATING_WIDTH - EDGE_PADDING);
+    const initialY = Math.max(
+      EDGE_PADDING,
+      window.innerHeight - FLOATING_DEFAULT_HEIGHT - EDGE_PADDING,
+    );
+    posRef.current = { x: initialX, y: initialY };
+    springX.jump(initialX);
+    springY.jump(initialY);
+  }, [springX, springY]);
 
   useEffect(() => {
     const onResize = () => {
@@ -430,8 +445,8 @@ export function FloatingVideoPanel({
       const dx = e.clientX - dragRef.current.startX;
       const dy = e.clientY - dragRef.current.startY;
       const raw = {
-        x: dragRef.current.originX - dx,
-        y: dragRef.current.originY - dy,
+        x: dragRef.current.originX + dx,
+        y: dragRef.current.originY + dy,
       };
       const clamped = clampPosition(raw.x, raw.y);
       posRef.current = clamped;
@@ -515,8 +530,8 @@ export function FloatingVideoPanel({
       <motion.div
         className="fixed z-50 select-none"
         style={{
-          right: animatedX,
-          bottom: animatedY,
+          left: animatedX,
+          top: animatedY,
           width: panelWidth,
         }}
         initial={{ opacity: 0, y: 12 }}

--- a/apps/web/src/components/video-panel.tsx
+++ b/apps/web/src/components/video-panel.tsx
@@ -166,21 +166,28 @@ function ScreenShareTile({
   );
 }
 
-type ZoomTarget = { identity: string; kind: 'camera' | 'screen' };
+export type ZoomTarget = { identity: string; kind: 'camera' | 'screen' };
 
-function useClearZoomWhenMissing(
+export function shouldClearZoomTarget(
+  zoomTarget: ZoomTarget | null,
+  tiles: VideoPanelParticipant[],
+): boolean {
+  if (zoomTarget === null) return false;
+  const stillPresent = tiles.some((t) => {
+    if (t.identity !== zoomTarget.identity) return false;
+    if (zoomTarget.kind === 'screen') return t.hasScreenShare && t.screenShareTrack !== null;
+    return true;
+  });
+  return !stillPresent;
+}
+
+export function useClearZoomWhenMissing(
   zoomTarget: ZoomTarget | null,
   tiles: VideoPanelParticipant[],
   setZoomTarget: (target: ZoomTarget | null) => void,
 ) {
   useEffect(() => {
-    if (zoomTarget === null) return;
-    const stillPresent = tiles.some((t) => {
-      if (t.identity !== zoomTarget.identity) return false;
-      if (zoomTarget.kind === 'screen') return t.hasScreenShare && t.screenShareTrack !== null;
-      return true;
-    });
-    if (!stillPresent) setZoomTarget(null);
+    if (shouldClearZoomTarget(zoomTarget, tiles)) setZoomTarget(null);
   }, [tiles, zoomTarget, setZoomTarget]);
 }
 


### PR DESCRIPTION
Floating panel anchored top-left and resizable from any of four corners. Click-to-zoom opens a 96vh by 96vw overlay with a focus trap and Esc dismiss. Pointer cancel and lost-capture both end resize cleanly.