### PR TITLE
Feat/admin audit logs api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,10 @@ COLLAB_PLANE_URL=http://localhost:3001
 # COLLAB_PLANE_CLIENT_URL=ws://localhost:3001  # browser-facing URL (set when COLLAB_PLANE_URL is Docker-internal)
 CONTROL_PLANE_URL=http://localhost:3000
 
+# Trusted reverse proxies for control-plane client IP resolution (comma-separated)
+# Leave empty for local direct access. In production behind nginx/docker, set to the proxy CIDR/IP.
+TRUSTED_PROXIES=
+
 # AI plane (LLM proxy)
 AI_PROVIDER=openai-compatible
 AI_PLATFORM_BASE_URL=https://lab.cs.tsinghua.edu.cn/ai-platform/api/v1

--- a/.env.example
+++ b/.env.example
@@ -52,8 +52,8 @@ COLLAB_PLANE_URL=http://localhost:3001
 CONTROL_PLANE_URL=http://localhost:3000
 
 # Trusted reverse proxies for control-plane client IP resolution (comma-separated)
-# Leave empty for local direct access. Production requires an explicit value.
-TRUSTED_PROXIES=loopback,linklocal,uniquelocal
+# Leave empty for local direct access. Production compose requires the exact nginx/proxy CIDR.
+TRUSTED_PROXIES=
 
 # AI plane (LLM proxy)
 AI_PROVIDER=openai-compatible

--- a/.env.example
+++ b/.env.example
@@ -52,8 +52,8 @@ COLLAB_PLANE_URL=http://localhost:3001
 CONTROL_PLANE_URL=http://localhost:3000
 
 # Trusted reverse proxies for control-plane client IP resolution (comma-separated)
-# Leave empty for local direct access. In production behind nginx/docker, set to the proxy CIDR/IP.
-TRUSTED_PROXIES=
+# Leave empty for local direct access. Production requires an explicit value.
+TRUSTED_PROXIES=loopback,linklocal,uniquelocal
 
 # AI plane (LLM proxy)
 AI_PROVIDER=openai-compatible

--- a/apps/control-plane/.env.example
+++ b/apps/control-plane/.env.example
@@ -48,7 +48,7 @@ THROTTLE_LIMIT=10
 CORS_ORIGINS=http://localhost:5173
 
 # Trusted reverse proxies for Express client IP resolution (comma-separated)
-# Leave empty for local direct access. In production behind nginx/docker, set to the proxy CIDR/IP.
+# Leave empty for local direct access. Production requires an explicit value.
 TRUSTED_PROXIES=
 
 # Observability

--- a/apps/control-plane/.env.example
+++ b/apps/control-plane/.env.example
@@ -47,6 +47,10 @@ THROTTLE_LIMIT=10
 # CORS (comma-separated list of allowed origins)
 CORS_ORIGINS=http://localhost:5173
 
+# Trusted reverse proxies for Express client IP resolution (comma-separated)
+# Leave empty for local direct access. In production behind nginx/docker, set to the proxy CIDR/IP.
+TRUSTED_PROXIES=
+
 # Observability
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 

--- a/apps/control-plane/src/app.module.ts
+++ b/apps/control-plane/src/app.module.ts
@@ -9,6 +9,7 @@ import { GlobalExceptionFilter } from './common/filters/global-exception.filter.
 import { type EnvConfig, validateEnv } from './config/env.config.js';
 import { InfrastructureModule } from './infrastructure/infrastructure.module.js';
 import { AdminModule } from './modules/admin/admin.module.js';
+import { AdminAuditModule } from './modules/admin/admin-audit.module.js';
 import { AuthModule } from './modules/auth/auth.module.js';
 import { DbModule } from './modules/db/db.module.js';
 import { ExecutionModule } from './modules/execution/execution.module.js';
@@ -119,6 +120,7 @@ if (!isProd) {
 
     // Feature modules
     AuthModule,
+    AdminAuditModule,
     UsersModule,
     RoomsModule,
     WhiteboardAssetsModule,

--- a/apps/control-plane/src/config/env.config.spec.ts
+++ b/apps/control-plane/src/config/env.config.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { validateEnv } from './env.config.js';
+
+const baseEnv = {
+  DATABASE_URL: 'postgres://syncode:syncode@localhost:5432/syncode',
+  REDIS_URL: 'redis://localhost:6379',
+  AUTH_JWT_SECRET: 'a'.repeat(32),
+  JWT_REFRESH_SECRET: 'r'.repeat(32),
+  COLLAB_JWT_SECRET: 'c'.repeat(32),
+  INTERNAL_CALLBACK_SECRET: 'i'.repeat(32),
+  S3_ENDPOINT: 'http://localhost:8333',
+  S3_ACCESS_KEY: 'access',
+  S3_SECRET_KEY: 'secret',
+  S3_BUCKET: 'syncode',
+  LIVEKIT_API_KEY: 'livekit-key',
+  LIVEKIT_API_SECRET: 'livekit-secret',
+  LIVEKIT_URL: 'http://localhost:7880',
+};
+
+describe('validateEnv', () => {
+  it('GIVEN production env without trusted proxies WHEN validating THEN rejects startup config', () => {
+    expect(() =>
+      validateEnv({
+        ...baseEnv,
+        NODE_ENV: 'production',
+        TRUSTED_PROXIES: '',
+      }),
+    ).toThrow(/TRUSTED_PROXIES/);
+  });
+
+  it('GIVEN production env with trusted proxies WHEN validating THEN parses proxy list', () => {
+    const env = validateEnv({
+      ...baseEnv,
+      NODE_ENV: 'production',
+      TRUSTED_PROXIES: 'loopback, linklocal, uniquelocal',
+    });
+
+    expect(env.TRUSTED_PROXIES).toEqual(['loopback', 'linklocal', 'uniquelocal']);
+  });
+});

--- a/apps/control-plane/src/config/env.config.ts
+++ b/apps/control-plane/src/config/env.config.ts
@@ -9,6 +9,16 @@ const booleanEnv = z
   .union([z.boolean(), z.string()])
   .transform((val) => val === true || val === 'true' || val === '1');
 
+const commaSeparatedListEnv = z
+  .string()
+  .default('')
+  .transform((val) =>
+    val
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean),
+  );
+
 /**
  * Environment variable validation schema
  */
@@ -59,6 +69,9 @@ const envSchema = z
       .string()
       .default('http://localhost:5173,https://syncode.anggita.org')
       .transform((val) => val.split(',').map((origin) => origin.trim())),
+    TRUSTED_PROXIES: commaSeparatedListEnv.describe(
+      'Comma-separated Express trust proxy values. Leave empty to ignore forwarded IP headers.',
+    ),
 
     THROTTLE_TTL_SECS: z.coerce
       .number()

--- a/apps/control-plane/src/config/env.config.ts
+++ b/apps/control-plane/src/config/env.config.ts
@@ -105,7 +105,11 @@ const envSchema = z
         'INTERNAL_CALLBACK_SECRET must be explicitly set in production and must not use the development default.',
       path: ['INTERNAL_CALLBACK_SECRET'],
     },
-  );
+  )
+  .refine((env) => env.NODE_ENV !== 'production' || env.TRUSTED_PROXIES.length > 0, {
+    message: 'TRUSTED_PROXIES must be explicitly set in production.',
+    path: ['TRUSTED_PROXIES'],
+  });
 
 /**
  * Validated environment configuration type

--- a/apps/control-plane/src/main.ts
+++ b/apps/control-plane/src/main.ts
@@ -3,6 +3,7 @@ import './telemetry.js';
 
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
+import type { NestExpressApplication } from '@nestjs/platform-express';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import cookieParser from 'cookie-parser';
 import { Logger } from 'nestjs-pino';
@@ -14,7 +15,7 @@ import type { EnvConfig } from './config/env.config.js';
  * Bootstrap the control plane application
  */
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, {
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bufferLogs: true, // Buffer logs until logger is ready.
   });
 
@@ -25,6 +26,10 @@ async function bootstrap() {
   app.useGlobalPipes(new ZodValidationPipe());
 
   const config = app.get(ConfigService<EnvConfig>);
+  const trustedProxies = config.get('TRUSTED_PROXIES', { infer: true });
+  if (trustedProxies && trustedProxies.length > 0) {
+    app.set('trust proxy', trustedProxies);
+  }
 
   const corsOrigins = config.get('CORS_ORIGINS', { infer: true });
   app.enableCors({

--- a/apps/control-plane/src/modules/admin/admin-audit.controller.integration.spec.ts
+++ b/apps/control-plane/src/modules/admin/admin-audit.controller.integration.spec.ts
@@ -1,0 +1,217 @@
+import type { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { auditLogs, type Database } from '@syncode/db';
+import { ZodValidationPipe } from 'nestjs-zod';
+import request from 'supertest';
+import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard.js';
+import { DB_CLIENT } from '@/modules/db/db.module.js';
+import { createTestDb, insertUser } from '@/test/integration-setup.js';
+import { asUser, TestAuthGuard } from '@/test/mock-factories.js';
+import { AdminAuditController } from './admin-audit.controller.js';
+import { AuditService } from './audit.service.js';
+
+let app: INestApplication;
+let db: Database;
+let cleanup: () => Promise<void>;
+
+beforeEach(async () => {
+  const testDb = await createTestDb();
+  db = testDb.db;
+  cleanup = testDb.cleanup;
+
+  const module = await Test.createTestingModule({
+    controllers: [AdminAuditController],
+    providers: [AuditService, { provide: DB_CLIENT, useValue: db }],
+  })
+    .overrideGuard(JwtAuthGuard)
+    .useClass(TestAuthGuard)
+    .compile();
+
+  app = module.createNestApplication();
+  app.useGlobalPipes(new ZodValidationPipe());
+  await app.init();
+});
+
+afterEach(async () => {
+  await app.close();
+  await cleanup();
+});
+
+describe('GET /admin/audit-logs', () => {
+  it('GIVEN admin user WHEN querying logs THEN returns searchable paginated audit entries', async () => {
+    const admin = await insertUser(db, { role: 'admin' });
+    const actor = await insertUser(db, {
+      email: 'actor@example.com',
+      username: 'actor-user',
+      displayName: 'Actor User',
+    });
+    const oldLog = await insertAuditLog(actor.id, {
+      action: 'auth.register',
+      targetId: actor.id,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const recentLog = await insertAuditLog(actor.id, {
+      action: 'auth.login',
+      targetId: actor.id,
+      metadata: { identifierType: 'email' },
+      createdAt: new Date('2026-01-02T00:00:00.000Z'),
+    });
+    await insertAuditLog(null, {
+      action: 'system.cleanup',
+      targetType: 'system',
+      targetId: 'daily',
+      createdAt: new Date('2026-01-03T00:00:00.000Z'),
+    });
+
+    const firstPage = await asUser(
+      request(app.getHttpServer()).get('/admin/audit-logs?search=actor&limit=1'),
+      admin,
+    ).expect(200);
+
+    expect(firstPage.body.data).toHaveLength(1);
+    expect(firstPage.body.data[0]).toMatchObject({
+      id: recentLog.id,
+      actorId: actor.id,
+      actor: {
+        id: actor.id,
+        email: 'actor@example.com',
+        username: 'actor-user',
+        displayName: 'Actor User',
+      },
+      action: 'auth.login',
+      targetType: 'user',
+      targetId: actor.id,
+      metadata: { identifierType: 'email' },
+      ipAddress: '127.0.0.1',
+      createdAt: '2026-01-02T00:00:00.000Z',
+    });
+    expect(firstPage.body.pagination).toMatchObject({
+      hasMore: true,
+      nextCursor: expect.any(String),
+    });
+
+    const secondPage = await asUser(
+      request(app.getHttpServer()).get(
+        `/admin/audit-logs?search=actor&limit=1&cursor=${firstPage.body.pagination.nextCursor}`,
+      ),
+      admin,
+    ).expect(200);
+
+    expect(secondPage.body.data.map((log: { id: string }) => log.id)).toEqual([oldLog.id]);
+    expect(secondPage.body.pagination).toEqual({ hasMore: false, nextCursor: null });
+  });
+
+  it('GIVEN action and date filters WHEN querying logs THEN returns matching entries only', async () => {
+    const admin = await insertUser(db, { role: 'admin' });
+    const actor = await insertUser(db);
+    const expected = await insertAuditLog(actor.id, {
+      action: 'auth.logout',
+      targetId: actor.id,
+      createdAt: new Date('2026-01-02T00:00:00.000Z'),
+    });
+    await insertAuditLog(actor.id, {
+      action: 'auth.login',
+      targetId: actor.id,
+      createdAt: new Date('2026-01-02T00:00:00.000Z'),
+    });
+    await insertAuditLog(actor.id, {
+      action: 'auth.logout',
+      targetId: actor.id,
+      createdAt: new Date('2026-01-05T00:00:00.000Z'),
+    });
+
+    const res = await asUser(
+      request(app.getHttpServer()).get(
+        '/admin/audit-logs?action=auth.logout&from=2026-01-01T00:00:00.000Z&to=2026-01-03T00:00:00.000Z',
+      ),
+      admin,
+    ).expect(200);
+
+    expect(res.body.data.map((log: { id: string }) => log.id)).toEqual([expected.id]);
+  });
+
+  it('GIVEN actor and target filters WHEN querying logs THEN returns matching entries only', async () => {
+    const admin = await insertUser(db, { role: 'admin' });
+    const actor = await insertUser(db);
+    const otherActor = await insertUser(db);
+    const target = await insertUser(db);
+    const expected = await insertAuditLog(actor.id, {
+      action: 'admin.user.ban',
+      targetId: target.id,
+    });
+    await insertAuditLog(otherActor.id, {
+      action: 'admin.user.ban',
+      targetId: target.id,
+    });
+    await insertAuditLog(actor.id, {
+      action: 'admin.user.unban',
+      targetId: otherActor.id,
+    });
+
+    const res = await asUser(
+      request(app.getHttpServer()).get(
+        `/admin/audit-logs?actorId=${actor.id}&targetId=${target.id}`,
+      ),
+      admin,
+    ).expect(200);
+
+    expect(res.body.data.map((log: { id: string }) => log.id)).toEqual([expected.id]);
+  });
+
+  it('GIVEN malformed cursor WHEN querying logs THEN rejects the request', async () => {
+    const admin = await insertUser(db, { role: 'admin' });
+
+    const res = await asUser(
+      request(app.getHttpServer()).get('/admin/audit-logs?cursor=not-a-valid-cursor'),
+      admin,
+    ).expect(400);
+
+    expect(res.body).toMatchObject({
+      code: 'VALIDATION_FAILED',
+      message: 'Invalid cursor',
+    });
+  });
+
+  it('GIVEN cursor with invalid fields WHEN querying logs THEN rejects the request', async () => {
+    const admin = await insertUser(db, { role: 'admin' });
+    const cursor = Buffer.from(
+      JSON.stringify({ createdAt: 'not-a-date', id: 'not-a-uuid' }),
+      'utf8',
+    ).toString('base64url');
+
+    const res = await asUser(
+      request(app.getHttpServer()).get(`/admin/audit-logs?cursor=${cursor}`),
+      admin,
+    ).expect(400);
+
+    expect(res.body).toMatchObject({
+      code: 'VALIDATION_FAILED',
+      message: 'Invalid cursor',
+    });
+  });
+
+  it('GIVEN non-admin user WHEN querying logs THEN rejects the request', async () => {
+    const user = await insertUser(db);
+
+    await asUser(request(app.getHttpServer()).get('/admin/audit-logs'), user).expect(403);
+  });
+});
+
+async function insertAuditLog(
+  actorId: string | null,
+  overrides: Partial<typeof auditLogs.$inferInsert>,
+) {
+  const [row] = await db
+    .insert(auditLogs)
+    .values({
+      actorId,
+      action: 'auth.login',
+      targetType: 'user',
+      targetId: actorId ?? 'anonymous',
+      metadata: null,
+      ipAddress: '127.0.0.1',
+      ...overrides,
+    })
+    .returning();
+  return row;
+}

--- a/apps/control-plane/src/modules/admin/admin-audit.controller.ts
+++ b/apps/control-plane/src/modules/admin/admin-audit.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { CONTROL_API } from '@syncode/contracts';
+import { CurrentUser } from '@/common/decorators/current-user.decorator.js';
+import { ErrorResponseDto } from '@/common/dto/error-response.dto.js';
+import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard.js';
+import { AuditService } from './audit.service.js';
+import { AdminAuditLogsQueryDto, AdminAuditLogsResponseDto } from './dto/admin-audit.dto.js';
+
+@ApiTags('admin')
+@Controller()
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+export class AdminAuditController {
+  constructor(private readonly auditService: AuditService) {}
+
+  @Get(CONTROL_API.ADMIN.AUDIT_LOGS.route)
+  @ApiOperation({ summary: 'List audit logs for admin review' })
+  @ApiResponse({
+    status: 200,
+    type: AdminAuditLogsResponseDto,
+    description: 'Paginated audit logs',
+  })
+  @ApiQuery({ name: 'cursor', required: false, description: 'Pagination cursor' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Page size' })
+  @ApiQuery({ name: 'search', required: false, description: 'Search action, target, or actor' })
+  @ApiQuery({ name: 'action', required: false, description: 'Filter by action' })
+  @ApiQuery({ name: 'actorId', required: false, description: 'Filter by actor user ID' })
+  @ApiQuery({ name: 'targetId', required: false, description: 'Filter by target ID' })
+  @ApiQuery({ name: 'from', required: false, description: 'Created-at lower bound' })
+  @ApiQuery({ name: 'to', required: false, description: 'Created-at upper bound' })
+  @ApiResponse({ status: 400, type: ErrorResponseDto, description: 'Validation error' })
+  @ApiResponse({ status: 401, type: ErrorResponseDto, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, type: ErrorResponseDto, description: 'Admin access required' })
+  async listAuditLogs(
+    @CurrentUser() user: { id: string },
+    @Query() query: AdminAuditLogsQueryDto,
+  ): Promise<AdminAuditLogsResponseDto> {
+    return this.auditService.listLogs(user.id, query);
+  }
+}

--- a/apps/control-plane/src/modules/admin/admin-audit.controller.ts
+++ b/apps/control-plane/src/modules/admin/admin-audit.controller.ts
@@ -21,14 +21,31 @@ export class AdminAuditController {
     type: AdminAuditLogsResponseDto,
     description: 'Paginated audit logs',
   })
-  @ApiQuery({ name: 'cursor', required: false, description: 'Pagination cursor' })
-  @ApiQuery({ name: 'limit', required: false, description: 'Page size' })
+  @ApiQuery({ name: 'cursor', required: false, description: 'Opaque pagination cursor' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Page size' })
   @ApiQuery({ name: 'search', required: false, description: 'Search action, target, or actor' })
   @ApiQuery({ name: 'action', required: false, description: 'Filter by action' })
-  @ApiQuery({ name: 'actorId', required: false, description: 'Filter by actor user ID' })
+  @ApiQuery({
+    name: 'actorId',
+    required: false,
+    format: 'uuid',
+    description: 'Filter by actor user ID',
+  })
   @ApiQuery({ name: 'targetId', required: false, description: 'Filter by target ID' })
-  @ApiQuery({ name: 'from', required: false, description: 'Created-at lower bound' })
-  @ApiQuery({ name: 'to', required: false, description: 'Created-at upper bound' })
+  @ApiQuery({
+    name: 'from',
+    required: false,
+    type: String,
+    format: 'date-time',
+    description: 'Created-at lower bound',
+  })
+  @ApiQuery({
+    name: 'to',
+    required: false,
+    type: String,
+    format: 'date-time',
+    description: 'Created-at upper bound',
+  })
   @ApiResponse({ status: 400, type: ErrorResponseDto, description: 'Validation error' })
   @ApiResponse({ status: 401, type: ErrorResponseDto, description: 'Unauthorized' })
   @ApiResponse({ status: 403, type: ErrorResponseDto, description: 'Admin access required' })

--- a/apps/control-plane/src/modules/admin/admin-audit.module.ts
+++ b/apps/control-plane/src/modules/admin/admin-audit.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AdminAuditController } from './admin-audit.controller.js';
+import { AuditModule } from './audit.module.js';
+
+@Module({
+  imports: [AuditModule],
+  controllers: [AdminAuditController],
+})
+export class AdminAuditModule {}

--- a/apps/control-plane/src/modules/admin/admin.controller.integration.spec.ts
+++ b/apps/control-plane/src/modules/admin/admin.controller.integration.spec.ts
@@ -1,6 +1,6 @@
 import type { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import { type Database, users } from '@syncode/db';
+import { auditLogs, type Database, users } from '@syncode/db';
 import { eq } from 'drizzle-orm';
 import { ZodValidationPipe } from 'nestjs-zod';
 import request from 'supertest';
@@ -10,6 +10,7 @@ import { createTestDb, insertUser } from '@/test/integration-setup.js';
 import { asUser, TestAuthGuard } from '@/test/mock-factories.js';
 import { AdminController } from './admin.controller.js';
 import { AdminService } from './admin.service.js';
+import { AuditService } from './audit.service.js';
 
 let app: INestApplication;
 let db: Database;
@@ -22,7 +23,7 @@ beforeEach(async () => {
 
   const module = await Test.createTestingModule({
     controllers: [AdminController],
-    providers: [AdminService, { provide: DB_CLIENT, useValue: db }],
+    providers: [AdminService, AuditService, { provide: DB_CLIENT, useValue: db }],
   })
     .overrideGuard(JwtAuthGuard)
     .useClass(TestAuthGuard)
@@ -176,6 +177,36 @@ describe('PATCH /admin/users/:id/ban', () => {
     });
     expect(row?.bannedAt).toBeInstanceOf(Date);
     expect(row?.bannedReason).toBe('Repeated abuse');
+
+    const auditLog = await db.query.auditLogs.findFirst({
+      where: eq(auditLogs.targetId, target.id),
+    });
+    expect(auditLog).toMatchObject({
+      actorId: admin.id,
+      action: 'admin.user.ban',
+      targetType: 'user',
+      targetId: target.id,
+      metadata: { reason: 'Repeated abuse' },
+    });
+  });
+
+  it('GIVEN trusted proxy forwarding WHEN banning an account THEN records forwarded client IP', async () => {
+    app.getHttpAdapter().getInstance().set('trust proxy', 'loopback');
+    const admin = await insertUser(db, { role: 'admin' });
+    const target = await insertUser(db);
+
+    await asUser(
+      request(app.getHttpServer())
+        .patch(`/admin/users/${target.id}/ban`)
+        .set('X-Forwarded-For', '198.51.100.20')
+        .send({ reason: 'policy' }),
+      admin,
+    ).expect(200);
+
+    const auditLog = await db.query.auditLogs.findFirst({
+      where: eq(auditLogs.targetId, target.id),
+    });
+    expect(auditLog?.ipAddress).toBe('198.51.100.20');
   });
 
   it('GIVEN non-admin user WHEN banning an account THEN rejects the request', async () => {
@@ -245,6 +276,17 @@ describe('PATCH /admin/users/:id/unban', () => {
     expect(row).toMatchObject({
       bannedAt: null,
       bannedReason: null,
+    });
+
+    const auditLog = await db.query.auditLogs.findFirst({
+      where: eq(auditLogs.targetId, target.id),
+    });
+    expect(auditLog).toMatchObject({
+      actorId: admin.id,
+      action: 'admin.user.unban',
+      targetType: 'user',
+      targetId: target.id,
+      metadata: null,
     });
   });
 

--- a/apps/control-plane/src/modules/admin/admin.controller.spec.ts
+++ b/apps/control-plane/src/modules/admin/admin.controller.spec.ts
@@ -49,14 +49,23 @@ describe('AdminController', () => {
     };
     vi.mocked(service.banUser).mockResolvedValue(banned);
 
-    await expect(controller.banUser(ADMIN, TARGET_ID, { reason: 'policy' })).resolves.toEqual(
-      banned,
+    await expect(
+      controller.banUser(ADMIN, TARGET_ID, { reason: 'policy' }, '203.0.113.10'),
+    ).resolves.toEqual(banned);
+    expect(service.banUser).toHaveBeenCalledWith(
+      ADMIN.id,
+      TARGET_ID,
+      { reason: 'policy' },
+      '203.0.113.10',
     );
   });
 
   it('GIVEN unban request WHEN unbanning user THEN returns updated user', async () => {
     vi.mocked(service.unbanUser).mockResolvedValue(ADMIN_USER);
 
-    await expect(controller.unbanUser(ADMIN, TARGET_ID)).resolves.toEqual(ADMIN_USER);
+    await expect(controller.unbanUser(ADMIN, TARGET_ID, '203.0.113.10')).resolves.toEqual(
+      ADMIN_USER,
+    );
+    expect(service.unbanUser).toHaveBeenCalledWith(ADMIN.id, TARGET_ID, '203.0.113.10');
   });
 });

--- a/apps/control-plane/src/modules/admin/admin.controller.ts
+++ b/apps/control-plane/src/modules/admin/admin.controller.ts
@@ -14,10 +14,11 @@ import {
   ApiBody,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { CONTROL_API } from '@syncode/contracts';
+import { adminUserStatusOptions, CONTROL_API } from '@syncode/contracts';
 import { CurrentUser } from '@/common/decorators/current-user.decorator.js';
 import { ErrorResponseDto } from '@/common/dto/error-response.dto.js';
 import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard.js';
@@ -39,6 +40,16 @@ export class AdminController {
   @Get(CONTROL_API.ADMIN.USERS.LIST.route)
   @ApiOperation({ summary: 'List users for admin management' })
   @ApiResponse({ status: 200, type: AdminUsersResponseDto, description: 'Paginated users' })
+  @ApiQuery({ name: 'cursor', required: false, description: 'Opaque pagination cursor' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Page size' })
+  @ApiQuery({ name: 'search', required: false, description: 'Search by username, email, or name' })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: adminUserStatusOptions,
+    description: 'Account status filter',
+  })
+  @ApiResponse({ status: 400, type: ErrorResponseDto, description: 'Validation error' })
   @ApiResponse({ status: 401, type: ErrorResponseDto, description: 'Unauthorized' })
   @ApiResponse({ status: 403, type: ErrorResponseDto, description: 'Admin access required' })
   async listUsers(

--- a/apps/control-plane/src/modules/admin/admin.controller.ts
+++ b/apps/control-plane/src/modules/admin/admin.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Get,
+  Ip,
   Param,
   ParseUUIDPipe,
   Patch,
@@ -60,8 +61,9 @@ export class AdminController {
     @CurrentUser() user: { id: string },
     @Param('id', ParseUUIDPipe) id: string,
     @Body() body: AdminBanUserDto,
+    @Ip() ipAddress: string,
   ): Promise<AdminUserDto> {
-    return this.adminService.banUser(user.id, id, body);
+    return this.adminService.banUser(user.id, id, body, ipAddress);
   }
 
   @Patch(CONTROL_API.ADMIN.USERS.UNBAN.route)
@@ -75,7 +77,8 @@ export class AdminController {
   async unbanUser(
     @CurrentUser() user: { id: string },
     @Param('id', ParseUUIDPipe) id: string,
+    @Ip() ipAddress: string,
   ): Promise<AdminUserDto> {
-    return this.adminService.unbanUser(user.id, id);
+    return this.adminService.unbanUser(user.id, id, ipAddress);
   }
 }

--- a/apps/control-plane/src/modules/admin/admin.module.ts
+++ b/apps/control-plane/src/modules/admin/admin.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AdminController } from './admin.controller.js';
 import { AdminService } from './admin.service.js';
+import { AuditModule } from './audit.module.js';
 
 @Module({
+  imports: [AuditModule],
   controllers: [AdminController],
   providers: [AdminService],
 })

--- a/apps/control-plane/src/modules/admin/admin.service.spec.ts
+++ b/apps/control-plane/src/modules/admin/admin.service.spec.ts
@@ -1,0 +1,82 @@
+import { InternalServerErrorException } from '@nestjs/common';
+import type { Database } from '@syncode/db';
+import { describe, expect, it, vi } from 'vitest';
+import { AdminService } from './admin.service.js';
+
+function createServiceWithAuditFailure() {
+  const returning = vi.fn().mockResolvedValue([
+    {
+      id: '22222222-2222-4222-8222-222222222222',
+      email: 'target@example.com',
+      username: 'target',
+      displayName: null,
+      role: 'user',
+      avatarUrl: null,
+      bannedAt: new Date('2026-01-01T00:00:00.000Z'),
+      bannedReason: 'policy',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    },
+  ]);
+  const update = vi.fn(() => ({
+    set: vi.fn(() => ({
+      where: vi.fn(() => ({
+        returning,
+      })),
+    })),
+  }));
+  const insert = vi.fn(() => ({
+    values: vi.fn(async () => {
+      throw new InternalServerErrorException('audit unavailable');
+    }),
+  }));
+  const tx = { update, insert };
+  const db = {
+    query: {
+      users: {
+        findFirst: vi.fn().mockResolvedValue({ role: 'admin', bannedAt: null }),
+      },
+    },
+    transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
+      callback(tx),
+    ),
+  };
+
+  return {
+    service: new AdminService(db as unknown as Database),
+    mocks: { db, tx, returning, update, insert },
+  };
+}
+
+describe('AdminService', () => {
+  it('GIVEN audit insert fails WHEN banning a user THEN rejects instead of silently applying an unaudited admin mutation', async () => {
+    const { service, mocks } = createServiceWithAuditFailure();
+
+    await expect(
+      service.banUser(
+        '11111111-1111-4111-8111-111111111111',
+        '22222222-2222-4222-8222-222222222222',
+        {
+          reason: 'policy',
+        },
+      ),
+    ).rejects.toThrow('audit unavailable');
+
+    expect(mocks.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mocks.tx.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it('GIVEN audit insert fails WHEN unbanning a user THEN rejects instead of silently applying an unaudited admin mutation', async () => {
+    const { service, mocks } = createServiceWithAuditFailure();
+
+    await expect(
+      service.unbanUser(
+        '11111111-1111-4111-8111-111111111111',
+        '22222222-2222-4222-8222-222222222222',
+      ),
+    ).rejects.toThrow('audit unavailable');
+
+    expect(mocks.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mocks.tx.insert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/control-plane/src/modules/admin/admin.service.spec.ts
+++ b/apps/control-plane/src/modules/admin/admin.service.spec.ts
@@ -2,6 +2,7 @@ import { InternalServerErrorException } from '@nestjs/common';
 import type { Database } from '@syncode/db';
 import { describe, expect, it, vi } from 'vitest';
 import { AdminService } from './admin.service.js';
+import type { AuditService } from './audit.service.js';
 
 function createServiceWithAuditFailure() {
   const returning = vi.fn().mockResolvedValue([
@@ -31,6 +32,10 @@ function createServiceWithAuditFailure() {
     }),
   }));
   const tx = { update, insert };
+  const auditService = {
+    log: vi.fn(async () => undefined),
+    logWithClient: vi.fn(async (client: typeof tx) => client.insert({}).values({})),
+  };
   const db = {
     query: {
       users: {
@@ -43,8 +48,8 @@ function createServiceWithAuditFailure() {
   };
 
   return {
-    service: new AdminService(db as unknown as Database),
-    mocks: { db, tx, returning, update, insert },
+    service: new AdminService(db as unknown as Database, auditService as unknown as AuditService),
+    mocks: { db, tx, returning, update, insert, auditService },
   };
 }
 
@@ -63,7 +68,7 @@ describe('AdminService', () => {
     ).rejects.toThrow('audit unavailable');
 
     expect(mocks.db.transaction).toHaveBeenCalledTimes(1);
-    expect(mocks.tx.insert).toHaveBeenCalledTimes(1);
+    expect(mocks.auditService.logWithClient).toHaveBeenCalledTimes(1);
   });
 
   it('GIVEN audit insert fails WHEN unbanning a user THEN rejects instead of silently applying an unaudited admin mutation', async () => {
@@ -77,6 +82,6 @@ describe('AdminService', () => {
     ).rejects.toThrow('audit unavailable');
 
     expect(mocks.db.transaction).toHaveBeenCalledTimes(1);
-    expect(mocks.tx.insert).toHaveBeenCalledTimes(1);
+    expect(mocks.auditService.logWithClient).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/control-plane/src/modules/admin/admin.service.ts
+++ b/apps/control-plane/src/modules/admin/admin.service.ts
@@ -13,10 +13,10 @@ import {
   ERROR_CODES,
 } from '@syncode/contracts';
 import type { Database } from '@syncode/db';
-import { auditLogs, users } from '@syncode/db';
+import { users } from '@syncode/db';
 import { and, desc, eq, ilike, isNotNull, isNull, lt, or, type SQL } from 'drizzle-orm';
 import { DB_CLIENT } from '@/modules/db/db.module.js';
-import type { AuditLogInput } from './audit.service.js';
+import { AuditService } from './audit.service.js';
 
 interface UsersCursor {
   createdAt: string;
@@ -40,7 +40,10 @@ const adminUserSelection = {
 
 @Injectable()
 export class AdminService {
-  constructor(@Inject(DB_CLIENT) private readonly db: Database) {}
+  constructor(
+    @Inject(DB_CLIENT) private readonly db: Database,
+    private readonly auditService: AuditService,
+  ) {}
 
   async listUsers(actorId: string, query: AdminUsersQuery): Promise<AdminUsersResponse> {
     await this.assertAdmin(actorId);
@@ -110,7 +113,7 @@ export class AdminService {
         });
       }
 
-      await this.logAdminAudit(tx, {
+      await this.auditService.logWithClient(tx, {
         actorId,
         action: 'admin.user.ban',
         targetType: 'user',
@@ -145,7 +148,7 @@ export class AdminService {
         });
       }
 
-      await this.logAdminAudit(tx, {
+      await this.auditService.logWithClient(tx, {
         actorId,
         action: 'admin.user.unban',
         targetType: 'user',
@@ -154,17 +157,6 @@ export class AdminService {
       });
 
       return this.toAdminUser(user);
-    });
-  }
-
-  private async logAdminAudit(db: Pick<Database, 'insert'>, input: AuditLogInput): Promise<void> {
-    await db.insert(auditLogs).values({
-      actorId: input.actorId,
-      action: input.action,
-      targetType: input.targetType,
-      targetId: input.targetId,
-      metadata: input.metadata ?? null,
-      ipAddress: input.ipAddress ?? null,
     });
   }
 

--- a/apps/control-plane/src/modules/admin/admin.service.ts
+++ b/apps/control-plane/src/modules/admin/admin.service.ts
@@ -13,9 +13,10 @@ import {
   ERROR_CODES,
 } from '@syncode/contracts';
 import type { Database } from '@syncode/db';
-import { users } from '@syncode/db';
+import { auditLogs, users } from '@syncode/db';
 import { and, desc, eq, ilike, isNotNull, isNull, lt, or, type SQL } from 'drizzle-orm';
 import { DB_CLIENT } from '@/modules/db/db.module.js';
+import type { AuditLogInput } from './audit.service.js';
 
 interface UsersCursor {
   createdAt: string;
@@ -78,6 +79,7 @@ export class AdminService {
     actorId: string,
     targetUserId: string,
     input: AdminBanUserInput,
+    ipAddress?: string,
   ): Promise<AdminUser> {
     await this.assertAdmin(actorId);
 
@@ -88,49 +90,82 @@ export class AdminService {
       });
     }
 
-    const now = new Date();
-    const [user] = await this.db
-      .update(users)
-      .set({
-        bannedAt: now,
-        bannedReason: input.reason?.trim() || null,
-        updatedAt: now,
-      })
-      .where(and(eq(users.id, targetUserId), isNull(users.deletedAt)))
-      .returning(adminUserSelection);
+    return this.db.transaction(async (tx) => {
+      const now = new Date();
+      const reason = input.reason?.trim() || null;
+      const [user] = await tx
+        .update(users)
+        .set({
+          bannedAt: now,
+          bannedReason: reason,
+          updatedAt: now,
+        })
+        .where(and(eq(users.id, targetUserId), isNull(users.deletedAt)))
+        .returning(adminUserSelection);
 
-    if (!user) {
-      throw new NotFoundException({
-        message: 'User not found',
-        code: ERROR_CODES.USER_NOT_FOUND,
+      if (!user) {
+        throw new NotFoundException({
+          message: 'User not found',
+          code: ERROR_CODES.USER_NOT_FOUND,
+        });
+      }
+
+      await this.logAdminAudit(tx, {
+        actorId,
+        action: 'admin.user.ban',
+        targetType: 'user',
+        targetId: targetUserId,
+        metadata: { reason },
+        ipAddress,
       });
-    }
 
-    return this.toAdminUser(user);
+      return this.toAdminUser(user);
+    });
   }
 
-  async unbanUser(actorId: string, targetUserId: string): Promise<AdminUser> {
+  async unbanUser(actorId: string, targetUserId: string, ipAddress?: string): Promise<AdminUser> {
     await this.assertAdmin(actorId);
 
-    const now = new Date();
-    const [user] = await this.db
-      .update(users)
-      .set({
-        bannedAt: null,
-        bannedReason: null,
-        updatedAt: now,
-      })
-      .where(and(eq(users.id, targetUserId), isNull(users.deletedAt)))
-      .returning(adminUserSelection);
+    return this.db.transaction(async (tx) => {
+      const now = new Date();
+      const [user] = await tx
+        .update(users)
+        .set({
+          bannedAt: null,
+          bannedReason: null,
+          updatedAt: now,
+        })
+        .where(and(eq(users.id, targetUserId), isNull(users.deletedAt)))
+        .returning(adminUserSelection);
 
-    if (!user) {
-      throw new NotFoundException({
-        message: 'User not found',
-        code: ERROR_CODES.USER_NOT_FOUND,
+      if (!user) {
+        throw new NotFoundException({
+          message: 'User not found',
+          code: ERROR_CODES.USER_NOT_FOUND,
+        });
+      }
+
+      await this.logAdminAudit(tx, {
+        actorId,
+        action: 'admin.user.unban',
+        targetType: 'user',
+        targetId: targetUserId,
+        ipAddress,
       });
-    }
 
-    return this.toAdminUser(user);
+      return this.toAdminUser(user);
+    });
+  }
+
+  private async logAdminAudit(db: Pick<Database, 'insert'>, input: AuditLogInput): Promise<void> {
+    await db.insert(auditLogs).values({
+      actorId: input.actorId,
+      action: input.action,
+      targetType: input.targetType,
+      targetId: input.targetId,
+      metadata: input.metadata ?? null,
+      ipAddress: input.ipAddress ?? null,
+    });
   }
 
   private async assertAdmin(userId: string): Promise<void> {

--- a/apps/control-plane/src/modules/admin/audit.module.ts
+++ b/apps/control-plane/src/modules/admin/audit.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { AuditService } from './audit.service.js';
+
+@Module({
+  providers: [AuditService],
+  exports: [AuditService],
+})
+export class AuditModule {}

--- a/apps/control-plane/src/modules/admin/audit.service.integration.spec.ts
+++ b/apps/control-plane/src/modules/admin/audit.service.integration.spec.ts
@@ -1,0 +1,48 @@
+import type { Database } from '@syncode/db';
+import { auditLogs } from '@syncode/db';
+import { eq } from 'drizzle-orm';
+import { createTestDb, insertUser } from '@/test/integration-setup.js';
+import { AuditService } from './audit.service.js';
+
+let db: Database;
+let cleanup: () => Promise<void>;
+let service: AuditService;
+
+beforeEach(async () => {
+  const testDb = await createTestDb();
+  db = testDb.db;
+  cleanup = testDb.cleanup;
+  service = new AuditService(db);
+});
+
+afterEach(async () => {
+  await cleanup();
+});
+
+describe('AuditService.log', () => {
+  it('GIVEN audit input WHEN logging THEN persists an audit row', async () => {
+    const actor = await insertUser(db);
+
+    await service.log({
+      actorId: actor.id,
+      action: 'auth.login',
+      targetType: 'user',
+      targetId: actor.id,
+      metadata: { identifierType: 'email' },
+      ipAddress: '127.0.0.1',
+    });
+
+    const row = await db.query.auditLogs.findFirst({
+      where: eq(auditLogs.actorId, actor.id),
+    });
+
+    expect(row).toMatchObject({
+      actorId: actor.id,
+      action: 'auth.login',
+      targetType: 'user',
+      targetId: actor.id,
+      metadata: { identifierType: 'email' },
+      ipAddress: '127.0.0.1',
+    });
+  });
+});

--- a/apps/control-plane/src/modules/admin/audit.service.ts
+++ b/apps/control-plane/src/modules/admin/audit.service.ts
@@ -31,7 +31,11 @@ export class AuditService {
   constructor(@Inject(DB_CLIENT) private readonly db: Database) {}
 
   async log(input: AuditLogInput): Promise<void> {
-    await this.db.insert(auditLogs).values({
+    await this.logWithClient(this.db, input);
+  }
+
+  async logWithClient(db: Pick<Database, 'insert'>, input: AuditLogInput): Promise<void> {
+    await db.insert(auditLogs).values({
       actorId: input.actorId,
       action: input.action,
       targetType: input.targetType,

--- a/apps/control-plane/src/modules/admin/audit.service.ts
+++ b/apps/control-plane/src/modules/admin/audit.service.ts
@@ -1,0 +1,226 @@
+import { BadRequestException, ForbiddenException, Inject, Injectable } from '@nestjs/common';
+import {
+  type AdminAuditLogsQuery,
+  type AdminAuditLogsResponse,
+  type AuditLog,
+  ERROR_CODES,
+} from '@syncode/contracts';
+import type { Database } from '@syncode/db';
+import { auditLogs, users } from '@syncode/db';
+import { and, desc, eq, gte, ilike, isNull, lt, lte, or, type SQL } from 'drizzle-orm';
+import { DB_CLIENT } from '@/modules/db/db.module.js';
+
+interface AuditCursor {
+  createdAt: string;
+  id: string;
+}
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export interface AuditLogInput {
+  actorId: string | null;
+  action: string;
+  targetType: string;
+  targetId: string;
+  metadata?: unknown;
+  ipAddress?: string | null;
+}
+
+@Injectable()
+export class AuditService {
+  constructor(@Inject(DB_CLIENT) private readonly db: Database) {}
+
+  async log(input: AuditLogInput): Promise<void> {
+    await this.db.insert(auditLogs).values({
+      actorId: input.actorId,
+      action: input.action,
+      targetType: input.targetType,
+      targetId: input.targetId,
+      metadata: input.metadata ?? null,
+      ipAddress: input.ipAddress ?? null,
+    });
+  }
+
+  async listLogs(actorId: string, query: AdminAuditLogsQuery): Promise<AdminAuditLogsResponse> {
+    await this.assertAdmin(actorId);
+
+    const limit = query.limit ?? 20;
+    const filters = [
+      this.buildSearchFilter(query.search),
+      this.buildActionFilter(query.action),
+      this.buildActorFilter(query.actorId),
+      this.buildTargetFilter(query.targetId),
+      this.buildDateFilter(query.from, query.to),
+      this.buildCursorFilter(query.cursor),
+    ].filter((item): item is SQL => Boolean(item));
+
+    const rows = await this.db
+      .select({
+        id: auditLogs.id,
+        actorId: auditLogs.actorId,
+        action: auditLogs.action,
+        targetType: auditLogs.targetType,
+        targetId: auditLogs.targetId,
+        metadata: auditLogs.metadata,
+        ipAddress: auditLogs.ipAddress,
+        createdAt: auditLogs.createdAt,
+        actorUsername: users.username,
+        actorEmail: users.email,
+        actorDisplayName: users.displayName,
+      })
+      .from(auditLogs)
+      .leftJoin(users, eq(users.id, auditLogs.actorId))
+      .where(filters.length > 0 ? and(...filters) : undefined)
+      .orderBy(desc(auditLogs.createdAt), desc(auditLogs.id))
+      .limit(limit + 1);
+
+    const page = rows.slice(0, limit);
+    const last = page.at(-1);
+
+    return {
+      data: page.map((row) => this.toAuditLog(row)),
+      pagination: {
+        hasMore: rows.length > limit,
+        nextCursor:
+          rows.length > limit && last
+            ? this.encodeCursor({ createdAt: last.createdAt.toISOString(), id: last.id })
+            : null,
+      },
+    };
+  }
+
+  private async assertAdmin(userId: string): Promise<void> {
+    const actor = await this.db.query.users.findFirst({
+      columns: { role: true, bannedAt: true },
+      where: (table) => and(eq(table.id, userId), isNull(table.deletedAt)),
+    });
+
+    if (actor?.role !== 'admin' || actor.bannedAt) {
+      throw new ForbiddenException({
+        message: 'Admin access required',
+        code: ERROR_CODES.FORBIDDEN,
+      });
+    }
+  }
+
+  private buildSearchFilter(search: string | undefined): SQL | undefined {
+    const normalized = search?.trim();
+    if (!normalized) {
+      return undefined;
+    }
+
+    const pattern = `%${normalized}%`;
+    return or(
+      ilike(auditLogs.action, pattern),
+      ilike(auditLogs.targetType, pattern),
+      ilike(auditLogs.targetId, pattern),
+      ilike(users.email, pattern),
+      ilike(users.username, pattern),
+      ilike(users.displayName, pattern),
+    );
+  }
+
+  private buildActionFilter(action: string | undefined): SQL | undefined {
+    const normalized = action?.trim();
+    return normalized ? eq(auditLogs.action, normalized) : undefined;
+  }
+
+  private buildActorFilter(actorId: string | undefined): SQL | undefined {
+    return actorId ? eq(auditLogs.actorId, actorId) : undefined;
+  }
+
+  private buildTargetFilter(targetId: string | undefined): SQL | undefined {
+    const normalized = targetId?.trim();
+    return normalized ? eq(auditLogs.targetId, normalized) : undefined;
+  }
+
+  private buildDateFilter(from: string | undefined, to: string | undefined): SQL | undefined {
+    const filters = [
+      from ? gte(auditLogs.createdAt, new Date(from)) : undefined,
+      to ? lte(auditLogs.createdAt, new Date(to)) : undefined,
+    ].filter((item): item is SQL => Boolean(item));
+
+    return filters.length > 0 ? and(...filters) : undefined;
+  }
+
+  private buildCursorFilter(cursor: string | undefined): SQL | undefined {
+    if (!cursor) {
+      return undefined;
+    }
+
+    const decoded = this.decodeCursor(cursor);
+    const createdAt = new Date(decoded.createdAt);
+    return or(
+      lt(auditLogs.createdAt, createdAt),
+      and(eq(auditLogs.createdAt, createdAt), lt(auditLogs.id, decoded.id)),
+    );
+  }
+
+  private toAuditLog(row: {
+    id: string;
+    actorId: string | null;
+    action: string;
+    targetType: string;
+    targetId: string;
+    metadata: unknown;
+    ipAddress: string | null;
+    createdAt: Date;
+    actorUsername: string | null;
+    actorEmail: string | null;
+    actorDisplayName: string | null;
+  }): AuditLog {
+    return {
+      id: row.id,
+      actorId: row.actorId,
+      actor:
+        row.actorId && row.actorEmail && row.actorUsername
+          ? {
+              id: row.actorId,
+              username: row.actorUsername,
+              email: row.actorEmail,
+              displayName: row.actorDisplayName,
+            }
+          : null,
+      action: row.action,
+      targetType: row.targetType,
+      targetId: row.targetId,
+      metadata: row.metadata ?? null,
+      ipAddress: row.ipAddress,
+      createdAt: row.createdAt.toISOString(),
+    };
+  }
+
+  private encodeCursor(cursor: AuditCursor): string {
+    return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+  }
+
+  private decodeCursor(cursor: string): AuditCursor {
+    try {
+      const buf = Buffer.from(cursor, 'base64url');
+      if (buf.toString('base64url') !== cursor) {
+        throw new Error('Cursor failed base64url round trip');
+      }
+
+      const parsed = JSON.parse(buf.toString('utf8')) as Partial<AuditCursor>;
+      if (!this.isValidCursor(parsed)) {
+        throw new Error('Cursor payload is invalid');
+      }
+
+      return { createdAt: parsed.createdAt, id: parsed.id };
+    } catch {
+      throw new BadRequestException({
+        message: 'Invalid cursor',
+        code: ERROR_CODES.VALIDATION_FAILED,
+      });
+    }
+  }
+
+  private isValidCursor(cursor: Partial<AuditCursor>): cursor is AuditCursor {
+    if (typeof cursor.createdAt !== 'string' || typeof cursor.id !== 'string') {
+      return false;
+    }
+
+    const createdAt = new Date(cursor.createdAt);
+    return createdAt.toISOString() === cursor.createdAt && UUID_PATTERN.test(cursor.id);
+  }
+}

--- a/apps/control-plane/src/modules/admin/dto/admin-audit.dto.ts
+++ b/apps/control-plane/src/modules/admin/dto/admin-audit.dto.ts
@@ -1,0 +1,12 @@
+import {
+  adminAuditLogsQuerySchema,
+  adminAuditLogsResponseSchema,
+  auditLogSchema,
+} from '@syncode/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class AdminAuditLogsQueryDto extends createZodDto(adminAuditLogsQuerySchema) {}
+
+export class AuditLogDto extends createZodDto(auditLogSchema) {}
+
+export class AdminAuditLogsResponseDto extends createZodDto(adminAuditLogsResponseSchema) {}

--- a/apps/control-plane/src/modules/auth/auth.controller.integration.spec.ts
+++ b/apps/control-plane/src/modules/auth/auth.controller.integration.spec.ts
@@ -12,6 +12,7 @@ import { DB_CLIENT } from '@/modules/db/db.module.js';
 import { InMemoryCacheService } from '@/test/in-memory-cache.service.js';
 import { createTestDb } from '@/test/integration-setup.js';
 import { createMockConfigService, createMockStorageService } from '@/test/mock-factories.js';
+import { AuditService } from '../admin/audit.service.js';
 import { AuthController } from './auth.controller.js';
 import { AuthService } from './auth.service.js';
 
@@ -45,6 +46,7 @@ beforeEach(async () => {
     controllers: [AuthController],
     providers: [
       AuthService,
+      AuditService,
       { provide: DB_CLIENT, useValue: db },
       { provide: CACHE_SERVICE, useValue: new InMemoryCacheService() },
       { provide: STORAGE_SERVICE, useValue: createMockStorageService() },
@@ -98,6 +100,36 @@ describe('POST /auth/register', () => {
     expect(res.headers['set-cookie']).toEqual(
       expect.arrayContaining([expect.stringContaining('refreshToken=')]),
     );
+
+    const auditLog = await db.query.auditLogs.findFirst({
+      where: (table, { eq }) => eq(table.action, 'auth.register'),
+    });
+    expect(auditLog).toMatchObject({
+      actorId: res.body.user.id,
+      targetType: 'user',
+      targetId: res.body.user.id,
+      metadata: { email: 'alice@example.com', username: 'alice_sync' },
+    });
+  });
+
+  it('GIVEN trusted proxy forwarding WHEN registering THEN records forwarded client IP', async () => {
+    app.getHttpAdapter().getInstance().set('trust proxy', 'loopback');
+
+    const res = await request(app.getHttpServer())
+      .post('/auth/register')
+      .set('X-Forwarded-For', '198.51.100.10')
+      .send({
+        username: 'alice_sync',
+        email: 'alice@example.com',
+        password: 'secret123',
+      });
+
+    expect(res.status).toBe(201);
+
+    const auditLog = await db.query.auditLogs.findFirst({
+      where: (table, { eq }) => eq(table.action, 'auth.register'),
+    });
+    expect(auditLog?.ipAddress).toBe('198.51.100.10');
   });
 
   it('GIVEN duplicate email WHEN registering THEN returns 409 with AUTH_EMAIL_TAKEN code', async () => {
@@ -161,6 +193,16 @@ describe('POST /auth/login', () => {
     expect(res.headers['set-cookie']).toEqual(
       expect.arrayContaining([expect.stringContaining('refreshToken=')]),
     );
+
+    const auditLog = await db.query.auditLogs.findFirst({
+      where: (table, { eq }) => eq(table.action, 'auth.login'),
+    });
+    expect(auditLog).toMatchObject({
+      actorId: res.body.user.id,
+      targetType: 'user',
+      targetId: res.body.user.id,
+      metadata: { identifierType: 'email' },
+    });
   });
 
   it('GIVEN wrong password WHEN logging in THEN returns 401', async () => {
@@ -223,6 +265,13 @@ describe('POST /auth/logout', () => {
     expect(logoutResponse.headers['set-cookie']).toEqual(
       expect.arrayContaining([expect.stringContaining('refreshToken=;')]),
     );
+    const auditLog = await db.query.auditLogs.findFirst({
+      where: (table, { eq }) => eq(table.action, 'auth.logout'),
+    });
+    expect(auditLog).toMatchObject({
+      targetType: 'user',
+      metadata: expect.objectContaining({ tokenId: expect.any(String) }),
+    });
 
     const refreshResponse = await request(app.getHttpServer())
       .post('/auth/refresh')

--- a/apps/control-plane/src/modules/auth/auth.controller.spec.ts
+++ b/apps/control-plane/src/modules/auth/auth.controller.spec.ts
@@ -68,7 +68,7 @@ describe('AuthController', () => {
   }
 
   it('GIVEN register request WHEN successful THEN returns payload and sets refresh cookie', async () => {
-    const { controller, response } = createController();
+    const { controller, response, authService } = createController();
 
     const result = await controller.register(
       {
@@ -77,15 +77,22 @@ describe('AuthController', () => {
         password: 'secret123',
       },
       response as Response,
+      '203.0.113.10',
     );
 
     expect(result.accessToken).toBe('access-token');
     expect(result.user.username).toBe('alice');
     expect(response.cookie).toHaveBeenCalledTimes(1);
+    expect(authService.register).toHaveBeenCalledWith(
+      'alice',
+      'alice@example.com',
+      'secret123',
+      '203.0.113.10',
+    );
   });
 
   it('GIVEN login request WHEN successful THEN returns payload and sets refresh cookie', async () => {
-    const { controller, response } = createController();
+    const { controller, response, authService } = createController();
 
     const result = await controller.login(
       {
@@ -93,11 +100,13 @@ describe('AuthController', () => {
         password: 'secret123',
       },
       response as Response,
+      '203.0.113.10',
     );
 
     expect(result.accessToken).toBe('access-token');
     expect(result.user.email).toBe('user@example.com');
     expect(response.cookie).toHaveBeenCalledTimes(1);
+    expect(authService.login).toHaveBeenCalledWith('alice', 'secret123', '203.0.113.10');
   });
 
   it('GIVEN missing refresh cookie WHEN refreshing THEN throws unauthorized', async () => {
@@ -121,9 +130,9 @@ describe('AuthController', () => {
   it('GIVEN refresh cookie WHEN logging out THEN clears refresh cookie', async () => {
     const { controller, response, authService } = createController();
 
-    await controller.logout('refresh-token', response as Response);
+    await controller.logout('refresh-token', response as Response, '203.0.113.10');
 
-    expect(authService.logout).toHaveBeenCalledWith('refresh-token');
+    expect(authService.logout).toHaveBeenCalledWith('refresh-token', '203.0.113.10');
     expect(response.cookie).toHaveBeenCalledTimes(1);
     expect(response.cookie).toHaveBeenCalledWith(
       'refreshToken',

--- a/apps/control-plane/src/modules/auth/auth.controller.ts
+++ b/apps/control-plane/src/modules/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   HttpCode,
   HttpStatus,
+  Ip,
   Post,
   Res,
   UnauthorizedException,
@@ -74,11 +75,13 @@ export class AuthController {
   async register(
     @Body() body: RegisterDto,
     @Res({ passthrough: true }) response: Response,
+    @Ip() ipAddress: string,
   ): Promise<RegisterResponseDto> {
     const registerResult = await this.authService.register(
       body.username,
       body.email,
       body.password,
+      ipAddress,
     );
 
     this.setRefreshTokenCookie(response, registerResult.refreshToken);
@@ -111,8 +114,9 @@ export class AuthController {
   async login(
     @Body() body: LoginDto,
     @Res({ passthrough: true }) response: Response,
+    @Ip() ipAddress: string,
   ): Promise<LoginResponseDto> {
-    const loginResult = await this.authService.login(body.identifier, body.password);
+    const loginResult = await this.authService.login(body.identifier, body.password, ipAddress);
 
     this.setRefreshTokenCookie(response, loginResult.refreshToken);
 
@@ -172,9 +176,10 @@ export class AuthController {
   async logout(
     @Cookies(AuthController.REFRESH_TOKEN_COOKIE_NAME) refreshToken: string | undefined,
     @Res({ passthrough: true }) response: Response,
+    @Ip() ipAddress: string,
   ): Promise<void> {
     this.assertRefreshTokenCookie(refreshToken);
-    await this.authService.logout(refreshToken);
+    await this.authService.logout(refreshToken, ipAddress);
 
     this.clearRefreshTokenCookie(response);
   }

--- a/apps/control-plane/src/modules/auth/auth.module.ts
+++ b/apps/control-plane/src/modules/auth/auth.module.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import type { EnvConfig } from '@/config/env.config.js';
+import { AuditModule } from '../admin/audit.module.js';
 import { AuthController } from './auth.controller.js';
 import { AuthService } from './auth.service.js';
 import { JwtStrategy } from './jwt.strategy.js';
@@ -13,6 +14,7 @@ import { RefreshTokenCleanupService } from './refresh-token-cleanup.service.js';
  */
 @Module({
   imports: [
+    AuditModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       useFactory: (config: ConfigService<EnvConfig>) => ({

--- a/apps/control-plane/src/modules/auth/auth.service.spec.ts
+++ b/apps/control-plane/src/modules/auth/auth.service.spec.ts
@@ -31,6 +31,7 @@ type AuthServiceDatabaseMock = {
       where: (...args: unknown[]) => unknown;
     };
   };
+  transaction: <T>(callback: (tx: AuthServiceDatabaseMock) => Promise<T>) => Promise<T>;
 };
 
 type AuthServiceJwtServiceMock = {
@@ -49,7 +50,9 @@ async function createPasswordHash(password: string): Promise<string> {
   return `${salt}:${derivedKey.toString('hex')}`;
 }
 
-function createAuthServiceFixture(options?: { auditService?: Pick<AuditService, 'log'> }) {
+type AuthAuditServiceMock = Pick<AuditService, 'log' | 'logWithClient'>;
+
+function createAuthServiceFixture(options?: { auditService?: AuthAuditServiceMock }) {
   const findFirst = vi.fn();
   const usersReturning = vi.fn();
   const usersValues = vi.fn(() => ({ returning: usersReturning }));
@@ -74,7 +77,7 @@ function createAuthServiceFixture(options?: { auditService?: Pick<AuditService, 
     throw new Error('Unexpected table in mock db.insert');
   });
 
-  const db = {
+  const db: AuthServiceDatabaseMock = {
     query: {
       users: {
         findFirst,
@@ -99,7 +102,10 @@ function createAuthServiceFixture(options?: { auditService?: Pick<AuditService, 
 
       throw new Error('Unexpected table in mock db.delete');
     }),
-  } satisfies AuthServiceDatabaseMock;
+    transaction: vi.fn(async (callback: (tx: AuthServiceDatabaseMock) => Promise<unknown>) =>
+      callback(db),
+    ),
+  };
 
   const cacheService: Partial<ICacheService> = {
     get: vi.fn(async () => null),
@@ -137,13 +143,20 @@ function createAuthServiceFixture(options?: { auditService?: Pick<AuditService, 
     }),
   } satisfies AuthServiceConfigServiceMock;
 
+  const auditService =
+    options?.auditService ??
+    ({
+      log: vi.fn(async () => undefined),
+      logWithClient: vi.fn(async () => undefined),
+    } satisfies AuthAuditServiceMock);
+
   const service = new AuthService(
     db as unknown as Database,
     cacheService as ICacheService,
     createMockStorageService() as unknown as IStorageService,
     jwtService as unknown as JwtService,
     configService as unknown as ConfigService,
-    options?.auditService as AuditService,
+    auditService as AuditService,
   );
 
   return {
@@ -158,7 +171,7 @@ function createAuthServiceFixture(options?: { auditService?: Pick<AuditService, 
       updateWhere,
       cacheService,
       jwtService,
-      auditService: options?.auditService,
+      auditService,
     },
   };
 }
@@ -209,12 +222,13 @@ describe('AuthService', () => {
     expect(insertedUserValues.passwordHash).not.toBe('secret123');
   });
 
-  it('GIVEN audit log failure WHEN registering THEN still returns auth payload', async () => {
+  it('GIVEN audit log failure WHEN registering THEN rejects before issuing tokens', async () => {
     const auditService = {
-      log: vi.fn(async () => {
+      log: vi.fn(async () => undefined),
+      logWithClient: vi.fn(async () => {
         throw new Error('audit unavailable');
       }),
-    } satisfies Pick<AuditService, 'log'>;
+    } satisfies AuthAuditServiceMock;
     const { service, mocks } = createAuthServiceFixture({ auditService });
 
     mocks.findFirst.mockResolvedValueOnce(null);
@@ -232,15 +246,10 @@ describe('AuthService', () => {
       },
     ]);
 
-    const result = await service.register(
-      'alice',
-      'Alice@Example.com',
-      'secret123',
-      '203.0.113.10',
-    );
-
-    expect(result.accessToken).toBe('access-token');
-    expect(result.user.email).toBe('alice@example.com');
+    await expect(
+      service.register('alice', 'Alice@Example.com', 'secret123', '203.0.113.10'),
+    ).rejects.toThrow('audit unavailable');
+    expect(mocks.jwtService.signAsync).not.toHaveBeenCalled();
   });
 
   it('GIVEN existing email WHEN registering THEN throws conflict with AUTH_EMAIL_TAKEN', async () => {
@@ -353,12 +362,13 @@ describe('AuthService', () => {
     expect(result.user.username).toBe('alice');
   });
 
-  it('GIVEN audit log failure WHEN logging in THEN still returns auth payload', async () => {
+  it('GIVEN audit log failure WHEN logging in THEN rejects before issuing tokens', async () => {
     const auditService = {
       log: vi.fn(async () => {
         throw new Error('audit unavailable');
       }),
-    } satisfies Pick<AuditService, 'log'>;
+      logWithClient: vi.fn(async () => undefined),
+    } satisfies AuthAuditServiceMock;
     const { service, mocks } = createAuthServiceFixture({ auditService });
     const passwordHash = await createPasswordHash('secret123');
 
@@ -376,10 +386,10 @@ describe('AuthService', () => {
       updatedAt: new Date('2026-01-01T00:00:00.000Z'),
     });
 
-    const result = await service.login('alice', 'secret123', '203.0.113.10');
-
-    expect(result.accessToken).toBe('access-token');
-    expect(result.user.username).toBe('alice');
+    await expect(service.login('alice', 'secret123', '203.0.113.10')).rejects.toThrow(
+      'audit unavailable',
+    );
+    expect(mocks.jwtService.signAsync).not.toHaveBeenCalled();
   });
 
   it('GIVEN invalid refresh token WHEN refreshing THEN throws unauthorized', async () => {
@@ -423,15 +433,18 @@ describe('AuthService', () => {
     await expect(service.logout('refresh-token')).resolves.toBeUndefined();
   });
 
-  it('GIVEN audit log failure WHEN logging out THEN still completes', async () => {
+  it('GIVEN audit log failure WHEN logging out THEN rejects', async () => {
     const auditService = {
       log: vi.fn(async () => {
         throw new Error('audit unavailable');
       }),
-    } satisfies Pick<AuditService, 'log'>;
+      logWithClient: vi.fn(async () => undefined),
+    } satisfies AuthAuditServiceMock;
     const { service } = createAuthServiceFixture({ auditService });
 
-    await expect(service.logout('refresh-token', '203.0.113.10')).resolves.toBeUndefined();
+    await expect(service.logout('refresh-token', '203.0.113.10')).rejects.toThrow(
+      'audit unavailable',
+    );
   });
 
   it('GIVEN expired refresh tokens WHEN cleanup runs THEN completes without error', async () => {

--- a/apps/control-plane/src/modules/auth/auth.service.spec.ts
+++ b/apps/control-plane/src/modules/auth/auth.service.spec.ts
@@ -9,6 +9,7 @@ import { refreshTokens, users } from '@syncode/db';
 import type { ICacheService, IStorageService } from '@syncode/shared/ports';
 import { describe, expect, it, vi } from 'vitest';
 import { createMockStorageService } from '@/test/mock-factories.js';
+import type { AuditService } from '../admin/audit.service.js';
 import { AuthService } from './auth.service.js';
 
 const scryptAsync = promisify(scrypt);
@@ -48,7 +49,7 @@ async function createPasswordHash(password: string): Promise<string> {
   return `${salt}:${derivedKey.toString('hex')}`;
 }
 
-function createAuthServiceFixture() {
+function createAuthServiceFixture(options?: { auditService?: Pick<AuditService, 'log'> }) {
   const findFirst = vi.fn();
   const usersReturning = vi.fn();
   const usersValues = vi.fn(() => ({ returning: usersReturning }));
@@ -142,6 +143,7 @@ function createAuthServiceFixture() {
     createMockStorageService() as unknown as IStorageService,
     jwtService as unknown as JwtService,
     configService as unknown as ConfigService,
+    options?.auditService as AuditService,
   );
 
   return {
@@ -156,6 +158,7 @@ function createAuthServiceFixture() {
       updateWhere,
       cacheService,
       jwtService,
+      auditService: options?.auditService,
     },
   };
 }
@@ -204,6 +207,40 @@ describe('AuthService', () => {
     };
     expect(insertedUserValues.email).toBe('alice@example.com');
     expect(insertedUserValues.passwordHash).not.toBe('secret123');
+  });
+
+  it('GIVEN audit log failure WHEN registering THEN still returns auth payload', async () => {
+    const auditService = {
+      log: vi.fn(async () => {
+        throw new Error('audit unavailable');
+      }),
+    } satisfies Pick<AuditService, 'log'>;
+    const { service, mocks } = createAuthServiceFixture({ auditService });
+
+    mocks.findFirst.mockResolvedValueOnce(null);
+    mocks.usersReturning.mockResolvedValueOnce([
+      {
+        id: '497f6eca-6276-4993-bfeb-53cbbbba6f08',
+        email: 'alice@example.com',
+        username: 'alice',
+        displayName: null,
+        role: 'user',
+        avatarUrl: null,
+        bio: null,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    ]);
+
+    const result = await service.register(
+      'alice',
+      'Alice@Example.com',
+      'secret123',
+      '203.0.113.10',
+    );
+
+    expect(result.accessToken).toBe('access-token');
+    expect(result.user.email).toBe('alice@example.com');
   });
 
   it('GIVEN existing email WHEN registering THEN throws conflict with AUTH_EMAIL_TAKEN', async () => {
@@ -316,6 +353,35 @@ describe('AuthService', () => {
     expect(result.user.username).toBe('alice');
   });
 
+  it('GIVEN audit log failure WHEN logging in THEN still returns auth payload', async () => {
+    const auditService = {
+      log: vi.fn(async () => {
+        throw new Error('audit unavailable');
+      }),
+    } satisfies Pick<AuditService, 'log'>;
+    const { service, mocks } = createAuthServiceFixture({ auditService });
+    const passwordHash = await createPasswordHash('secret123');
+
+    mocks.findFirst.mockResolvedValueOnce({
+      id: '497f6eca-6276-4993-bfeb-53cbbbba6f08',
+      email: 'alice@example.com',
+      username: 'alice',
+      displayName: null,
+      role: 'user',
+      avatarUrl: null,
+      bio: null,
+      passwordHash,
+      bannedAt: null,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    const result = await service.login('alice', 'secret123', '203.0.113.10');
+
+    expect(result.accessToken).toBe('access-token');
+    expect(result.user.username).toBe('alice');
+  });
+
   it('GIVEN invalid refresh token WHEN refreshing THEN throws unauthorized', async () => {
     const { service, mocks } = createAuthServiceFixture();
     mocks.jwtService.verifyAsync.mockRejectedValueOnce(new Error('invalid'));
@@ -355,6 +421,17 @@ describe('AuthService', () => {
     const { service } = createAuthServiceFixture();
 
     await expect(service.logout('refresh-token')).resolves.toBeUndefined();
+  });
+
+  it('GIVEN audit log failure WHEN logging out THEN still completes', async () => {
+    const auditService = {
+      log: vi.fn(async () => {
+        throw new Error('audit unavailable');
+      }),
+    } satisfies Pick<AuditService, 'log'>;
+    const { service } = createAuthServiceFixture({ auditService });
+
+    await expect(service.logout('refresh-token', '203.0.113.10')).resolves.toBeUndefined();
   });
 
   it('GIVEN expired refresh tokens WHEN cleanup runs THEN completes without error', async () => {

--- a/apps/control-plane/src/modules/auth/auth.service.ts
+++ b/apps/control-plane/src/modules/auth/auth.service.ts
@@ -5,7 +5,6 @@ import {
   Inject,
   Injectable,
   Logger,
-  Optional,
   UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -50,7 +49,7 @@ export class AuthService {
     @Inject(STORAGE_SERVICE) private readonly storageService: IStorageService,
     private readonly jwtService: JwtService,
     private readonly config: ConfigService<EnvConfig>,
-    @Optional() private readonly auditService?: AuditService,
+    private readonly auditService: AuditService,
   ) {}
 
   async register(
@@ -91,38 +90,43 @@ export class AuthService {
     const passwordHash = await this.hashPassword(password);
 
     try {
-      const [createdUser] = await this.db
-        .insert(users)
-        .values({
-          username: normalizedUsername,
-          email: normalizedEmail,
-          passwordHash,
-        })
-        .returning({
-          id: users.id,
-          email: users.email,
-          username: users.username,
-          displayName: users.displayName,
-          role: users.role,
-          avatarUrl: users.avatarUrl,
-          bio: users.bio,
-          createdAt: users.createdAt,
-          updatedAt: users.updatedAt,
+      const createdUser = await this.db.transaction(async (tx) => {
+        const [user] = await tx
+          .insert(users)
+          .values({
+            username: normalizedUsername,
+            email: normalizedEmail,
+            passwordHash,
+          })
+          .returning({
+            id: users.id,
+            email: users.email,
+            username: users.username,
+            displayName: users.displayName,
+            role: users.role,
+            avatarUrl: users.avatarUrl,
+            bio: users.bio,
+            createdAt: users.createdAt,
+            updatedAt: users.updatedAt,
+          });
+
+        if (!user) {
+          throw new Error('Failed to create user');
+        }
+
+        await this.auditService.logWithClient(tx, {
+          actorId: user.id,
+          action: 'auth.register',
+          targetType: 'user',
+          targetId: user.id,
+          metadata: { email: user.email, username: user.username },
+          ipAddress,
         });
 
-      if (!createdUser) {
-        throw new Error('Failed to create user');
-      }
+        return user;
+      });
 
       const tokenPair = await this.issueTokenPair(createdUser.id, createdUser.email);
-      await this.logAuthAudit({
-        actorId: createdUser.id,
-        action: 'auth.register',
-        targetType: 'user',
-        targetId: createdUser.id,
-        metadata: { email: createdUser.email, username: createdUser.username },
-        ipAddress,
-      });
 
       return {
         ...tokenPair,
@@ -200,7 +204,6 @@ export class AuthService {
       });
     }
 
-    const tokenPair = await this.issueTokenPair(user.id, user.email);
     await this.logAuthAudit({
       actorId: user.id,
       action: 'auth.login',
@@ -209,6 +212,7 @@ export class AuthService {
       metadata: { identifierType: normalizedIdentifier.includes('@') ? 'email' : 'username' },
       ipAddress,
     });
+    const tokenPair = await this.issueTokenPair(user.id, user.email);
 
     return {
       ...tokenPair,
@@ -276,16 +280,7 @@ export class AuthService {
   }
 
   private async logAuthAudit(input: AuditLogInput): Promise<void> {
-    if (!this.auditService) {
-      return;
-    }
-
-    try {
-      await this.auditService.log(input);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.logger.warn(`Failed to write auth audit log for ${input.action}: ${message}`);
-    }
+    await this.auditService.log(input);
   }
 
   private async issueTokenPair(

--- a/apps/control-plane/src/modules/auth/auth.service.ts
+++ b/apps/control-plane/src/modules/auth/auth.service.ts
@@ -5,6 +5,7 @@ import {
   Inject,
   Injectable,
   Logger,
+  Optional,
   UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -23,6 +24,7 @@ import { resolveAvatarUrls } from '@/common/resolve-avatar-urls.js';
 import type { EnvConfig } from '@/config/env.config.js';
 import { DB_CLIENT } from '@/modules/db/db.module.js';
 import { toUserProfile } from '@/modules/users/user-profile.mapper.js';
+import { type AuditLogInput, AuditService } from '../admin/audit.service.js';
 
 const scryptAsync = promisify(scrypt);
 
@@ -48,12 +50,14 @@ export class AuthService {
     @Inject(STORAGE_SERVICE) private readonly storageService: IStorageService,
     private readonly jwtService: JwtService,
     private readonly config: ConfigService<EnvConfig>,
+    @Optional() private readonly auditService?: AuditService,
   ) {}
 
   async register(
     username: string,
     email: string,
     password: string,
+    ipAddress?: string,
   ): Promise<{
     accessToken: string;
     refreshToken: string;
@@ -111,6 +115,14 @@ export class AuthService {
       }
 
       const tokenPair = await this.issueTokenPair(createdUser.id, createdUser.email);
+      await this.logAuthAudit({
+        actorId: createdUser.id,
+        action: 'auth.register',
+        targetType: 'user',
+        targetId: createdUser.id,
+        metadata: { email: createdUser.email, username: createdUser.username },
+        ipAddress,
+      });
 
       return {
         ...tokenPair,
@@ -137,6 +149,7 @@ export class AuthService {
   async login(
     identifier: string,
     password: string,
+    ipAddress?: string,
   ): Promise<{
     accessToken: string;
     refreshToken: string;
@@ -188,6 +201,14 @@ export class AuthService {
     }
 
     const tokenPair = await this.issueTokenPair(user.id, user.email);
+    await this.logAuthAudit({
+      actorId: user.id,
+      action: 'auth.login',
+      targetType: 'user',
+      targetId: user.id,
+      metadata: { identifierType: normalizedIdentifier.includes('@') ? 'email' : 'username' },
+      ipAddress,
+    });
 
     return {
       ...tokenPair,
@@ -223,9 +244,17 @@ export class AuthService {
     return this.issueTokenPair(user.id, user.email);
   }
 
-  async logout(refreshToken: string): Promise<void> {
+  async logout(refreshToken: string, ipAddress?: string): Promise<void> {
     const payload = await this.verifyRefreshToken(refreshToken);
     await this.revokeRefreshTokenByPayload(payload);
+    await this.logAuthAudit({
+      actorId: payload.sub,
+      action: 'auth.logout',
+      targetType: 'user',
+      targetId: payload.sub,
+      metadata: { tokenId: payload.jti },
+      ipAddress,
+    });
   }
 
   async revokeAllRefreshTokensForUser(userId: string): Promise<void> {
@@ -244,6 +273,19 @@ export class AuthService {
 
   async cleanupExpiredRefreshTokens(): Promise<void> {
     await this.db.delete(refreshTokens).where(lt(refreshTokens.expiresAt, new Date()));
+  }
+
+  private async logAuthAudit(input: AuditLogInput): Promise<void> {
+    if (!this.auditService) {
+      return;
+    }
+
+    try {
+      await this.auditService.log(input);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Failed to write auth audit log for ${input.action}: ${message}`);
+    }
   }
 
   private async issueTokenPair(

--- a/apps/control-plane/src/modules/users/users.controller.integration.spec.ts
+++ b/apps/control-plane/src/modules/users/users.controller.integration.spec.ts
@@ -18,6 +18,7 @@ import { ZodValidationPipe } from 'nestjs-zod';
 import request from 'supertest';
 import { GlobalExceptionFilter } from '@/common/filters/global-exception.filter.js';
 import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard.js';
+import { AuditService } from '@/modules/admin/audit.service.js';
 import { AuthService } from '@/modules/auth/auth.service.js';
 import { DB_CLIENT } from '@/modules/db/db.module.js';
 import { InMemoryCacheService } from '@/test/in-memory-cache.service.js';
@@ -49,6 +50,7 @@ beforeEach(async () => {
     providers: [
       UsersService,
       AuthService,
+      AuditService,
       JwtAuthGuard,
       JwtStrategy,
       { provide: DB_CLIENT, useValue: db },

--- a/apps/control-plane/src/modules/whiteboard-assets/whiteboard-assets.controller.integration.spec.ts
+++ b/apps/control-plane/src/modules/whiteboard-assets/whiteboard-assets.controller.integration.spec.ts
@@ -12,6 +12,7 @@ import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { GlobalExceptionFilter } from '@/common/filters/global-exception.filter.js';
 import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard.js';
+import { AuditService } from '@/modules/admin/audit.service.js';
 import { AuthService } from '@/modules/auth/auth.service.js';
 import { JwtStrategy } from '@/modules/auth/jwt.strategy.js';
 import { DB_CLIENT } from '@/modules/db/db.module.js';
@@ -60,6 +61,7 @@ beforeEach(async () => {
     providers: [
       WhiteboardAssetsService,
       AuthService,
+      AuditService,
       JwtAuthGuard,
       JwtStrategy,
       { provide: DB_CLIENT, useValue: db },

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,7 +44,7 @@ services:
     restart: unless-stopped
     env_file: .env
     environment:
-      TRUSTED_PROXIES: ${TRUSTED_PROXIES:-loopback,linklocal,uniquelocal}
+      TRUSTED_PROXIES: ${TRUSTED_PROXIES:?TRUSTED_PROXIES must name the exact nginx/proxy CIDR trusted by control-plane}
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     depends_on:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -43,6 +43,8 @@ services:
       dockerfile: infra/docker/Dockerfile.control-plane
     restart: unless-stopped
     env_file: .env
+    environment:
+      TRUSTED_PROXIES: ${TRUSTED_PROXIES:-loopback,linklocal,uniquelocal}
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     depends_on:

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -29,8 +29,8 @@ http {
 
     client_max_body_size 10m;
 
-    # Trust X-Forwarded-* headers from the VPS reverse proxy.
-    # TODO: Narrow down to proxy VPS IP.
+    # Trust X-Forwarded-* only from the TLS-terminating VPS proxy.
+    # Control-plane must separately set TRUSTED_PROXIES to this nginx hop's exact CIDR/IP.
     set_real_ip_from 10.0.0.0/8;
     set_real_ip_from 172.16.0.0/12;
     set_real_ip_from 192.168.0.0/16;

--- a/packages/contracts/src/control/admin-audit.ts
+++ b/packages/contracts/src/control/admin-audit.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { paginationSchema } from './pagination.js';
+
+export const auditActorSchema = z.object({
+  id: z.uuid(),
+  username: z.string(),
+  email: z.email(),
+  displayName: z.string().nullable(),
+});
+
+export type AuditActor = z.infer<typeof auditActorSchema>;
+
+export const auditLogSchema = z.object({
+  id: z.uuid(),
+  actorId: z.uuid().nullable(),
+  actor: auditActorSchema.nullable(),
+  action: z.string(),
+  targetType: z.string(),
+  targetId: z.string(),
+  metadata: z.unknown().nullable(),
+  ipAddress: z.string().nullable(),
+  createdAt: z.iso.datetime(),
+});
+
+export type AuditLog = z.infer<typeof auditLogSchema>;
+
+export const adminAuditLogsQuerySchema = z.object({
+  cursor: z.string().optional().describe('Opaque pagination cursor'),
+  limit: z.coerce.number().int().min(1).max(100).default(20).describe('Page size'),
+  search: z.string().trim().max(100).optional().describe('Search action, target, or actor'),
+  action: z.string().trim().max(100).optional().describe('Filter by action'),
+  actorId: z.uuid().optional().describe('Filter by actor user ID'),
+  targetId: z.string().trim().max(255).optional().describe('Filter by target ID'),
+  from: z.iso.datetime().optional().describe('Created-at lower bound'),
+  to: z.iso.datetime().optional().describe('Created-at upper bound'),
+});
+
+export type AdminAuditLogsQuery = z.infer<typeof adminAuditLogsQuerySchema>;
+
+export const adminAuditLogsResponseSchema = z.object({
+  data: z.array(auditLogSchema),
+  pagination: paginationSchema,
+});
+
+export type AdminAuditLogsResponse = z.infer<typeof adminAuditLogsResponseSchema>;

--- a/packages/contracts/src/control/index.ts
+++ b/packages/contracts/src/control/index.ts
@@ -1,4 +1,5 @@
 export * from './admin.js';
+export * from './admin-audit.js';
 export * from './auth.js';
 export * from './bookmarks.js';
 export * from './error.js';

--- a/packages/contracts/src/control/routes.ts
+++ b/packages/contracts/src/control/routes.ts
@@ -6,6 +6,7 @@ import type {
   adminUsersQuerySchema,
   adminUsersResponseSchema,
 } from './admin.js';
+import type { adminAuditLogsQuerySchema, adminAuditLogsResponseSchema } from './admin-audit.js';
 import type {
   accessTokenResponseSchema,
   loginResponseSchema,
@@ -81,6 +82,10 @@ import type {
 
 export const CONTROL_API = {
   ADMIN: {
+    AUDIT_LOGS: defineRoute<
+      z.infer<typeof adminAuditLogsQuerySchema>,
+      z.infer<typeof adminAuditLogsResponseSchema>
+    >()('admin/audit-logs', 'GET'),
     USERS: {
       LIST: defineRoute<
         z.infer<typeof adminUsersQuerySchema>,


### PR DESCRIPTION
Closes #198
Adds audit logging service, auth audit hooks, admin audit log query endpoint, pagination/search/filtering, and integration tests.