### PR TITLE
Feat/admin audit log viewer

### DIFF
--- a/apps/web/src/locales/en/admin.json
+++ b/apps/web/src/locales/en/admin.json
@@ -1,5 +1,9 @@
 {
   "nav": "Admin",
+  "navLinks": {
+    "users": "Users",
+    "auditLogs": "Audit logs"
+  },
   "users": {
     "heading": "User management",
     "sub": "Review accounts, search by identity, and control access for banned users.",
@@ -63,5 +67,60 @@
       "next": "Next",
       "ariaLabel": "User pages"
     }
+  },
+  "audit": {
+    "heading": "Audit logs",
+    "sub": "Search sensitive activity across authentication, account, and admin operations.",
+    "forbidden": {
+      "title": "Admin access required",
+      "description": "This area is only available to SynCode administrators."
+    },
+    "filters": {
+      "searchLabel": "Search",
+      "searchPlaceholder": "Search actor, action, or target",
+      "actionLabel": "Action",
+      "actionPlaceholder": "auth.login",
+      "fromLabel": "From",
+      "toLabel": "To",
+      "datePlaceholder": "Pick date",
+      "previousMonth": "Previous month",
+      "nextMonth": "Next month",
+      "selectDate": "Select {{date}}",
+      "clearDate": "Clear date",
+      "clear": "Clear"
+    },
+    "table": {
+      "timestamp": "Timestamp",
+      "actor": "Actor",
+      "action": "Action",
+      "target": "Target",
+      "ip": "IP",
+      "details": "Details"
+    },
+    "actions": {
+      "refresh": "Refresh",
+      "expand": "Show details",
+      "collapse": "Hide details"
+    },
+    "empty": {
+      "title": "No audit logs found",
+      "description": "Try widening your search or date range."
+    },
+    "feedback": {
+      "loadErrorTitle": "Audit logs failed to load",
+      "loadError": "Could not load audit logs."
+    },
+    "metadata": {
+      "title": "Metadata",
+      "empty": "No metadata"
+    },
+    "pagination": {
+      "summary": "{{count}} logs on this page",
+      "previous": "Previous",
+      "next": "Next",
+      "ariaLabel": "Audit log pages"
+    },
+    "unknownActor": "System",
+    "emptyValue": "None"
   }
 }

--- a/apps/web/src/locales/zh/admin.json
+++ b/apps/web/src/locales/zh/admin.json
@@ -1,5 +1,9 @@
 {
   "nav": "\u7ba1\u7406",
+  "navLinks": {
+    "users": "\u7528\u6237",
+    "auditLogs": "\u5ba1\u8ba1\u65e5\u5fd7"
+  },
   "users": {
     "heading": "\u7528\u6237\u7ba1\u7406",
     "sub": "\u67e5\u770b\u8d26\u6237\u3001\u6309\u8eab\u4efd\u641c\u7d22\uff0c\u5e76\u7ba1\u7406\u88ab\u7981\u7528\u7528\u6237\u7684\u8bbf\u95ee\u6743\u9650\u3002",
@@ -63,5 +67,60 @@
       "next": "\u4e0b\u4e00\u9875",
       "ariaLabel": "\u7528\u6237\u5206\u9875"
     }
+  },
+  "audit": {
+    "heading": "\u5ba1\u8ba1\u65e5\u5fd7",
+    "sub": "\u641c\u7d22\u8eab\u4efd\u9a8c\u8bc1\u3001\u8d26\u6237\u548c\u7ba1\u7406\u64cd\u4f5c\u4e2d\u7684\u654f\u611f\u6d3b\u52a8\u3002",
+    "forbidden": {
+      "title": "\u9700\u8981\u7ba1\u7406\u5458\u6743\u9650",
+      "description": "\u8be5\u533a\u57df\u4ec5\u5bf9 SynCode \u7ba1\u7406\u5458\u5f00\u653e\u3002"
+    },
+    "filters": {
+      "searchLabel": "\u641c\u7d22",
+      "searchPlaceholder": "\u641c\u7d22\u64cd\u4f5c\u4eba\u3001\u52a8\u4f5c\u6216\u76ee\u6807",
+      "actionLabel": "\u52a8\u4f5c",
+      "actionPlaceholder": "auth.login",
+      "fromLabel": "\u5f00\u59cb",
+      "toLabel": "\u7ed3\u675f",
+      "datePlaceholder": "\u9009\u62e9\u65e5\u671f",
+      "previousMonth": "\u4e0a\u4e00\u4e2a\u6708",
+      "nextMonth": "\u4e0b\u4e00\u4e2a\u6708",
+      "selectDate": "\u9009\u62e9 {{date}}",
+      "clearDate": "\u6e05\u9664\u65e5\u671f",
+      "clear": "\u6e05\u9664"
+    },
+    "table": {
+      "timestamp": "\u65f6\u95f4",
+      "actor": "\u64cd\u4f5c\u4eba",
+      "action": "\u52a8\u4f5c",
+      "target": "\u76ee\u6807",
+      "ip": "IP",
+      "details": "\u8be6\u60c5"
+    },
+    "actions": {
+      "refresh": "\u5237\u65b0",
+      "expand": "\u663e\u793a\u8be6\u60c5",
+      "collapse": "\u9690\u85cf\u8be6\u60c5"
+    },
+    "empty": {
+      "title": "\u672a\u627e\u5230\u5ba1\u8ba1\u65e5\u5fd7",
+      "description": "\u8bf7\u653e\u5bbd\u641c\u7d22\u6216\u65e5\u671f\u8303\u56f4\u3002"
+    },
+    "feedback": {
+      "loadErrorTitle": "\u5ba1\u8ba1\u65e5\u5fd7\u52a0\u8f7d\u5931\u8d25",
+      "loadError": "\u65e0\u6cd5\u52a0\u8f7d\u5ba1\u8ba1\u65e5\u5fd7\u3002"
+    },
+    "metadata": {
+      "title": "\u5143\u6570\u636e",
+      "empty": "\u65e0\u5143\u6570\u636e"
+    },
+    "pagination": {
+      "summary": "\u672c\u9875 {{count}} \u6761\u65e5\u5fd7",
+      "previous": "\u4e0a\u4e00\u9875",
+      "next": "\u4e0b\u4e00\u9875",
+      "ariaLabel": "\u5ba1\u8ba1\u65e5\u5fd7\u5206\u9875"
+    },
+    "unknownActor": "\u7cfb\u7edf",
+    "emptyValue": "\u65e0"
   }
 }

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as AppRoomsRoomIdRouteImport } from './routes/_app/rooms_.$roomId
 import { Route as AppRoomsBrowseRouteImport } from './routes/_app/rooms/browse'
 import { Route as AppProblemsProblemIdRouteImport } from './routes/_app/problems.$problemId'
 import { Route as AppAdminUsersRouteImport } from './routes/_app/admin.users'
+import { Route as AppAdminAuditLogsRouteImport } from './routes/_app/admin.audit-logs'
 
 const PublicRouteRoute = PublicRouteRouteImport.update({
   id: '/_public',
@@ -110,6 +111,11 @@ const AppAdminUsersRoute = AppAdminUsersRouteImport.update({
   path: '/admin/users',
   getParentRoute: () => AppRouteRoute,
 } as any)
+const AppAdminAuditLogsRoute = AppAdminAuditLogsRouteImport.update({
+  id: '/admin/audit-logs',
+  path: '/admin/audit-logs',
+  getParentRoute: () => AppRouteRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof PublicIndexRoute
@@ -119,6 +125,7 @@ export interface FileRoutesByFullPath {
   '/profile': typeof AppProfileRoute
   '/login': typeof PublicLoginRoute
   '/register': typeof PublicRegisterRoute
+  '/admin/audit-logs': typeof AppAdminAuditLogsRoute
   '/admin/users': typeof AppAdminUsersRoute
   '/problems/$problemId': typeof AppProblemsProblemIdRoute
   '/rooms/browse': typeof AppRoomsBrowseRoute
@@ -135,6 +142,7 @@ export interface FileRoutesByTo {
   '/profile': typeof AppProfileRoute
   '/login': typeof PublicLoginRoute
   '/register': typeof PublicRegisterRoute
+  '/admin/audit-logs': typeof AppAdminAuditLogsRoute
   '/admin/users': typeof AppAdminUsersRoute
   '/problems/$problemId': typeof AppProblemsProblemIdRoute
   '/rooms/browse': typeof AppRoomsBrowseRoute
@@ -155,6 +163,7 @@ export interface FileRoutesById {
   '/_public/login': typeof PublicLoginRoute
   '/_public/register': typeof PublicRegisterRoute
   '/_public/': typeof PublicIndexRoute
+  '/_app/admin/audit-logs': typeof AppAdminAuditLogsRoute
   '/_app/admin/users': typeof AppAdminUsersRoute
   '/_app/problems/$problemId': typeof AppProblemsProblemIdRoute
   '/_app/rooms/browse': typeof AppRoomsBrowseRoute
@@ -174,6 +183,7 @@ export interface FileRouteTypes {
     | '/profile'
     | '/login'
     | '/register'
+    | '/admin/audit-logs'
     | '/admin/users'
     | '/problems/$problemId'
     | '/rooms/browse'
@@ -190,6 +200,7 @@ export interface FileRouteTypes {
     | '/profile'
     | '/login'
     | '/register'
+    | '/admin/audit-logs'
     | '/admin/users'
     | '/problems/$problemId'
     | '/rooms/browse'
@@ -209,6 +220,7 @@ export interface FileRouteTypes {
     | '/_public/login'
     | '/_public/register'
     | '/_public/'
+    | '/_app/admin/audit-logs'
     | '/_app/admin/users'
     | '/_app/problems/$problemId'
     | '/_app/rooms/browse'
@@ -345,6 +357,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppAdminUsersRouteImport
       parentRoute: typeof AppRouteRoute
     }
+    '/_app/admin/audit-logs': {
+      id: '/_app/admin/audit-logs'
+      path: '/admin/audit-logs'
+      fullPath: '/admin/audit-logs'
+      preLoaderRoute: typeof AppAdminAuditLogsRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
   }
 }
 
@@ -367,6 +386,7 @@ interface AppRouteRouteChildren {
   AppBookmarksRoute: typeof AppBookmarksRoute
   AppDashboardRoute: typeof AppDashboardRoute
   AppProfileRoute: typeof AppProfileRoute
+  AppAdminAuditLogsRoute: typeof AppAdminAuditLogsRoute
   AppAdminUsersRoute: typeof AppAdminUsersRoute
   AppProblemsProblemIdRoute: typeof AppProblemsProblemIdRoute
   AppRoomsRoomIdRoute: typeof AppRoomsRoomIdRoute
@@ -380,6 +400,7 @@ const AppRouteRouteChildren: AppRouteRouteChildren = {
   AppBookmarksRoute: AppBookmarksRoute,
   AppDashboardRoute: AppDashboardRoute,
   AppProfileRoute: AppProfileRoute,
+  AppAdminAuditLogsRoute: AppAdminAuditLogsRoute,
   AppAdminUsersRoute: AppAdminUsersRoute,
   AppProblemsProblemIdRoute: AppProblemsProblemIdRoute,
   AppRoomsRoomIdRoute: AppRoomsRoomIdRoute,

--- a/apps/web/src/routes/_app/-admin.audit-logs.spec.tsx
+++ b/apps/web/src/routes/_app/-admin.audit-logs.spec.tsx
@@ -1,0 +1,242 @@
+import { type AdminAuditLogsResponse, type AuditLog, CONTROL_API } from '@syncode/contracts';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (config: unknown) => config,
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/lib/api-client.js', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api-client.js')>('@/lib/api-client.js');
+  return {
+    ...actual,
+    api: vi.fn(),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'en', resolvedLanguage: 'en' },
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (options?.count !== undefined) return `${key}:${String(options.count)}`;
+      if (options?.date !== undefined) return `${key}:${String(options.date)}`;
+      return key;
+    },
+  }),
+}));
+
+let authUser: { id: string; role: 'admin' | 'user' } | null = { id: 'admin-1', role: 'admin' };
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: (
+    selector: (state: { user: { id: string; role: 'admin' | 'user' } | null }) => unknown,
+  ) => selector({ user: authUser }),
+}));
+
+import { api } from '@/lib/api-client.js';
+import { AdminAuditLogsPage } from './admin.audit-logs.js';
+
+const apiMock = vi.mocked(api);
+
+function makeLog(overrides: Partial<AuditLog> = {}): AuditLog {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    actorId: '22222222-2222-4222-8222-222222222222',
+    actor: {
+      id: '22222222-2222-4222-8222-222222222222',
+      username: 'admin',
+      email: 'admin@example.com',
+      displayName: 'Admin User',
+    },
+    action: 'auth.login',
+    targetType: 'user',
+    targetId: '22222222-2222-4222-8222-222222222222',
+    metadata: { method: 'password' },
+    ipAddress: '203.0.113.10',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeResponse(logs: AuditLog[], hasMore = false): AdminAuditLogsResponse {
+  return {
+    data: logs,
+    pagination: { hasMore, nextCursor: hasMore ? 'next-cursor' : null },
+  };
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return {
+    client,
+    ...render(
+      <QueryClientProvider client={client}>
+        <AdminAuditLogsPage />
+      </QueryClientProvider>,
+    ),
+  };
+}
+
+describe('AdminAuditLogsPage', () => {
+  beforeEach(() => {
+    apiMock.mockReset();
+    authUser = { id: 'admin-1', role: 'admin' };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('GIVEN a non-admin user WHEN rendering THEN shows forbidden state and does not query logs', () => {
+    authUser = { id: 'user-1', role: 'user' };
+
+    renderPage();
+
+    expect(screen.getByText('audit.forbidden.title')).toBeInTheDocument();
+    expect(apiMock).not.toHaveBeenCalled();
+  });
+
+  it('GIVEN search changes WHEN the next query is pending THEN stale logs are hidden', async () => {
+    let resolveNext: (value: AdminAuditLogsResponse) => void = () => undefined;
+    apiMock
+      .mockResolvedValueOnce(makeResponse([makeLog({ action: 'auth.login' })]))
+      .mockImplementationOnce(
+        () =>
+          new Promise<AdminAuditLogsResponse>((resolve) => {
+            resolveNext = resolve;
+          }) as never,
+      );
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(await screen.findByText('auth.login')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('audit.filters.searchLabel'), 'ban');
+
+    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText('auth.login')).not.toBeInTheDocument();
+    expect(screen.getAllByText('loading')).not.toHaveLength(0);
+
+    await act(async () => {
+      resolveNext(makeResponse([makeLog({ action: 'admin.user.ban' })]));
+    });
+
+    expect(await screen.findByText('admin.user.ban')).toBeInTheDocument();
+  });
+
+  it('GIVEN filters and pagination change WHEN querying THEN sends search, action, date, limit, and cursor params', async () => {
+    apiMock.mockResolvedValue(makeResponse([makeLog()], true));
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(await screen.findByText('auth.login')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(apiMock).toHaveBeenCalledWith(CONTROL_API.ADMIN.AUDIT_LOGS, {
+        searchParams: {
+          action: undefined,
+          cursor: undefined,
+          from: undefined,
+          limit: 20,
+          search: undefined,
+          to: undefined,
+        },
+      });
+    });
+
+    await user.type(screen.getByLabelText('audit.filters.searchLabel'), 'admin');
+    await user.type(screen.getByLabelText('audit.filters.actionLabel'), 'auth.login');
+    fireEvent.change(screen.getByLabelText('audit.filters.fromLabel'), {
+      target: { value: '2026-01-02' },
+    });
+
+    await waitFor(() => {
+      const hasFilteredCall = apiMock.mock.calls.some(
+        ([route, options]) =>
+          route === CONTROL_API.ADMIN.AUDIT_LOGS &&
+          options?.searchParams?.search === 'admin' &&
+          options.searchParams.action === 'auth.login' &&
+          typeof options.searchParams.from === 'string',
+      );
+      expect(hasFilteredCall).toBe(true);
+    });
+
+    await user.click(screen.getByRole('button', { name: 'audit.pagination.next' }));
+
+    await waitFor(() => {
+      const hasCursorCall = apiMock.mock.calls.some(
+        ([route, options]) =>
+          route === CONTROL_API.ADMIN.AUDIT_LOGS && options?.searchParams?.cursor === 'next-cursor',
+      );
+      expect(hasCursorCall).toBe(true);
+    });
+  });
+
+  it('GIVEN an audit row WHEN details are toggled THEN metadata is expanded with aria state', async () => {
+    apiMock.mockResolvedValue(makeResponse([makeLog({ metadata: { reason: 'policy' } })]));
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(await screen.findByText('auth.login')).toBeInTheDocument();
+    const detailsButton = screen.getByRole('button', { name: 'audit.actions.expand' });
+
+    await user.click(detailsButton);
+
+    expect(detailsButton).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText(/policy/)).toBeInTheDocument();
+  });
+
+  it('GIVEN rows are visible WHEN refresh fails THEN shows the load error instead of silently keeping stale data', async () => {
+    apiMock
+      .mockResolvedValueOnce(makeResponse([makeLog({ action: 'auth.login' })]))
+      .mockRejectedValueOnce(new Error('failed'));
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(await screen.findByText('auth.login')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'audit.actions.refresh' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('audit.feedback.loadError');
+    expect(screen.getByText('auth.login')).toBeInTheDocument();
+  });
+
+  it('GIVEN initial load fails WHEN no rows are cached THEN shows an error alert instead of empty results', async () => {
+    apiMock.mockRejectedValue(new Error('failed'));
+
+    renderPage();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('audit.feedback.loadErrorTitle');
+    expect(screen.getByRole('alert')).toHaveTextContent('audit.feedback.loadError');
+    expect(screen.queryByText('audit.empty.title')).not.toBeInTheDocument();
+  });
+
+  it('GIVEN the page renders THEN admin navigation and pagination use accessible localized labels', async () => {
+    apiMock.mockResolvedValue(makeResponse([makeLog()], true));
+
+    renderPage();
+
+    expect(await screen.findByText('auth.login')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'navLinks.users' })).toHaveAttribute(
+      'href',
+      '/admin/users',
+    );
+    expect(
+      screen.getByRole('navigation', { name: 'audit.pagination.ariaLabel' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'audit.pagination.previous' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'audit.pagination.next' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/_app/-admin.users.spec.tsx
+++ b/apps/web/src/routes/_app/-admin.users.spec.tsx
@@ -6,6 +6,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@tanstack/react-router', () => ({
   createFileRoute: () => (config: unknown) => config,
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
 }));
 
 vi.mock('@/lib/api-client.js', async () => {

--- a/apps/web/src/routes/_app/admin.audit-logs.tsx
+++ b/apps/web/src/routes/_app/admin.audit-logs.tsx
@@ -1,0 +1,461 @@
+import { type AdminAuditLogsQuery, type AuditLog, CONTROL_API } from '@syncode/contracts';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Input,
+  Label,
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationNext,
+  PaginationPrevious,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@syncode/ui';
+import { useQuery } from '@tanstack/react-query';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { ChevronDown, ChevronRight, Loader2, RefreshCw, Search, ShieldAlert } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { api } from '@/lib/api-client.js';
+import { useAuthStore } from '@/stores/auth.store.js';
+
+export const Route = createFileRoute('/_app/admin/audit-logs')({
+  component: AdminAuditLogsPage,
+});
+
+const PAGE_SIZE = 20;
+const FILTER_DEBOUNCE_MS = 300;
+
+function createPaginationState() {
+  return {
+    currentCursor: undefined as string | undefined,
+    cursorHistory: [] as Array<string | undefined>,
+  };
+}
+
+export function AdminAuditLogsPage() {
+  const { t } = useTranslation('admin');
+  const { t: tCommon } = useTranslation('common');
+  const user = useAuthStore((state) => state.user);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [action, setAction] = useState('');
+  const [debouncedAction, setDebouncedAction] = useState('');
+  const [fromDate, setFromDate] = useState('');
+  const [toDate, setToDate] = useState('');
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [paginationState, setPaginationState] = useState(createPaginationState);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setDebouncedSearch(search);
+      setDebouncedAction(action);
+    }, FILTER_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [action, search]);
+
+  const query = useMemo<AdminAuditLogsQuery>(
+    () => ({
+      cursor: paginationState.currentCursor,
+      limit: PAGE_SIZE,
+      search: debouncedSearch.trim() || undefined,
+      action: debouncedAction.trim() || undefined,
+      from: toIsoDateTime(fromDate, 'start'),
+      to: toIsoDateTime(toDate, 'end'),
+    }),
+    [debouncedAction, debouncedSearch, fromDate, paginationState.currentCursor, toDate],
+  );
+
+  const auditQuery = useQuery({
+    queryKey: ['admin', 'audit-logs', query],
+    enabled: user?.role === 'admin',
+    queryFn: () => api(CONTROL_API.ADMIN.AUDIT_LOGS, { searchParams: query }),
+  });
+
+  if (user?.role !== 'admin') {
+    return (
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:py-10 lg:py-12">
+        <Card className="border border-border/50 bg-card/80 py-0 backdrop-blur-sm">
+          <CardContent className="flex min-h-80 flex-col items-center justify-center px-6 py-12 text-center">
+            <div className="mb-4 inline-flex size-12 items-center justify-center rounded-full border border-destructive/25 bg-destructive/10 text-destructive">
+              <ShieldAlert className="size-5" />
+            </div>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">
+              {t('audit.forbidden.title')}
+            </h1>
+            <p className="mt-3 max-w-md text-sm leading-relaxed text-muted-foreground">
+              {t('audit.forbidden.description')}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const areTextFiltersSettling =
+    search.trim() !== debouncedSearch.trim() || action.trim() !== debouncedAction.trim();
+  const isAuditLoading = auditQuery.isLoading || areTextFiltersSettling;
+  const isAuditFetching = auditQuery.isFetching || areTextFiltersSettling;
+  const logs = areTextFiltersSettling ? [] : (auditQuery.data?.data ?? []);
+  const nextCursor = auditQuery.data?.pagination.nextCursor ?? null;
+  const hasNextPage = auditQuery.data?.pagination.hasMore === true && nextCursor !== null;
+  const hasPreviousPage = paginationState.cursorHistory.length > 0;
+
+  const resetFilters = () => {
+    setSearch('');
+    setAction('');
+    setFromDate('');
+    setToDate('');
+    setExpandedId(null);
+    setPaginationState(createPaginationState());
+  };
+
+  const resetPagination = () => {
+    setExpandedId(null);
+    setPaginationState(createPaginationState());
+  };
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8 sm:py-10 lg:py-12">
+      <section className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div className="max-w-3xl">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {t('audit.heading')}
+          </h1>
+          <p className="mt-3 text-sm text-muted-foreground sm:text-base">{t('audit.sub')}</p>
+        </div>
+        <div className="flex flex-wrap gap-2 self-start md:self-auto">
+          <Button variant="outline" asChild>
+            <Link to="/admin/users">{t('navLinks.users')}</Link>
+          </Button>
+          <Button
+            variant="outline"
+            className="gap-2"
+            disabled={isAuditFetching}
+            onClick={() => {
+              auditQuery.refetch().catch(() => undefined);
+            }}
+          >
+            <RefreshCw className="size-4" />
+            {t('audit.actions.refresh')}
+          </Button>
+        </div>
+      </section>
+
+      <section className="mt-8 grid gap-4 rounded-xl border border-border/50 bg-card/50 p-4 backdrop-blur-sm md:grid-cols-[minmax(0,1fr)_180px_160px_160px_auto] md:items-end">
+        <div className="space-y-2">
+          <Label htmlFor="audit-search">{t('audit.filters.searchLabel')}</Label>
+          <div className="relative">
+            <Search className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-3 size-4 text-muted-foreground" />
+            <Input
+              id="audit-search"
+              value={search}
+              placeholder={t('audit.filters.searchPlaceholder')}
+              className="pl-9"
+              onChange={(event) => {
+                setSearch(event.target.value);
+                resetPagination();
+              }}
+            />
+          </div>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="audit-action">{t('audit.filters.actionLabel')}</Label>
+          <Input
+            id="audit-action"
+            value={action}
+            placeholder={t('audit.filters.actionPlaceholder')}
+            onChange={(event) => {
+              setAction(event.target.value);
+              resetPagination();
+            }}
+          />
+        </div>
+        <div className="space-y-2">
+          <DateFilterPicker
+            id="audit-from"
+            label={t('audit.filters.fromLabel')}
+            value={fromDate}
+            onChange={(value) => {
+              setFromDate(value);
+              resetPagination();
+            }}
+          />
+        </div>
+        <div className="space-y-2">
+          <DateFilterPicker
+            id="audit-to"
+            label={t('audit.filters.toLabel')}
+            value={toDate}
+            onChange={(value) => {
+              setToDate(value);
+              resetPagination();
+            }}
+          />
+        </div>
+        <Button variant="outline" onClick={resetFilters}>
+          {t('audit.filters.clear')}
+        </Button>
+      </section>
+
+      <Card
+        className="mt-5 gap-0 overflow-hidden border border-border/50 bg-card/80 py-0 backdrop-blur-sm"
+        aria-busy={isAuditFetching}
+      >
+        {auditQuery.isError && logs.length > 0 ? (
+          <div
+            className="border-b border-destructive/20 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+            role="alert"
+          >
+            {t('audit.feedback.loadError')}
+          </div>
+        ) : null}
+
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead className="w-42">{t('audit.table.timestamp')}</TableHead>
+                <TableHead className="min-w-56">{t('audit.table.actor')}</TableHead>
+                <TableHead className="w-44">{t('audit.table.action')}</TableHead>
+                <TableHead className="min-w-56">{t('audit.table.target')}</TableHead>
+                <TableHead className="w-34">{t('audit.table.ip')}</TableHead>
+                <TableHead className="w-24 text-right">{t('audit.table.details')}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {logs.map((log) => (
+                <AuditLogRows
+                  key={log.id}
+                  log={log}
+                  isExpanded={expandedId === log.id}
+                  onToggle={() => setExpandedId(expandedId === log.id ? null : log.id)}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {isAuditLoading ? (
+          <div className="flex min-h-60 items-center justify-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" />
+            {tCommon('loading')}
+          </div>
+        ) : null}
+
+        {!isAuditLoading && logs.length === 0 ? (
+          <div
+            className="flex min-h-60 flex-col items-center justify-center px-6 py-12 text-center"
+            role={auditQuery.isError ? 'alert' : undefined}
+          >
+            <h2 className="text-lg font-semibold tracking-tight text-foreground">
+              {auditQuery.isError ? t('audit.feedback.loadErrorTitle') : t('audit.empty.title')}
+            </h2>
+            <p className="mt-2 max-w-md text-sm text-muted-foreground">
+              {auditQuery.isError ? t('audit.feedback.loadError') : t('audit.empty.description')}
+            </p>
+          </div>
+        ) : null}
+      </Card>
+
+      <div className="flex flex-col gap-3 pt-5 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-muted-foreground">
+          {t('audit.pagination.summary', { count: logs.length })}
+        </p>
+        <Pagination className="justify-end" aria-label={t('audit.pagination.ariaLabel')}>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                aria-label={t('audit.pagination.previous')}
+                disabled={!hasPreviousPage || isAuditFetching}
+                onClick={() => {
+                  if (!hasPreviousPage || isAuditFetching) return;
+                  setExpandedId(null);
+                  setPaginationState((current) => ({
+                    currentCursor: current.cursorHistory.at(-1),
+                    cursorHistory: current.cursorHistory.slice(0, -1),
+                  }));
+                }}
+              >
+                {t('audit.pagination.previous')}
+              </PaginationPrevious>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationNext
+                aria-label={t('audit.pagination.next')}
+                disabled={!hasNextPage || isAuditFetching}
+                onClick={() => {
+                  if (!hasNextPage || !nextCursor || isAuditFetching) return;
+                  setExpandedId(null);
+                  setPaginationState((current) => ({
+                    currentCursor: nextCursor,
+                    cursorHistory: [...current.cursorHistory, current.currentCursor],
+                  }));
+                }}
+              >
+                {t('audit.pagination.next')}
+              </PaginationNext>
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </div>
+      <output className="sr-only" aria-live="polite" aria-atomic="true">
+        {auditQuery.isError
+          ? ''
+          : isAuditLoading
+            ? tCommon('loading')
+            : t('audit.pagination.summary', { count: logs.length })}
+      </output>
+    </div>
+  );
+}
+
+function DateFilterPicker({
+  id,
+  label,
+  value,
+  onChange,
+}: {
+  readonly id: string;
+  readonly label: string;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Input id={id} type="date" value={value} onChange={(event) => onChange(event.target.value)} />
+    </div>
+  );
+}
+
+function AuditLogRows({
+  log,
+  isExpanded,
+  onToggle,
+}: {
+  readonly log: AuditLog;
+  readonly isExpanded: boolean;
+  readonly onToggle: () => void;
+}) {
+  const { i18n, t } = useTranslation('admin');
+  const actorName = log.actor?.displayName || log.actor?.username || t('audit.unknownActor');
+  const metadata = formatMetadata(log.metadata, t('audit.metadata.empty'));
+  const dateLocale = getDateLocale(i18n.resolvedLanguage ?? i18n.language);
+  const detailsId = `audit-log-details-${log.id}`;
+
+  return (
+    <>
+      <TableRow>
+        <TableCell className="text-sm text-muted-foreground">
+          {new Intl.DateTimeFormat(dateLocale, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+          }).format(new Date(log.createdAt))}
+        </TableCell>
+        <TableCell>
+          <div className="min-w-0">
+            <div className="truncate font-medium text-foreground">{actorName}</div>
+            <div className="truncate text-xs text-muted-foreground">
+              {log.actor?.email ?? t('audit.emptyValue')}
+            </div>
+          </div>
+        </TableCell>
+        <TableCell>
+          <Badge variant="outline">{log.action}</Badge>
+        </TableCell>
+        <TableCell className="text-sm">
+          <div className="truncate font-mono text-xs text-foreground">{log.targetId}</div>
+          <div className="text-xs text-muted-foreground">{log.targetType}</div>
+        </TableCell>
+        <TableCell className="text-sm text-muted-foreground">
+          {log.ipAddress ?? t('audit.emptyValue')}
+        </TableCell>
+        <TableCell className="text-right">
+          <Button
+            size="sm"
+            variant="ghost"
+            aria-controls={detailsId}
+            aria-expanded={isExpanded}
+            onClick={onToggle}
+          >
+            {isExpanded ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
+            {isExpanded ? t('audit.actions.collapse') : t('audit.actions.expand')}
+          </Button>
+        </TableCell>
+      </TableRow>
+      {isExpanded ? (
+        <TableRow className="bg-muted/20 hover:bg-muted/20">
+          <TableCell colSpan={6}>
+            <div id={detailsId} className="rounded-lg border border-border/50 bg-background/70 p-4">
+              <div className="mb-2 text-xs font-semibold uppercase text-muted-foreground">
+                {t('audit.metadata.title')}
+              </div>
+              <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-md bg-black/40 p-3 font-mono text-xs leading-relaxed text-foreground">
+                {metadata}
+              </pre>
+            </div>
+          </TableCell>
+        </TableRow>
+      ) : null}
+    </>
+  );
+}
+
+function toIsoDateTime(value: string, boundary: 'start' | 'end') {
+  const date = parseDateValue(value);
+  if (!date) {
+    return undefined;
+  }
+
+  if (boundary === 'start') {
+    date.setHours(0, 0, 0, 0);
+  } else {
+    date.setHours(23, 59, 59, 999);
+  }
+
+  return date.toISOString();
+}
+
+function formatMetadata(metadata: unknown, emptyLabel: string) {
+  if (metadata === null || metadata === undefined) {
+    return emptyLabel;
+  }
+
+  try {
+    return JSON.stringify(metadata, null, 2);
+  } catch {
+    return String(metadata);
+  }
+}
+
+function getDateLocale(language: string | undefined) {
+  return language?.startsWith('zh') ? 'zh-CN' : 'en-US';
+}
+
+function parseDateValue(value: string) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  const date = new Date(year, month, day);
+
+  return date.getFullYear() === year && date.getMonth() === month && date.getDate() === day
+    ? date
+    : null;
+}

--- a/apps/web/src/routes/_app/admin.users.tsx
+++ b/apps/web/src/routes/_app/admin.users.tsx
@@ -31,7 +31,7 @@ import {
   TableRow,
 } from '@syncode/ui';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, Link } from '@tanstack/react-router';
 import { Ban, Loader2, RefreshCw, Search, ShieldAlert, ShieldCheck } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -168,17 +168,22 @@ export function AdminUsersPage() {
           </h1>
           <p className="mt-3 text-sm text-muted-foreground sm:text-base">{t('users.sub')}</p>
         </div>
-        <Button
-          variant="outline"
-          className="gap-2 self-start md:self-auto"
-          disabled={isUsersFetching}
-          onClick={() => {
-            usersQuery.refetch().catch(() => undefined);
-          }}
-        >
-          <RefreshCw className="size-4" />
-          {t('users.actions.refresh')}
-        </Button>
+        <div className="flex flex-wrap gap-2 self-start md:self-auto">
+          <Button variant="outline" asChild>
+            <Link to="/admin/audit-logs">{t('navLinks.auditLogs')}</Link>
+          </Button>
+          <Button
+            variant="outline"
+            className="gap-2"
+            disabled={isUsersFetching}
+            onClick={() => {
+              usersQuery.refetch().catch(() => undefined);
+            }}
+          >
+            <RefreshCw className="size-4" />
+            {t('users.actions.refresh')}
+          </Button>
+        </div>
       </section>
 
       <section className="mt-8 grid gap-4 rounded-xl border border-border/50 bg-card/50 p-4 backdrop-blur-sm md:grid-cols-[minmax(0,1fr)_220px]">


### PR DESCRIPTION
Closes #199
Adds admin audit log viewer with search, action/date filters, expandable metadata, i18n, and admin-only access.