### PR TITLE
Feat/admin users api

### DIFF
--- a/apps/control-plane/src/app.module.ts
+++ b/apps/control-plane/src/app.module.ts
@@ -8,6 +8,7 @@ import { AppController } from './app.controller.js';
 import { GlobalExceptionFilter } from './common/filters/global-exception.filter.js';
 import { type EnvConfig, validateEnv } from './config/env.config.js';
 import { InfrastructureModule } from './infrastructure/infrastructure.module.js';
+import { AdminModule } from './modules/admin/admin.module.js';
 import { AuthModule } from './modules/auth/auth.module.js';
 import { DbModule } from './modules/db/db.module.js';
 import { ExecutionModule } from './modules/execution/execution.module.js';
@@ -124,6 +125,7 @@ if (!isProd) {
     SessionsModule,
     ProblemsModule,
     FeedbackModule,
+    AdminModule,
     ExecutionModule,
     InternalModule,
   ],

--- a/apps/control-plane/src/modules/admin/admin.controller.integration.spec.ts
+++ b/apps/control-plane/src/modules/admin/admin.controller.integration.spec.ts
@@ -118,6 +118,38 @@ describe('GET /admin/users', () => {
       message: 'Admin access required',
     });
   });
+
+  it('GIVEN malformed cursor WHEN listing users THEN rejects the request', async () => {
+    const admin = await insertUser(db, { role: 'admin' });
+
+    const res = await asUser(
+      request(app.getHttpServer()).get('/admin/users?cursor=not-a-valid-cursor'),
+      admin,
+    ).expect(400);
+
+    expect(res.body).toMatchObject({
+      code: 'VALIDATION_FAILED',
+      message: 'Invalid cursor',
+    });
+  });
+
+  it('GIVEN cursor with invalid fields WHEN listing users THEN rejects the request', async () => {
+    const admin = await insertUser(db, { role: 'admin' });
+    const cursor = Buffer.from(
+      JSON.stringify({ createdAt: 'not-a-date', id: 'not-a-uuid' }),
+      'utf8',
+    ).toString('base64url');
+
+    const res = await asUser(
+      request(app.getHttpServer()).get(`/admin/users?cursor=${cursor}`),
+      admin,
+    ).expect(400);
+
+    expect(res.body).toMatchObject({
+      code: 'VALIDATION_FAILED',
+      message: 'Invalid cursor',
+    });
+  });
 });
 
 describe('PATCH /admin/users/:id/ban', () => {
@@ -174,6 +206,17 @@ describe('PATCH /admin/users/:id/ban', () => {
       message: 'Admins cannot ban their own account',
     });
   });
+
+  it('GIVEN malformed user id WHEN banning an account THEN rejects the request', async () => {
+    const admin = await insertUser(db, { role: 'admin' });
+
+    const res = await asUser(
+      request(app.getHttpServer()).patch('/admin/users/not-a-uuid/ban').send({}),
+      admin,
+    ).expect(400);
+
+    expect(res.body.message).toContain('uuid');
+  });
 });
 
 describe('PATCH /admin/users/:id/unban', () => {
@@ -194,5 +237,25 @@ describe('PATCH /admin/users/:id/unban', () => {
       bannedAt: null,
       bannedReason: null,
     });
+
+    const row = await db.query.users.findFirst({
+      columns: { bannedAt: true, bannedReason: true },
+      where: eq(users.id, target.id),
+    });
+    expect(row).toMatchObject({
+      bannedAt: null,
+      bannedReason: null,
+    });
+  });
+
+  it('GIVEN malformed user id WHEN unbanning an account THEN rejects the request', async () => {
+    const admin = await insertUser(db, { role: 'admin' });
+
+    const res = await asUser(
+      request(app.getHttpServer()).patch('/admin/users/not-a-uuid/unban'),
+      admin,
+    ).expect(400);
+
+    expect(res.body.message).toContain('uuid');
   });
 });

--- a/apps/control-plane/src/modules/admin/admin.controller.integration.spec.ts
+++ b/apps/control-plane/src/modules/admin/admin.controller.integration.spec.ts
@@ -111,7 +111,12 @@ describe('GET /admin/users', () => {
   it('GIVEN non-admin user WHEN listing users THEN rejects the request', async () => {
     const user = await insertUser(db);
 
-    await asUser(request(app.getHttpServer()).get('/admin/users'), user).expect(403);
+    const res = await asUser(request(app.getHttpServer()).get('/admin/users'), user).expect(403);
+
+    expect(res.body).toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Admin access required',
+    });
   });
 });
 
@@ -145,10 +150,15 @@ describe('PATCH /admin/users/:id/ban', () => {
     const actor = await insertUser(db);
     const target = await insertUser(db);
 
-    await asUser(
+    const res = await asUser(
       request(app.getHttpServer()).patch(`/admin/users/${target.id}/ban`).send({}),
       actor,
     ).expect(403);
+
+    expect(res.body).toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Admin access required',
+    });
   });
 
   it('GIVEN admin user WHEN banning their own account THEN rejects the request', async () => {

--- a/apps/control-plane/src/modules/admin/admin.controller.integration.spec.ts
+++ b/apps/control-plane/src/modules/admin/admin.controller.integration.spec.ts
@@ -1,0 +1,174 @@
+import type { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { type Database, users } from '@syncode/db';
+import { eq } from 'drizzle-orm';
+import { ZodValidationPipe } from 'nestjs-zod';
+import request from 'supertest';
+import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard.js';
+import { DB_CLIENT } from '@/modules/db/db.module.js';
+import { createTestDb, insertUser } from '@/test/integration-setup.js';
+import { asUser, TestAuthGuard } from '@/test/mock-factories.js';
+import { AdminController } from './admin.controller.js';
+import { AdminService } from './admin.service.js';
+
+let app: INestApplication;
+let db: Database;
+let cleanup: () => Promise<void>;
+
+beforeEach(async () => {
+  const testDb = await createTestDb();
+  db = testDb.db;
+  cleanup = testDb.cleanup;
+
+  const module = await Test.createTestingModule({
+    controllers: [AdminController],
+    providers: [AdminService, { provide: DB_CLIENT, useValue: db }],
+  })
+    .overrideGuard(JwtAuthGuard)
+    .useClass(TestAuthGuard)
+    .compile();
+
+  app = module.createNestApplication();
+  app.useGlobalPipes(new ZodValidationPipe());
+  await app.init();
+});
+
+afterEach(async () => {
+  await app.close();
+  await cleanup();
+});
+
+describe('GET /admin/users', () => {
+  it('GIVEN admin user WHEN listing users THEN returns a paginated user list', async () => {
+    const admin = await insertUser(db, {
+      role: 'admin',
+      createdAt: new Date('2025-12-31T00:00:00.000Z'),
+    });
+    const first = await insertUser(db, {
+      email: 'first@example.com',
+      username: 'first',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const second = await insertUser(db, {
+      email: 'second@example.com',
+      username: 'second',
+      createdAt: new Date('2026-01-02T00:00:00.000Z'),
+    });
+
+    const firstPage = await asUser(
+      request(app.getHttpServer()).get('/admin/users?limit=2'),
+      admin,
+    ).expect(200);
+
+    expect(firstPage.body.data).toHaveLength(2);
+    expect(firstPage.body.data.map((user: { id: string }) => user.id)).toEqual([
+      second.id,
+      first.id,
+    ]);
+    expect(firstPage.body.pagination).toMatchObject({ hasMore: true });
+    expect(firstPage.body.pagination.nextCursor).toEqual(expect.any(String));
+
+    const secondPage = await asUser(
+      request(app.getHttpServer()).get(
+        `/admin/users?limit=2&cursor=${firstPage.body.pagination.nextCursor}`,
+      ),
+      admin,
+    ).expect(200);
+
+    expect(secondPage.body.data.map((user: { id: string }) => user.id)).toEqual([admin.id]);
+    expect(secondPage.body.pagination).toEqual({ hasMore: false, nextCursor: null });
+  });
+
+  it('GIVEN search and banned status filters WHEN listing users THEN only matching users return', async () => {
+    const admin = await insertUser(db, { role: 'admin' });
+    const banned = await insertUser(db, {
+      email: 'target@example.com',
+      username: 'target-user',
+      displayName: 'Target User',
+      bannedAt: new Date(),
+      bannedReason: 'policy',
+    });
+    await insertUser(db, {
+      email: 'target-active@example.com',
+      username: 'target-active',
+      displayName: 'Target Active',
+    });
+
+    const res = await asUser(
+      request(app.getHttpServer()).get('/admin/users?search=target&status=banned'),
+      admin,
+    ).expect(200);
+
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0]).toMatchObject({
+      id: banned.id,
+      email: 'target@example.com',
+      bannedReason: 'policy',
+    });
+    expect(res.body.data[0].bannedAt).toEqual(expect.any(String));
+  });
+
+  it('GIVEN non-admin user WHEN listing users THEN rejects the request', async () => {
+    const user = await insertUser(db);
+
+    await asUser(request(app.getHttpServer()).get('/admin/users'), user).expect(403);
+  });
+});
+
+describe('PATCH /admin/users/:id/ban', () => {
+  it('GIVEN admin user WHEN banning an account THEN persists banned fields', async () => {
+    const admin = await insertUser(db, { role: 'admin' });
+    const target = await insertUser(db);
+
+    const res = await asUser(
+      request(app.getHttpServer()).patch(`/admin/users/${target.id}/ban`).send({
+        reason: 'Repeated abuse',
+      }),
+      admin,
+    ).expect(200);
+
+    expect(res.body).toMatchObject({
+      id: target.id,
+      bannedAt: expect.any(String),
+      bannedReason: 'Repeated abuse',
+    });
+
+    const row = await db.query.users.findFirst({
+      columns: { bannedAt: true, bannedReason: true },
+      where: eq(users.id, target.id),
+    });
+    expect(row?.bannedAt).toBeInstanceOf(Date);
+    expect(row?.bannedReason).toBe('Repeated abuse');
+  });
+
+  it('GIVEN non-admin user WHEN banning an account THEN rejects the request', async () => {
+    const actor = await insertUser(db);
+    const target = await insertUser(db);
+
+    await asUser(
+      request(app.getHttpServer()).patch(`/admin/users/${target.id}/ban`).send({}),
+      actor,
+    ).expect(403);
+  });
+});
+
+describe('PATCH /admin/users/:id/unban', () => {
+  it('GIVEN admin user WHEN unbanning an account THEN clears banned fields', async () => {
+    const admin = await insertUser(db, { role: 'admin' });
+    const target = await insertUser(db, {
+      bannedAt: new Date(),
+      bannedReason: 'policy',
+    });
+
+    const res = await asUser(
+      request(app.getHttpServer()).patch(`/admin/users/${target.id}/unban`),
+      admin,
+    ).expect(200);
+
+    expect(res.body).toMatchObject({
+      id: target.id,
+      bannedAt: null,
+      bannedReason: null,
+    });
+  });
+});

--- a/apps/control-plane/src/modules/admin/admin.controller.integration.spec.ts
+++ b/apps/control-plane/src/modules/admin/admin.controller.integration.spec.ts
@@ -150,6 +150,20 @@ describe('PATCH /admin/users/:id/ban', () => {
       actor,
     ).expect(403);
   });
+
+  it('GIVEN admin user WHEN banning their own account THEN rejects the request', async () => {
+    const admin = await insertUser(db, { role: 'admin' });
+
+    const res = await asUser(
+      request(app.getHttpServer()).patch(`/admin/users/${admin.id}/ban`).send({}),
+      admin,
+    ).expect(400);
+
+    expect(res.body).toMatchObject({
+      code: 'VALIDATION_FAILED',
+      message: 'Admins cannot ban their own account',
+    });
+  });
 });
 
 describe('PATCH /admin/users/:id/unban', () => {

--- a/apps/control-plane/src/modules/admin/admin.controller.spec.ts
+++ b/apps/control-plane/src/modules/admin/admin.controller.spec.ts
@@ -1,0 +1,62 @@
+import { AdminController } from './admin.controller.js';
+import type { AdminService } from './admin.service.js';
+
+const ADMIN = { id: '11111111-1111-4111-8111-111111111111' };
+const TARGET_ID = '22222222-2222-4222-8222-222222222222';
+
+const ADMIN_USER = {
+  id: TARGET_ID,
+  email: 'target@example.com',
+  username: 'target',
+  displayName: 'Target User',
+  role: 'user' as const,
+  avatarUrl: null,
+  bannedAt: null,
+  bannedReason: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('AdminController', () => {
+  const service = {
+    listUsers: vi.fn(),
+    banUser: vi.fn(),
+    unbanUser: vi.fn(),
+  } as unknown as AdminService;
+
+  let controller: AdminController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new AdminController(service);
+  });
+
+  it('GIVEN admin query WHEN listing users THEN returns service result', async () => {
+    const response = {
+      data: [ADMIN_USER],
+      pagination: { hasMore: false, nextCursor: null },
+    };
+    vi.mocked(service.listUsers).mockResolvedValue(response);
+
+    await expect(controller.listUsers(ADMIN, { limit: 20 })).resolves.toEqual(response);
+  });
+
+  it('GIVEN ban payload WHEN banning user THEN returns updated user', async () => {
+    const banned = {
+      ...ADMIN_USER,
+      bannedAt: '2026-01-02T00:00:00.000Z',
+      bannedReason: 'policy',
+    };
+    vi.mocked(service.banUser).mockResolvedValue(banned);
+
+    await expect(controller.banUser(ADMIN, TARGET_ID, { reason: 'policy' })).resolves.toEqual(
+      banned,
+    );
+  });
+
+  it('GIVEN unban request WHEN unbanning user THEN returns updated user', async () => {
+    vi.mocked(service.unbanUser).mockResolvedValue(ADMIN_USER);
+
+    await expect(controller.unbanUser(ADMIN, TARGET_ID)).resolves.toEqual(ADMIN_USER);
+  });
+});

--- a/apps/control-plane/src/modules/admin/admin.controller.ts
+++ b/apps/control-plane/src/modules/admin/admin.controller.ts
@@ -1,0 +1,71 @@
+import { Body, Controller, Get, Param, Patch, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { CONTROL_API } from '@syncode/contracts';
+import { CurrentUser } from '@/common/decorators/current-user.decorator.js';
+import { ErrorResponseDto } from '@/common/dto/error-response.dto.js';
+import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard.js';
+import { AdminService } from './admin.service.js';
+import {
+  AdminBanUserDto,
+  AdminUserDto,
+  AdminUsersQueryDto,
+  AdminUsersResponseDto,
+} from './dto/admin.dto.js';
+
+@ApiTags('admin')
+@Controller()
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @Get(CONTROL_API.ADMIN.USERS.LIST.route)
+  @ApiOperation({ summary: 'List users for admin management' })
+  @ApiResponse({ status: 200, type: AdminUsersResponseDto, description: 'Paginated users' })
+  @ApiResponse({ status: 401, type: ErrorResponseDto, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, type: ErrorResponseDto, description: 'Admin access required' })
+  async listUsers(
+    @CurrentUser() user: { id: string },
+    @Query() query: AdminUsersQueryDto,
+  ): Promise<AdminUsersResponseDto> {
+    return this.adminService.listUsers(user.id, query);
+  }
+
+  @Patch(CONTROL_API.ADMIN.USERS.BAN.route)
+  @ApiOperation({ summary: 'Ban a user account' })
+  @ApiParam({ name: 'id', description: 'User ID to ban' })
+  @ApiBody({ type: AdminBanUserDto })
+  @ApiResponse({ status: 200, type: AdminUserDto, description: 'Banned user' })
+  @ApiResponse({ status: 400, type: ErrorResponseDto, description: 'Validation error' })
+  @ApiResponse({ status: 401, type: ErrorResponseDto, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, type: ErrorResponseDto, description: 'Admin access required' })
+  @ApiResponse({ status: 404, type: ErrorResponseDto, description: 'User not found' })
+  async banUser(
+    @CurrentUser() user: { id: string },
+    @Param('id') id: string,
+    @Body() body: AdminBanUserDto,
+  ): Promise<AdminUserDto> {
+    return this.adminService.banUser(user.id, id, body);
+  }
+
+  @Patch(CONTROL_API.ADMIN.USERS.UNBAN.route)
+  @ApiOperation({ summary: 'Unban a user account' })
+  @ApiParam({ name: 'id', description: 'User ID to unban' })
+  @ApiResponse({ status: 200, type: AdminUserDto, description: 'Unbanned user' })
+  @ApiResponse({ status: 401, type: ErrorResponseDto, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, type: ErrorResponseDto, description: 'Admin access required' })
+  @ApiResponse({ status: 404, type: ErrorResponseDto, description: 'User not found' })
+  async unbanUser(
+    @CurrentUser() user: { id: string },
+    @Param('id') id: string,
+  ): Promise<AdminUserDto> {
+    return this.adminService.unbanUser(user.id, id);
+  }
+}

--- a/apps/control-plane/src/modules/admin/admin.controller.ts
+++ b/apps/control-plane/src/modules/admin/admin.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Param, Patch, Query, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiBody,
@@ -49,7 +58,7 @@ export class AdminController {
   @ApiResponse({ status: 404, type: ErrorResponseDto, description: 'User not found' })
   async banUser(
     @CurrentUser() user: { id: string },
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: AdminBanUserDto,
   ): Promise<AdminUserDto> {
     return this.adminService.banUser(user.id, id, body);
@@ -59,12 +68,13 @@ export class AdminController {
   @ApiOperation({ summary: 'Unban a user account' })
   @ApiParam({ name: 'id', description: 'User ID to unban' })
   @ApiResponse({ status: 200, type: AdminUserDto, description: 'Unbanned user' })
+  @ApiResponse({ status: 400, type: ErrorResponseDto, description: 'Validation error' })
   @ApiResponse({ status: 401, type: ErrorResponseDto, description: 'Unauthorized' })
   @ApiResponse({ status: 403, type: ErrorResponseDto, description: 'Admin access required' })
   @ApiResponse({ status: 404, type: ErrorResponseDto, description: 'User not found' })
   async unbanUser(
     @CurrentUser() user: { id: string },
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
   ): Promise<AdminUserDto> {
     return this.adminService.unbanUser(user.id, id);
   }

--- a/apps/control-plane/src/modules/admin/admin.module.ts
+++ b/apps/control-plane/src/modules/admin/admin.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AdminController } from './admin.controller.js';
+import { AdminService } from './admin.service.js';
+
+@Module({
+  controllers: [AdminController],
+  providers: [AdminService],
+})
+export class AdminModule {}

--- a/apps/control-plane/src/modules/admin/admin.service.ts
+++ b/apps/control-plane/src/modules/admin/admin.service.ts
@@ -1,4 +1,10 @@
-import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import {
   type AdminBanUserInput,
   type AdminUser,
@@ -70,6 +76,13 @@ export class AdminService {
     input: AdminBanUserInput,
   ): Promise<AdminUser> {
     await this.assertAdmin(actorId);
+
+    if (actorId === targetUserId) {
+      throw new BadRequestException({
+        message: 'Admins cannot ban their own account',
+        code: ERROR_CODES.VALIDATION_FAILED,
+      });
+    }
 
     const now = new Date();
     const [user] = await this.db

--- a/apps/control-plane/src/modules/admin/admin.service.ts
+++ b/apps/control-plane/src/modules/admin/admin.service.ts
@@ -22,6 +22,19 @@ interface UsersCursor {
   id: string;
 }
 
+const adminUserSelection = {
+  id: users.id,
+  email: users.email,
+  username: users.username,
+  displayName: users.displayName,
+  role: users.role,
+  avatarUrl: users.avatarUrl,
+  bannedAt: users.bannedAt,
+  bannedReason: users.bannedReason,
+  createdAt: users.createdAt,
+  updatedAt: users.updatedAt,
+};
+
 @Injectable()
 export class AdminService {
   constructor(@Inject(DB_CLIENT) private readonly db: Database) {}
@@ -38,18 +51,7 @@ export class AdminService {
     ].filter((item): item is SQL => Boolean(item));
 
     const rows = await this.db
-      .select({
-        id: users.id,
-        email: users.email,
-        username: users.username,
-        displayName: users.displayName,
-        role: users.role,
-        avatarUrl: users.avatarUrl,
-        bannedAt: users.bannedAt,
-        bannedReason: users.bannedReason,
-        createdAt: users.createdAt,
-        updatedAt: users.updatedAt,
-      })
+      .select(adminUserSelection)
       .from(users)
       .where(and(...filters))
       .orderBy(desc(users.createdAt), desc(users.id))
@@ -93,18 +95,7 @@ export class AdminService {
         updatedAt: now,
       })
       .where(and(eq(users.id, targetUserId), isNull(users.deletedAt)))
-      .returning({
-        id: users.id,
-        email: users.email,
-        username: users.username,
-        displayName: users.displayName,
-        role: users.role,
-        avatarUrl: users.avatarUrl,
-        bannedAt: users.bannedAt,
-        bannedReason: users.bannedReason,
-        createdAt: users.createdAt,
-        updatedAt: users.updatedAt,
-      });
+      .returning(adminUserSelection);
 
     if (!user) {
       throw new NotFoundException({
@@ -128,18 +119,7 @@ export class AdminService {
         updatedAt: now,
       })
       .where(and(eq(users.id, targetUserId), isNull(users.deletedAt)))
-      .returning({
-        id: users.id,
-        email: users.email,
-        username: users.username,
-        displayName: users.displayName,
-        role: users.role,
-        avatarUrl: users.avatarUrl,
-        bannedAt: users.bannedAt,
-        bannedReason: users.bannedReason,
-        createdAt: users.createdAt,
-        updatedAt: users.updatedAt,
-      });
+      .returning(adminUserSelection);
 
     if (!user) {
       throw new NotFoundException({

--- a/apps/control-plane/src/modules/admin/admin.service.ts
+++ b/apps/control-plane/src/modules/admin/admin.service.ts
@@ -1,0 +1,233 @@
+import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  type AdminBanUserInput,
+  type AdminUser,
+  type AdminUsersQuery,
+  type AdminUsersResponse,
+  ERROR_CODES,
+} from '@syncode/contracts';
+import type { Database } from '@syncode/db';
+import { users } from '@syncode/db';
+import { and, desc, eq, ilike, isNotNull, isNull, lt, or, type SQL } from 'drizzle-orm';
+import { DB_CLIENT } from '@/modules/db/db.module.js';
+
+interface UsersCursor {
+  createdAt: string;
+  id: string;
+}
+
+@Injectable()
+export class AdminService {
+  constructor(@Inject(DB_CLIENT) private readonly db: Database) {}
+
+  async listUsers(actorId: string, query: AdminUsersQuery): Promise<AdminUsersResponse> {
+    await this.assertAdmin(actorId);
+
+    const limit = query.limit ?? 20;
+    const filters = [
+      isNull(users.deletedAt),
+      this.buildSearchFilter(query.search),
+      this.buildStatusFilter(query.status),
+      this.buildCursorFilter(query.cursor),
+    ].filter((item): item is SQL => Boolean(item));
+
+    const rows = await this.db
+      .select({
+        id: users.id,
+        email: users.email,
+        username: users.username,
+        displayName: users.displayName,
+        role: users.role,
+        avatarUrl: users.avatarUrl,
+        bannedAt: users.bannedAt,
+        bannedReason: users.bannedReason,
+        createdAt: users.createdAt,
+        updatedAt: users.updatedAt,
+      })
+      .from(users)
+      .where(and(...filters))
+      .orderBy(desc(users.createdAt), desc(users.id))
+      .limit(limit + 1);
+
+    const page = rows.slice(0, limit);
+    const last = page.at(-1);
+
+    return {
+      data: page.map((row) => this.toAdminUser(row)),
+      pagination: {
+        hasMore: rows.length > limit,
+        nextCursor:
+          rows.length > limit && last
+            ? this.encodeCursor({ createdAt: last.createdAt.toISOString(), id: last.id })
+            : null,
+      },
+    };
+  }
+
+  async banUser(
+    actorId: string,
+    targetUserId: string,
+    input: AdminBanUserInput,
+  ): Promise<AdminUser> {
+    await this.assertAdmin(actorId);
+
+    const now = new Date();
+    const [user] = await this.db
+      .update(users)
+      .set({
+        bannedAt: now,
+        bannedReason: input.reason?.trim() || null,
+        updatedAt: now,
+      })
+      .where(and(eq(users.id, targetUserId), isNull(users.deletedAt)))
+      .returning({
+        id: users.id,
+        email: users.email,
+        username: users.username,
+        displayName: users.displayName,
+        role: users.role,
+        avatarUrl: users.avatarUrl,
+        bannedAt: users.bannedAt,
+        bannedReason: users.bannedReason,
+        createdAt: users.createdAt,
+        updatedAt: users.updatedAt,
+      });
+
+    if (!user) {
+      throw new NotFoundException({
+        message: 'User not found',
+        code: ERROR_CODES.USER_NOT_FOUND,
+      });
+    }
+
+    return this.toAdminUser(user);
+  }
+
+  async unbanUser(actorId: string, targetUserId: string): Promise<AdminUser> {
+    await this.assertAdmin(actorId);
+
+    const now = new Date();
+    const [user] = await this.db
+      .update(users)
+      .set({
+        bannedAt: null,
+        bannedReason: null,
+        updatedAt: now,
+      })
+      .where(and(eq(users.id, targetUserId), isNull(users.deletedAt)))
+      .returning({
+        id: users.id,
+        email: users.email,
+        username: users.username,
+        displayName: users.displayName,
+        role: users.role,
+        avatarUrl: users.avatarUrl,
+        bannedAt: users.bannedAt,
+        bannedReason: users.bannedReason,
+        createdAt: users.createdAt,
+        updatedAt: users.updatedAt,
+      });
+
+    if (!user) {
+      throw new NotFoundException({
+        message: 'User not found',
+        code: ERROR_CODES.USER_NOT_FOUND,
+      });
+    }
+
+    return this.toAdminUser(user);
+  }
+
+  private async assertAdmin(userId: string): Promise<void> {
+    const actor = await this.db.query.users.findFirst({
+      columns: { role: true, bannedAt: true },
+      where: (table) => and(eq(table.id, userId), isNull(table.deletedAt)),
+    });
+
+    if (actor?.role !== 'admin' || actor.bannedAt) {
+      throw new ForbiddenException({
+        message: 'Admin access required',
+        code: ERROR_CODES.FORBIDDEN,
+      });
+    }
+  }
+
+  private buildSearchFilter(search: string | undefined): SQL | undefined {
+    const normalized = search?.trim();
+    if (!normalized) {
+      return undefined;
+    }
+
+    const pattern = `%${normalized}%`;
+    return or(
+      ilike(users.email, pattern),
+      ilike(users.username, pattern),
+      ilike(users.displayName, pattern),
+    );
+  }
+
+  private buildStatusFilter(status: AdminUsersQuery['status']): SQL | undefined {
+    if (status === 'active') {
+      return isNull(users.bannedAt);
+    }
+
+    if (status === 'banned') {
+      return isNotNull(users.bannedAt);
+    }
+
+    return undefined;
+  }
+
+  private buildCursorFilter(cursor: string | undefined): SQL | undefined {
+    if (!cursor) {
+      return undefined;
+    }
+
+    const decoded = this.decodeCursor(cursor);
+    if (!decoded) {
+      return undefined;
+    }
+
+    const createdAt = new Date(decoded.createdAt);
+    return or(
+      lt(users.createdAt, createdAt),
+      and(eq(users.createdAt, createdAt), lt(users.id, decoded.id)),
+    );
+  }
+
+  private toAdminUser(row: {
+    id: string;
+    email: string;
+    username: string;
+    displayName: string | null;
+    role: 'user' | 'admin';
+    avatarUrl: string | null;
+    bannedAt: Date | null;
+    bannedReason: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }): AdminUser {
+    return {
+      ...row,
+      bannedAt: row.bannedAt?.toISOString() ?? null,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+    };
+  }
+
+  private encodeCursor(cursor: UsersCursor): string {
+    return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+  }
+
+  private decodeCursor(cursor: string): UsersCursor | null {
+    try {
+      const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as UsersCursor;
+      if (!parsed.createdAt || !parsed.id) {
+        return null;
+      }
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/apps/control-plane/src/modules/admin/admin.service.ts
+++ b/apps/control-plane/src/modules/admin/admin.service.ts
@@ -22,6 +22,8 @@ interface UsersCursor {
   id: string;
 }
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 const adminUserSelection = {
   id: users.id,
   email: users.email,
@@ -177,10 +179,6 @@ export class AdminService {
     }
 
     const decoded = this.decodeCursor(cursor);
-    if (!decoded) {
-      return undefined;
-    }
-
     const createdAt = new Date(decoded.createdAt);
     return or(
       lt(users.createdAt, createdAt),
@@ -212,15 +210,33 @@ export class AdminService {
     return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
   }
 
-  private decodeCursor(cursor: string): UsersCursor | null {
+  private decodeCursor(cursor: string): UsersCursor {
     try {
-      const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as UsersCursor;
-      if (!parsed.createdAt || !parsed.id) {
-        return null;
+      const buf = Buffer.from(cursor, 'base64url');
+      if (buf.toString('base64url') !== cursor) {
+        throw new Error('Cursor failed base64url round trip');
       }
-      return parsed;
+
+      const parsed = JSON.parse(buf.toString('utf8')) as Partial<UsersCursor>;
+      if (!this.isValidCursor(parsed)) {
+        throw new Error('Cursor payload is invalid');
+      }
+
+      return { createdAt: parsed.createdAt, id: parsed.id };
     } catch {
-      return null;
+      throw new BadRequestException({
+        message: 'Invalid cursor',
+        code: ERROR_CODES.VALIDATION_FAILED,
+      });
     }
+  }
+
+  private isValidCursor(cursor: Partial<UsersCursor>): cursor is UsersCursor {
+    if (typeof cursor.createdAt !== 'string' || typeof cursor.id !== 'string') {
+      return false;
+    }
+
+    const createdAt = new Date(cursor.createdAt);
+    return createdAt.toISOString() === cursor.createdAt && UUID_PATTERN.test(cursor.id);
   }
 }

--- a/apps/control-plane/src/modules/admin/dto/admin.dto.ts
+++ b/apps/control-plane/src/modules/admin/dto/admin.dto.ts
@@ -1,0 +1,15 @@
+import {
+  adminBanUserSchema,
+  adminUserSchema,
+  adminUsersQuerySchema,
+  adminUsersResponseSchema,
+} from '@syncode/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class AdminUsersQueryDto extends createZodDto(adminUsersQuerySchema) {}
+
+export class AdminUserDto extends createZodDto(adminUserSchema) {}
+
+export class AdminUsersResponseDto extends createZodDto(adminUsersResponseSchema) {}
+
+export class AdminBanUserDto extends createZodDto(adminBanUserSchema) {}

--- a/packages/contracts/src/control/admin.ts
+++ b/packages/contracts/src/control/admin.ts
@@ -1,0 +1,44 @@
+import { UserRole } from '@syncode/shared';
+import { z } from 'zod';
+import { paginationSchema } from './pagination.js';
+
+export const adminUserStatusOptions = ['active', 'banned'] as const;
+
+export const adminUsersQuerySchema = z.object({
+  cursor: z.string().optional().describe('Opaque pagination cursor'),
+  limit: z.coerce.number().int().min(1).max(100).default(20).describe('Page size'),
+  search: z.string().trim().max(100).optional().describe('Search by username, email, or name'),
+  status: z.enum(adminUserStatusOptions).optional().describe('Account status filter'),
+});
+
+export type AdminUsersQuery = z.infer<typeof adminUsersQuerySchema>;
+
+export const adminUserSchema = z.object({
+  id: z.uuid(),
+  email: z.email(),
+  username: z.string(),
+  displayName: z.string().nullable(),
+  role: z.enum([UserRole.USER, UserRole.ADMIN]),
+  avatarUrl: z.string().nullable(),
+  bannedAt: z.iso.datetime().nullable(),
+  bannedReason: z.string().nullable(),
+  createdAt: z.iso.datetime(),
+  updatedAt: z.iso.datetime(),
+});
+
+export type AdminUser = z.infer<typeof adminUserSchema>;
+
+export const adminUsersResponseSchema = z.object({
+  data: z.array(adminUserSchema),
+  pagination: paginationSchema,
+});
+
+export type AdminUsersResponse = z.infer<typeof adminUsersResponseSchema>;
+
+export const adminBanUserSchema = z
+  .object({
+    reason: z.string().trim().min(1).max(500).optional(),
+  })
+  .strict();
+
+export type AdminBanUserInput = z.infer<typeof adminBanUserSchema>;

--- a/packages/contracts/src/control/index.ts
+++ b/packages/contracts/src/control/index.ts
@@ -1,3 +1,4 @@
+export * from './admin.js';
 export * from './auth.js';
 export * from './bookmarks.js';
 export * from './error.js';

--- a/packages/contracts/src/control/routes.ts
+++ b/packages/contracts/src/control/routes.ts
@@ -1,6 +1,12 @@
 import type { z } from 'zod';
 import { defineRoute } from '../route-utils.js';
 import type {
+  adminBanUserSchema,
+  adminUserSchema,
+  adminUsersQuerySchema,
+  adminUsersResponseSchema,
+} from './admin.js';
+import type {
   accessTokenResponseSchema,
   loginResponseSchema,
   loginSchema,
@@ -74,6 +80,19 @@ import type {
 } from './whiteboard-assets.js';
 
 export const CONTROL_API = {
+  ADMIN: {
+    USERS: {
+      LIST: defineRoute<
+        z.infer<typeof adminUsersQuerySchema>,
+        z.infer<typeof adminUsersResponseSchema>
+      >()('admin/users', 'GET'),
+      BAN: defineRoute<z.infer<typeof adminBanUserSchema>, z.infer<typeof adminUserSchema>>()(
+        'admin/users/:id/ban',
+        'PATCH',
+      ),
+      UNBAN: defineRoute<void, z.infer<typeof adminUserSchema>>()('admin/users/:id/unban', 'PATCH'),
+    },
+  },
   AUTH: {
     REGISTER: defineRoute<z.infer<typeof registerSchema>, z.infer<typeof registerResponseSchema>>()(
       'auth/register',


### PR DESCRIPTION
Closes #94
Adds admin-only user listing, ban/unban endpoints, banned login rejection, self-ban protection, and backend tests.

