### PR TITLE
feat(web): add dashboard weakness summary

### DIFF
--- a/apps/control-plane/src/modules/sessions/session-reports.service.integration.spec.ts
+++ b/apps/control-plane/src/modules/sessions/session-reports.service.integration.spec.ts
@@ -2,7 +2,13 @@ import { NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { AI_CLIENT, ERROR_CODES } from '@syncode/contracts';
 import type { Database } from '@syncode/db';
-import { aiMessages, executionResults, sessionReports } from '@syncode/db';
+import {
+  aiMessages,
+  executionResults,
+  sessionReports,
+  userWeaknesses,
+  weaknessSessions,
+} from '@syncode/db';
 import { CACHE_SERVICE, STORAGE_SERVICE } from '@syncode/shared/ports';
 import { and, asc, eq } from 'drizzle-orm';
 import { DB_CLIENT } from '@/modules/db/db.module.js';
@@ -196,6 +202,32 @@ describe('handleResult', () => {
     const room = await insertRoom(db, user.id);
     const session = await insertSession(db, room.id, { status: 'finished' });
     await insertSessionParticipant(db, session.id, user.id, 'candidate');
+    const previousRoom = await insertRoom(db, user.id);
+    const previousSession = await insertSession(db, previousRoom.id, { status: 'finished' });
+    await insertSessionParticipant(db, previousSession.id, user.id, 'candidate');
+    await insertSessionReport(db, previousSession.id, {
+      userId: user.id,
+      status: 'completed',
+      overallScore: 82,
+      report: {
+        sessionId: previousSession.id,
+        generatedAt: '2026-04-19T07:00:00.000Z',
+        overallScore: 82,
+        dimensions: {
+          efficiency: {
+            score: 88,
+            feedback: 'Efficient solution.',
+            evidence: [],
+          },
+        },
+        strengths: [],
+        areasForImprovement: [],
+        detailedFeedback: 'Prior report',
+        comparisonToHistory: null,
+        peerFeedbackSummary: null,
+        testCaseBreakdown: [],
+      },
+    });
     await insertSessionReport(db, session.id, {
       userId: user.id,
       status: 'pending',
@@ -214,8 +246,20 @@ describe('handleResult', () => {
       sessionId: session.id,
       generatedAt: '2026-04-20T06:00:00.000Z',
       overallScore: 91,
+      dimensions: {
+        efficiency: {
+          score: 62,
+          feedback: 'The solution uses quadratic time complexity.',
+          evidence: [],
+        },
+        correctness: {
+          score: 78,
+          feedback: 'Misses edge cases around duplicate values.',
+          evidence: [],
+        },
+      },
       strengths: ['Clear reasoning'],
-      areasForImprovement: ['Trim dead code'],
+      areasForImprovement: ['Improve time complexity and cover edge cases.'],
       detailedFeedback: 'Detailed feedback',
       comparisonToHistory: null,
       peerFeedbackSummary: null,
@@ -244,6 +288,124 @@ describe('handleResult', () => {
       strengths: ['Clear reasoning'],
     });
     expect(await cacheService.get('session-report-meta:job-123')).toBeNull();
+
+    const weaknessRows = await db
+      .select({
+        id: userWeaknesses.id,
+        category: userWeaknesses.category,
+        frequency: userWeaknesses.frequency,
+        trend: userWeaknesses.trend,
+      })
+      .from(userWeaknesses)
+      .where(eq(userWeaknesses.userId, user.id))
+      .orderBy(asc(userWeaknesses.category));
+    const weaknessLinks = await db
+      .select({
+        weaknessId: weaknessSessions.weaknessId,
+        sessionId: weaknessSessions.sessionId,
+      })
+      .from(weaknessSessions);
+
+    expect(weaknessRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: 'edge_cases',
+          frequency: 1,
+        }),
+        expect.objectContaining({
+          category: 'time_complexity',
+          frequency: 1,
+          trend: 'worsening',
+        }),
+      ]),
+    );
+    expect(weaknessLinks).toEqual(
+      expect.arrayContaining(
+        weaknessRows.map((weakness) => ({
+          weaknessId: weakness.id,
+          sessionId: session.id,
+        })),
+      ),
+    );
+  });
+
+  it('GIVEN regenerated report WHEN weaknesses change THEN replaces stale weakness links', async () => {
+    const user = await insertUser(db);
+    const room = await insertRoom(db, user.id);
+    const session = await insertSession(db, room.id, { status: 'finished' });
+    await insertSessionParticipant(db, session.id, user.id, 'candidate');
+    await insertSessionReport(db, session.id, {
+      userId: user.id,
+      status: 'pending',
+      report: null,
+      overallScore: null,
+      generatedAt: null,
+    });
+    await cacheService.set(
+      'session-report-meta:first-job',
+      { sessionId: session.id, userId: user.id },
+      60,
+    );
+
+    await service.handleResult('first-job', {
+      sessionId: session.id,
+      generatedAt: '2026-04-20T06:00:00.000Z',
+      overallScore: 70,
+      dimensions: {
+        efficiency: {
+          score: 60,
+          feedback: 'Use an index map to optimize lookup.',
+          evidence: [],
+        },
+      },
+      strengths: [],
+      areasForImprovement: [],
+      detailedFeedback: 'Initial report',
+      comparisonToHistory: null,
+      peerFeedbackSummary: null,
+      testCaseBreakdown: [],
+    });
+
+    const initialWeaknessRows = await db
+      .select({ category: userWeaknesses.category })
+      .from(userWeaknesses)
+      .where(eq(userWeaknesses.userId, user.id));
+
+    expect(initialWeaknessRows).toEqual([{ category: 'time_complexity' }]);
+
+    await cacheService.set(
+      'session-report-meta:second-job',
+      { sessionId: session.id, userId: user.id },
+      60,
+    );
+
+    await service.handleResult('second-job', {
+      sessionId: session.id,
+      generatedAt: '2026-04-20T07:00:00.000Z',
+      overallScore: 96,
+      dimensions: {
+        efficiency: {
+          score: 96,
+          feedback: 'The solution now uses efficient lookup.',
+          evidence: [],
+        },
+      },
+      strengths: ['Improved lookup strategy'],
+      areasForImprovement: [],
+      detailedFeedback: 'Clean regenerated report',
+      comparisonToHistory: null,
+      peerFeedbackSummary: null,
+      testCaseBreakdown: [],
+    });
+
+    const regeneratedWeaknessRows = await db
+      .select({ id: userWeaknesses.id })
+      .from(userWeaknesses)
+      .where(eq(userWeaknesses.userId, user.id));
+    const regeneratedWeaknessLinks = await db.select().from(weaknessSessions);
+
+    expect(regeneratedWeaknessRows).toEqual([]);
+    expect(regeneratedWeaknessLinks).toEqual([]);
   });
 });
 

--- a/apps/control-plane/src/modules/sessions/session-reports.service.ts
+++ b/apps/control-plane/src/modules/sessions/session-reports.service.ts
@@ -5,17 +5,47 @@ import {
   type GenerateSessionReportResult,
   type IAiClient,
   type SessionReport,
+  type SessionReportDimension,
+  USER_WEAKNESS_CATEGORIES,
 } from '@syncode/contracts';
 import type { Database } from '@syncode/db';
-import { problems, sessionParticipants, sessionReports, users } from '@syncode/db';
+import {
+  problems,
+  sessionDeletions,
+  sessionParticipants,
+  sessionReports,
+  sessions,
+  users,
+  userWeaknesses,
+  weaknessSessions,
+} from '@syncode/db';
 import { CACHE_SERVICE, type ICacheService } from '@syncode/shared/ports';
-import { and, asc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, ne, sql } from 'drizzle-orm';
 import { DB_CLIENT } from '@/modules/db/db.module.js';
 import { SessionReportRequestBuilderService } from './session-report-request-builder.service.js';
 import { SessionsService } from './sessions.service.js';
 
 const SESSION_REPORT_META_KEY_PREFIX = 'session-report-meta:';
 const SESSION_REPORT_META_TTL_SECONDS = 24 * 60 * 60;
+const WEAKNESS_SCORE_THRESHOLD = 85;
+const PRIOR_TREND_DELTA = 3;
+const RECENT_REPORT_LIMIT = 5;
+
+type WeaknessCategory = (typeof USER_WEAKNESS_CATEGORIES)[number];
+type WeaknessTrend = 'improving' | 'stable' | 'worsening';
+type ReportDimensionKey =
+  | 'correctness'
+  | 'efficiency'
+  | 'codeQuality'
+  | 'communication'
+  | 'problemSolving';
+
+interface WeaknessSignal {
+  category: WeaknessCategory;
+  dimension: ReportDimensionKey;
+  score: number;
+  description: string;
+}
 
 interface SessionReportJobMeta {
   sessionId: string;
@@ -130,6 +160,8 @@ export class SessionReportsService {
         and(eq(sessionReports.sessionId, meta.sessionId), eq(sessionReports.userId, meta.userId)),
       );
 
+    await this.persistWeaknessSignals(meta.sessionId, meta.userId, reportPayload, generatedAt);
+
     await this.cacheService.del(metaKey);
 
     this.logger.debug(
@@ -216,5 +248,339 @@ export class SessionReportsService {
 
       throw error;
     }
+  }
+
+  private async persistWeaknessSignals(
+    sessionId: string,
+    userId: string,
+    report: SessionReport,
+    generatedAt: Date,
+  ): Promise<void> {
+    const signals = this.extractWeaknessSignals(report);
+
+    const signalsWithTrend = await Promise.all(
+      signals.map(async (signal) => ({
+        ...signal,
+        trend: await this.calculateWeaknessTrend(userId, sessionId, signal.dimension, signal.score),
+      })),
+    );
+
+    await this.db.transaction(async (tx) => {
+      const existingLinks = await tx
+        .select({ weaknessId: weaknessSessions.weaknessId })
+        .from(weaknessSessions)
+        .innerJoin(userWeaknesses, eq(userWeaknesses.id, weaknessSessions.weaknessId))
+        .where(and(eq(userWeaknesses.userId, userId), eq(weaknessSessions.sessionId, sessionId)));
+      const touchedWeaknessIds = new Set(existingLinks.map((link) => link.weaknessId));
+
+      if (existingLinks.length > 0) {
+        await tx.delete(weaknessSessions).where(
+          and(
+            eq(weaknessSessions.sessionId, sessionId),
+            inArray(
+              weaknessSessions.weaknessId,
+              existingLinks.map((link) => link.weaknessId),
+            ),
+          ),
+        );
+      }
+
+      for (const signal of signalsWithTrend) {
+        const [weakness] = await tx
+          .insert(userWeaknesses)
+          .values({
+            userId,
+            category: signal.category,
+            description: signal.description,
+            frequency: 1,
+            trend: signal.trend,
+            lastSeenAt: generatedAt,
+          })
+          .onConflictDoUpdate({
+            target: [userWeaknesses.userId, userWeaknesses.category],
+            set: {
+              description: signal.description,
+              trend: signal.trend,
+              lastSeenAt: generatedAt,
+            },
+          })
+          .returning({ id: userWeaknesses.id });
+
+        if (!weakness) {
+          continue;
+        }
+
+        touchedWeaknessIds.add(weakness.id);
+
+        await tx
+          .insert(weaknessSessions)
+          .values({
+            weaknessId: weakness.id,
+            sessionId,
+            description: signal.description,
+            trend: signal.trend,
+            score: signal.score,
+            reportedAt: generatedAt,
+          })
+          .onConflictDoNothing();
+      }
+
+      for (const weaknessId of touchedWeaknessIds) {
+        await tx
+          .update(userWeaknesses)
+          .set({
+            frequency: sql<number>`(
+              SELECT COUNT(*)::int
+              FROM ${weaknessSessions}
+              WHERE ${weaknessSessions.weaknessId} = ${weaknessId}
+            )`,
+          })
+          .where(eq(userWeaknesses.id, weaknessId));
+      }
+
+      if (touchedWeaknessIds.size > 0) {
+        await tx.delete(userWeaknesses).where(
+          and(
+            eq(userWeaknesses.userId, userId),
+            inArray(userWeaknesses.id, [...touchedWeaknessIds]),
+            sql`NOT EXISTS (
+                SELECT 1
+                FROM ${weaknessSessions}
+                WHERE ${weaknessSessions.weaknessId} = ${userWeaknesses.id}
+              )`,
+          ),
+        );
+      }
+    });
+  }
+
+  private extractWeaknessSignals(report: SessionReport): WeaknessSignal[] {
+    const signals = new Map<WeaknessCategory, WeaknessSignal>();
+    const dimensions = report.dimensions ?? {};
+    const areaText = report.areasForImprovement ?? [];
+
+    this.addDimensionSignal(signals, 'correctness', dimensions.correctness, areaText);
+    this.addDimensionSignal(signals, 'efficiency', dimensions.efficiency, areaText);
+    this.addDimensionSignal(signals, 'codeQuality', dimensions.codeQuality, areaText);
+    this.addDimensionSignal(signals, 'communication', dimensions.communication, areaText);
+    this.addDimensionSignal(signals, 'problemSolving', dimensions.problemSolving, areaText);
+
+    for (const text of areaText) {
+      const category = this.classifyWeaknessText(text);
+      if (!category || signals.has(category)) {
+        continue;
+      }
+
+      const dimension = this.dimensionForCategory(category);
+      const score = dimensions[dimension]?.score ?? WEAKNESS_SCORE_THRESHOLD - 1;
+      signals.set(category, {
+        category,
+        dimension,
+        score,
+        description: this.cleanDescription(text),
+      });
+    }
+
+    return [...signals.values()];
+  }
+
+  private addDimensionSignal(
+    signals: Map<WeaknessCategory, WeaknessSignal>,
+    dimension: ReportDimensionKey,
+    dimensionResult: SessionReportDimension | undefined,
+    areaText: string[],
+  ): void {
+    if (!dimensionResult || dimensionResult.score >= WEAKNESS_SCORE_THRESHOLD) {
+      return;
+    }
+
+    const category = this.classifyDimensionWeakness(dimension, [
+      dimensionResult.feedback,
+      ...areaText,
+    ]);
+
+    if (signals.has(category)) {
+      return;
+    }
+
+    signals.set(category, {
+      category,
+      dimension,
+      score: dimensionResult.score,
+      description: this.cleanDescription(dimensionResult.feedback),
+    });
+  }
+
+  private async calculateWeaknessTrend(
+    userId: string,
+    sessionId: string,
+    dimension: ReportDimensionKey,
+    currentScore: number,
+  ): Promise<WeaknessTrend> {
+    const priorReports = await this.db
+      .select({ report: sessionReports.report })
+      .from(sessionReports)
+      .innerJoin(sessions, eq(sessions.id, sessionReports.sessionId))
+      .innerJoin(
+        sessionParticipants,
+        and(
+          eq(sessionParticipants.sessionId, sessionReports.sessionId),
+          eq(sessionParticipants.userId, userId),
+        ),
+      )
+      .leftJoin(
+        sessionDeletions,
+        and(
+          eq(sessionDeletions.sessionId, sessionReports.sessionId),
+          eq(sessionDeletions.userId, userId),
+        ),
+      )
+      .where(
+        and(
+          eq(sessionReports.userId, userId),
+          eq(sessionReports.status, 'completed'),
+          ne(sessionReports.sessionId, sessionId),
+          eq(sessions.status, 'finished'),
+          sql`${sessionDeletions.userId} IS NULL`,
+        ),
+      )
+      .orderBy(desc(sessionReports.generatedAt), desc(sessionReports.requestedAt))
+      .limit(RECENT_REPORT_LIMIT);
+
+    const priorScores = priorReports
+      .map((row) => (row.report as SessionReport | null)?.dimensions?.[dimension]?.score)
+      .filter((score): score is number => typeof score === 'number');
+
+    if (priorScores.length === 0) {
+      return 'stable';
+    }
+
+    const priorAverage = priorScores.reduce((sum, score) => sum + score, 0) / priorScores.length;
+
+    if (currentScore >= priorAverage + PRIOR_TREND_DELTA) {
+      return 'improving';
+    }
+
+    if (currentScore <= priorAverage - PRIOR_TREND_DELTA) {
+      return 'worsening';
+    }
+
+    return 'stable';
+  }
+
+  private classifyDimensionWeakness(
+    dimension: ReportDimensionKey,
+    texts: readonly string[],
+  ): WeaknessCategory {
+    const [primaryText, ...supportingTexts] = texts;
+    const textCategory =
+      this.classifyWeaknessText(primaryText ?? '') ??
+      this.classifyWeaknessText(supportingTexts.join(' '));
+
+    if (textCategory && this.isCategoryCompatibleWithDimension(dimension, textCategory)) {
+      return textCategory;
+    }
+
+    if (dimension === 'correctness') return 'edge_cases';
+    if (dimension === 'efficiency') return 'time_complexity';
+    if (dimension === 'codeQuality') return 'code_structure';
+    if (dimension === 'communication') return 'communication';
+    return 'edge_cases';
+  }
+
+  private classifyWeaknessText(text: string): WeaknessCategory | null {
+    const normalizedText = text.toLowerCase();
+
+    if (/\boff[-\s]?by[-\s]?one\b|\bindex\b|\bboundary\b/.test(normalizedText)) {
+      return 'off_by_one';
+    }
+
+    if (
+      /\binput validation\b|\bvalidate\b|\binvalid input\b|\bempty input\b/.test(normalizedText)
+    ) {
+      return 'input_validation';
+    }
+
+    if (/\bspace\b|\bmemory\b/.test(normalizedText)) {
+      return 'space_complexity';
+    }
+
+    if (
+      /\btime complexity\b|\bruntime\b|\bquadratic\b|\bo\(n\^2\)\b|\boptimi[sz]/.test(
+        normalizedText,
+      )
+    ) {
+      return 'time_complexity';
+    }
+
+    if (/\bvariable\b|\bnaming\b|\bidentifier\b/.test(normalizedText)) {
+      return 'variable_naming';
+    }
+
+    if (
+      /\bstructure\b|\bdead code\b|\bduplication\b|\breadability\b|\bmodular\b/.test(normalizedText)
+    ) {
+      return 'code_structure';
+    }
+
+    if (/\bcommunicat|\bexplain|\btrade[-\s]?off|\breasoning\b/.test(normalizedText)) {
+      return 'communication';
+    }
+
+    if (
+      /\bedge cases?\b|\bcorner cases?\b|\bhidden cases?\b|\bfailing tests?\b/.test(normalizedText)
+    ) {
+      return 'edge_cases';
+    }
+
+    return null;
+  }
+
+  private isCategoryCompatibleWithDimension(
+    dimension: ReportDimensionKey,
+    category: WeaknessCategory,
+  ): boolean {
+    if (dimension === 'efficiency') {
+      return category === 'time_complexity' || category === 'space_complexity';
+    }
+
+    if (dimension === 'codeQuality') {
+      return category === 'variable_naming' || category === 'code_structure';
+    }
+
+    if (dimension === 'communication') {
+      return category === 'communication';
+    }
+
+    if (dimension === 'correctness' || dimension === 'problemSolving') {
+      return ['edge_cases', 'off_by_one', 'input_validation'].includes(category);
+    }
+
+    return false;
+  }
+
+  private dimensionForCategory(category: WeaknessCategory): ReportDimensionKey {
+    if (category === 'time_complexity' || category === 'space_complexity') {
+      return 'efficiency';
+    }
+
+    if (category === 'variable_naming' || category === 'code_structure') {
+      return 'codeQuality';
+    }
+
+    if (category === 'communication') {
+      return 'communication';
+    }
+
+    return 'correctness';
+  }
+
+  private cleanDescription(text: string): string {
+    const strippedText = text
+      .replace(/<\/?(?:green|yellow|orange|red)>/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    return strippedText;
   }
 }

--- a/apps/control-plane/src/modules/users/dto/user.dto.ts
+++ b/apps/control-plane/src/modules/users/dto/user.dto.ts
@@ -4,6 +4,8 @@ import {
   updateUserSchema,
   userProfileResponseSchema,
   userQuotasResponseSchema,
+  userWeaknessesResponseSchema,
+  userWeaknessSchema,
 } from '@syncode/contracts';
 import { createZodDto } from 'nestjs-zod';
 
@@ -11,4 +13,6 @@ export class UpdateUserDto extends createZodDto(updateUserSchema) {}
 export class UserProfileResponseDto extends createZodDto(userProfileResponseSchema) {}
 export class PublicUserProfileResponseDto extends createZodDto(publicUserProfileResponseSchema) {}
 export class UserQuotasResponseDto extends createZodDto(userQuotasResponseSchema) {}
+export class UserWeaknessDto extends createZodDto(userWeaknessSchema) {}
+export class UserWeaknessesResponseDto extends createZodDto(userWeaknessesResponseSchema) {}
 export class AvatarUploadUrlResponseDto extends createZodDto(avatarUploadUrlResponseSchema) {}

--- a/apps/control-plane/src/modules/users/users.controller.integration.spec.ts
+++ b/apps/control-plane/src/modules/users/users.controller.integration.spec.ts
@@ -11,6 +11,8 @@ import {
   rooms,
   runs,
   submissions,
+  userWeaknesses,
+  weaknessSessions,
 } from '@syncode/db';
 import { CACHE_SERVICE, STORAGE_SERVICE } from '@syncode/shared/ports';
 import { eq } from 'drizzle-orm';
@@ -22,7 +24,16 @@ import { AuditService } from '@/modules/admin/audit.service.js';
 import { AuthService } from '@/modules/auth/auth.service.js';
 import { DB_CLIENT } from '@/modules/db/db.module.js';
 import { InMemoryCacheService } from '@/test/in-memory-cache.service.js';
-import { createTestDb, insertProblem, insertUser } from '@/test/integration-setup.js';
+import {
+  createTestDb,
+  insertProblem,
+  insertRoom,
+  insertSession,
+  insertSessionDeletion,
+  insertSessionParticipant,
+  insertSessionReport,
+  insertUser,
+} from '@/test/integration-setup.js';
 import { createMockConfigService, createMockStorageService } from '@/test/mock-factories.js';
 import { JwtStrategy } from '../auth/jwt.strategy.js';
 import { UsersController } from './users.controller.js';
@@ -267,6 +278,135 @@ describe('GET /users/me/quotas', () => {
 
   it('GIVEN no bearer token WHEN fetching quotas THEN returns 401', async () => {
     const res = await request(app.getHttpServer()).get('/users/me/quotas');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /users/me/weaknesses', () => {
+  it('GIVEN persisted weaknesses WHEN fetching current weaknesses THEN returns sorted categories with visible linked sessions', async () => {
+    const user = await insertUser(db, {
+      email: 'alice@example.com',
+      username: 'alice_sync',
+    });
+    const otherUser = await insertUser(db, {
+      email: 'other@example.com',
+      username: 'other_sync',
+    });
+    const accessToken = await jwtService.signAsync({
+      sub: user.id,
+      email: user.email,
+      tokenType: 'access',
+    });
+
+    const problem = await insertProblem(db, { title: 'Two Sum' });
+    const room = await insertRoom(db, user.id, { problemId: problem.id });
+    const session = await insertSession(db, room.id, {
+      problemId: problem.id,
+      startedAt: new Date('2026-01-01T00:00:00.000Z'),
+      finishedAt: new Date('2026-01-01T00:30:00.000Z'),
+    });
+    const deletedRoom = await insertRoom(db, user.id);
+    const deletedSession = await insertSession(db, deletedRoom.id);
+    const otherRoom = await insertRoom(db, otherUser.id);
+    const inaccessibleSession = await insertSession(db, otherRoom.id);
+    const ongoingRoom = await insertRoom(db, user.id);
+    const ongoingSession = await insertSession(db, ongoingRoom.id, { status: 'ongoing' });
+
+    await insertSessionParticipant(db, session.id, user.id, 'candidate');
+    await insertSessionParticipant(db, deletedSession.id, user.id, 'candidate');
+    await insertSessionParticipant(db, inaccessibleSession.id, otherUser.id, 'candidate');
+    await insertSessionParticipant(db, ongoingSession.id, user.id, 'candidate');
+    await insertSessionReport(db, session.id, {
+      userId: user.id,
+      overallScore: 68,
+      generatedAt: new Date('2026-01-01T00:35:00.000Z'),
+    });
+
+    const [highFrequencyWeakness] = await db
+      .insert(userWeaknesses)
+      .values({
+        userId: user.id,
+        category: 'time_complexity',
+        description: 'Complexity analysis needs work',
+        frequency: 5,
+        trend: 'worsening',
+        lastSeenAt: new Date('2026-01-03T00:00:00.000Z'),
+      })
+      .returning();
+    const [lowFrequencyWeakness] = await db
+      .insert(userWeaknesses)
+      .values({
+        userId: user.id,
+        category: 'edge_cases',
+        description: 'Missed empty input cases',
+        frequency: 2,
+        trend: 'improving',
+        lastSeenAt: new Date('2026-01-02T00:00:00.000Z'),
+      })
+      .returning();
+    await db.insert(userWeaknesses).values({
+      userId: otherUser.id,
+      category: 'communication',
+      description: 'Other user weakness',
+      frequency: 10,
+      trend: 'stable',
+    });
+    await db.insert(weaknessSessions).values([
+      {
+        weaknessId: highFrequencyWeakness!.id,
+        sessionId: session.id,
+      },
+      {
+        weaknessId: highFrequencyWeakness!.id,
+        sessionId: deletedSession.id,
+      },
+      {
+        weaknessId: highFrequencyWeakness!.id,
+        sessionId: inaccessibleSession.id,
+      },
+      {
+        weaknessId: highFrequencyWeakness!.id,
+        sessionId: ongoingSession.id,
+      },
+      {
+        weaknessId: lowFrequencyWeakness!.id,
+        sessionId: deletedSession.id,
+      },
+    ]);
+    await insertSessionDeletion(db, deletedSession.id, user.id);
+
+    const res = await request(app.getHttpServer())
+      .get('/users/me/weaknesses')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0]).toMatchObject({
+      id: highFrequencyWeakness!.id,
+      category: 'time_complexity',
+      description: 'Complexity analysis needs work',
+      frequency: 1,
+      trend: 'worsening',
+      lastSeenAt: '2026-01-01T00:35:00.000Z',
+      sessions: [
+        {
+          sessionId: session.id,
+          problemName: 'Two Sum',
+          reportedAt: '2026-01-01T00:35:00.000Z',
+          score: 68,
+        },
+      ],
+    });
+    expect(Object.keys(res.body.data[0].sessions[0]).sort()).toEqual([
+      'problemName',
+      'reportedAt',
+      'score',
+      'sessionId',
+    ]);
+  });
+
+  it('GIVEN no bearer token WHEN fetching weaknesses THEN returns 401', async () => {
+    const res = await request(app.getHttpServer()).get('/users/me/weaknesses');
     expect(res.status).toBe(401);
   });
 });

--- a/apps/control-plane/src/modules/users/users.controller.spec.ts
+++ b/apps/control-plane/src/modules/users/users.controller.spec.ts
@@ -13,6 +13,7 @@ describe('UsersController', () => {
       | 'findPublicById'
       | 'getAvatarUploadUrl'
       | 'getQuotas'
+      | 'getWeaknesses'
       | 'update'
     > = {
       findById: vi.fn(async (id: string) => ({
@@ -54,6 +55,19 @@ describe('UsersController', () => {
           activeCount: 1,
           maxActive: 3,
         },
+      })),
+      getWeaknesses: vi.fn(async () => ({
+        data: [
+          {
+            id: '11111111-1111-4111-8111-111111111111',
+            category: 'edge_cases' as const,
+            description: 'Missed edge cases',
+            frequency: 2,
+            trend: 'improving' as const,
+            lastSeenAt: '2026-01-02T00:00:00.000Z',
+            sessions: [],
+          },
+        ],
       })),
       update: vi.fn(
         async (id: string, body: { displayName?: string; bio?: string; username?: string }) => ({
@@ -115,6 +129,15 @@ describe('UsersController', () => {
     expect(usersService.getQuotas).toHaveBeenCalledWith('user-1');
     expect(result.ai.used).toBe(1);
     expect(result.rooms.maxActive).toBe(3);
+  });
+
+  it('GIVEN authenticated user WHEN getCurrentUserWeaknesses THEN returns weakness summary for current id', async () => {
+    const { controller, usersService } = createUsersControllerFixture();
+
+    const result = await controller.getCurrentUserWeaknesses({ id: 'user-1' });
+
+    expect(usersService.getWeaknesses).toHaveBeenCalledWith('user-1');
+    expect(result.data[0]?.category).toBe('edge_cases');
   });
 
   it('GIVEN requested user id WHEN getUserById THEN returns profile', async () => {

--- a/apps/control-plane/src/modules/users/users.controller.ts
+++ b/apps/control-plane/src/modules/users/users.controller.ts
@@ -28,6 +28,7 @@ import {
   UpdateUserDto,
   UserProfileResponseDto,
   UserQuotasResponseDto,
+  UserWeaknessesResponseDto,
 } from './dto/user.dto.js';
 import { UsersService } from './users.service.js';
 
@@ -60,6 +61,21 @@ export class UsersController {
   @ApiResponse({ status: 500, type: ErrorResponseDto, description: 'Internal server error' })
   async getCurrentUserQuotas(@CurrentUser() user: { id: string }): Promise<UserQuotasResponseDto> {
     return this.usersService.getQuotas(user.id);
+  }
+
+  @Get(CONTROL_API.USERS.WEAKNESSES.route)
+  @ApiOperation({ summary: 'Get current user weakness summary' })
+  @ApiResponse({
+    status: 200,
+    type: UserWeaknessesResponseDto,
+    description: 'Current user weakness categories and linked sessions',
+  })
+  @ApiResponse({ status: 401, type: ErrorResponseDto, description: 'Unauthorized' })
+  @ApiResponse({ status: 500, type: ErrorResponseDto, description: 'Internal server error' })
+  async getCurrentUserWeaknesses(
+    @CurrentUser() user: { id: string },
+  ): Promise<UserWeaknessesResponseDto> {
+    return this.usersService.getWeaknesses(user.id);
   }
 
   @Get(CONTROL_API.USERS.GET_BY_ID.route)

--- a/apps/control-plane/src/modules/users/users.service.ts
+++ b/apps/control-plane/src/modules/users/users.service.ts
@@ -12,6 +12,7 @@ import {
   type UpdateUserInput,
   type UserProfileResponse,
   type UserQuotasResponse,
+  type UserWeaknessesResponse,
 } from '@syncode/contracts';
 import type { Database } from '@syncode/db';
 import {
@@ -19,14 +20,21 @@ import {
   aiMessages,
   aiReviews,
   GLOBAL_LIMIT_KEYS,
+  problems,
   rooms,
   runs,
+  sessionDeletions,
+  sessionParticipants,
+  sessionReports,
+  sessions,
   submissions,
   users,
+  userWeaknesses,
+  weaknessSessions,
 } from '@syncode/db';
 import { ROOM_STATUSES, RoomStatus } from '@syncode/shared';
 import { type IStorageService, STORAGE_SERVICE } from '@syncode/shared/ports';
-import { and, eq, gte, inArray, isNull, ne, type SQL, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, isNull, ne, type SQL, sql } from 'drizzle-orm';
 import type { AnyPgTable } from 'drizzle-orm/pg-core';
 import { resolveAvatarUrls } from '@/common/resolve-avatar-urls.js';
 import { DB_CLIENT } from '@/modules/db/db.module.js';
@@ -183,6 +191,134 @@ export class UsersService {
         activeCount: roomCount,
         maxActive: limits[GLOBAL_LIMIT_KEYS.ROOMS_MAX_ACTIVE] ?? 0,
       },
+    };
+  }
+
+  async getWeaknesses(userId: string): Promise<UserWeaknessesResponse> {
+    const weaknessRows = await this.db
+      .select({
+        id: userWeaknesses.id,
+        category: userWeaknesses.category,
+        description: userWeaknesses.description,
+        frequency: userWeaknesses.frequency,
+        trend: userWeaknesses.trend,
+        lastSeenAt: userWeaknesses.lastSeenAt,
+      })
+      .from(userWeaknesses)
+      .where(eq(userWeaknesses.userId, userId))
+      .orderBy(desc(userWeaknesses.frequency), desc(userWeaknesses.lastSeenAt));
+
+    if (weaknessRows.length === 0) {
+      return { data: [] };
+    }
+
+    const weaknessIds = weaknessRows.map((weakness) => weakness.id);
+    const linkedSessionRows = await this.db
+      .select({
+        weaknessId: weaknessSessions.weaknessId,
+        sessionId: weaknessSessions.sessionId,
+        description: weaknessSessions.description,
+        trend: weaknessSessions.trend,
+        problemName: problems.title,
+        reportedAt: sql<Date>`COALESCE(${weaknessSessions.reportedAt}, ${sessionReports.generatedAt}, ${sessions.finishedAt}, ${sessions.startedAt})`,
+        score: sql<
+          number | null
+        >`COALESCE(${weaknessSessions.score}, ${sessionReports.overallScore})`,
+        startedAt: sessions.startedAt,
+        finishedAt: sessions.finishedAt,
+      })
+      .from(weaknessSessions)
+      .innerJoin(sessions, eq(sessions.id, weaknessSessions.sessionId))
+      .innerJoin(
+        sessionParticipants,
+        and(eq(sessionParticipants.sessionId, sessions.id), eq(sessionParticipants.userId, userId)),
+      )
+      .leftJoin(
+        sessionReports,
+        and(
+          eq(sessionReports.sessionId, sessions.id),
+          eq(sessionReports.userId, userId),
+          eq(sessionReports.status, 'completed'),
+        ),
+      )
+      .leftJoin(problems, eq(problems.id, sessions.problemId))
+      .leftJoin(
+        sessionDeletions,
+        and(
+          eq(sessionDeletions.sessionId, weaknessSessions.sessionId),
+          eq(sessionDeletions.userId, userId),
+        ),
+      )
+      .where(
+        and(
+          inArray(weaknessSessions.weaknessId, weaknessIds),
+          eq(sessions.status, 'finished'),
+          isNull(sessionDeletions.userId),
+        ),
+      )
+      .orderBy(
+        desc(
+          sql`COALESCE(${weaknessSessions.reportedAt}, ${sessionReports.generatedAt}, ${sessions.finishedAt}, ${sessions.startedAt})`,
+        ),
+      );
+
+    const sessionsByWeakness = new Map<
+      string,
+      Array<{
+        sessionId: string;
+        description: string | null;
+        trend: 'improving' | 'stable' | 'worsening' | null;
+        problemName: string | null;
+        reportedAt: string;
+        score: number | null;
+      }>
+    >();
+
+    for (const row of linkedSessionRows) {
+      const currentSessions = sessionsByWeakness.get(row.weaknessId) ?? [];
+      currentSessions.push({
+        sessionId: row.sessionId,
+        description: row.description,
+        trend: row.trend,
+        problemName: row.problemName,
+        reportedAt: new Date(row.reportedAt).toISOString(),
+        score: row.score ?? null,
+      });
+      sessionsByWeakness.set(row.weaknessId, currentSessions);
+    }
+
+    const visibleWeaknesses = weaknessRows
+      .filter((weakness) => (sessionsByWeakness.get(weakness.id)?.length ?? 0) > 0)
+      .sort((a, b) => {
+        const frequencyDelta =
+          (sessionsByWeakness.get(b.id)?.length ?? 0) - (sessionsByWeakness.get(a.id)?.length ?? 0);
+
+        if (frequencyDelta !== 0) {
+          return frequencyDelta;
+        }
+
+        return b.lastSeenAt.getTime() - a.lastSeenAt.getTime();
+      });
+
+    return {
+      data: visibleWeaknesses.map((weakness) => {
+        const linkedSessions = sessionsByWeakness.get(weakness.id) ?? [];
+        const latestSession = linkedSessions[0];
+
+        return {
+          ...weakness,
+          description: latestSession?.description ?? weakness.description,
+          frequency: linkedSessions.length,
+          trend: latestSession?.trend ?? weakness.trend,
+          lastSeenAt: latestSession?.reportedAt ?? weakness.lastSeenAt.toISOString(),
+          sessions: linkedSessions.map(({ sessionId, problemName, reportedAt, score }) => ({
+            sessionId,
+            problemName,
+            reportedAt,
+            score,
+          })),
+        };
+      }),
     };
   }
 

--- a/apps/web/src/components/dashboard-recent-sessions.tsx
+++ b/apps/web/src/components/dashboard-recent-sessions.tsx
@@ -1,4 +1,4 @@
-import { ERROR_CODES } from '@syncode/contracts';
+import { ERROR_CODES, type UserWeaknessesResponse } from '@syncode/contracts';
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -52,6 +52,10 @@ import {
   removeSessionFromDashboardHistory,
 } from '@/lib/dashboard-session-history.js';
 import { getUserInitial } from '@/lib/user-utils.js';
+import {
+  removeSessionFromUserWeaknesses,
+  USER_WEAKNESSES_QUERY_KEY,
+} from '@/lib/user-weaknesses.js';
 import { useAuthStore } from '@/stores/auth.store.js';
 
 type SessionFilter = 'all' | 'passed' | 'failed';
@@ -224,38 +228,58 @@ export function DashboardRecentSessions({
     void,
     unknown,
     { sessionId: string },
-    { previousHistory?: DashboardSessionHistory }
+    { previousHistory?: DashboardSessionHistory; previousWeaknesses?: UserWeaknessesResponse }
   >({
     mutationFn: async ({ sessionId }) => {
       await deleteSession(sessionId);
     },
     onMutate: async ({ sessionId }) => {
-      await queryClient.cancelQueries({ queryKey: sessionHistoryQueryKey });
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: sessionHistoryQueryKey }),
+        queryClient.cancelQueries({ queryKey: USER_WEAKNESSES_QUERY_KEY }),
+      ]);
 
       const previousHistory =
         queryClient.getQueryData<DashboardSessionHistory>(sessionHistoryQueryKey);
+      const previousWeaknesses =
+        queryClient.getQueryData<UserWeaknessesResponse>(USER_WEAKNESSES_QUERY_KEY);
 
       queryClient.setQueryData<DashboardSessionHistory>(sessionHistoryQueryKey, (currentHistory) =>
         currentHistory
           ? removeSessionFromDashboardHistory(currentHistory, sessionId)
           : currentHistory,
       );
+      queryClient.setQueryData<UserWeaknessesResponse>(
+        USER_WEAKNESSES_QUERY_KEY,
+        (currentWeaknesses) =>
+          currentWeaknesses
+            ? removeSessionFromUserWeaknesses(currentWeaknesses, sessionId)
+            : currentWeaknesses,
+      );
 
-      return { previousHistory };
+      return { previousHistory, previousWeaknesses };
     },
     onSuccess: () => {
       // Close the dialog only after the request lands so the in-dialog
       // pending UI ('Deleting...') is actually visible.
       setPendingDeleteSessionId(null);
+      void queryClient.invalidateQueries({ queryKey: USER_WEAKNESSES_QUERY_KEY });
     },
     onError: (error, _variables, context) => {
       if (context?.previousHistory) {
         queryClient.setQueryData(sessionHistoryQueryKey, context.previousHistory);
       }
 
+      if (context?.previousWeaknesses) {
+        queryClient.setQueryData(USER_WEAKNESSES_QUERY_KEY, context.previousWeaknesses);
+      }
+
       // Refetch only on error so the optimistic update is reconciled with
       // server truth. The success path already removed the row optimistically.
-      void queryClient.invalidateQueries({ queryKey: sessionHistoryQueryKey });
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: sessionHistoryQueryKey }),
+        queryClient.invalidateQueries({ queryKey: USER_WEAKNESSES_QUERY_KEY }),
+      ]);
       toast.error(getDeleteSessionErrorMessage(error, t));
     },
   });

--- a/apps/web/src/components/dashboard-weakness-summary.spec.tsx
+++ b/apps/web/src/components/dashboard-weakness-summary.spec.tsx
@@ -1,0 +1,95 @@
+import type { UserWeakness } from '@syncode/contracts';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DashboardWeaknessSummary } from './dashboard-weakness-summary.js';
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    params,
+    to,
+  }: {
+    children: React.ReactNode;
+    params?: { sessionId: string };
+    to: string;
+  }) => <a href={to.replace('$sessionId', params?.sessionId ?? '')}>{children}</a>,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (options?.problem !== undefined)
+        return `${key}:${String(options.problem)}:${String(options.score)}`;
+      if (options?.category !== undefined) {
+        return `${key}:${String(options.category)}:${String(options.count)}`;
+      }
+      if (options?.score !== undefined) return `${key}:${String(options.score)}`;
+      if (options?.count !== undefined) return `${key}:${String(options.count)}`;
+      return key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+function makeWeakness(overrides: Partial<UserWeakness> = {}): UserWeakness {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    category: 'time_complexity',
+    description: 'Complexity analysis needs work',
+    frequency: 5,
+    trend: 'worsening',
+    lastSeenAt: '2026-01-03T00:00:00.000Z',
+    sessions: [
+      {
+        sessionId: '22222222-2222-4222-8222-222222222222',
+        problemName: 'Two Sum',
+        reportedAt: '2026-01-03T00:00:00.000Z',
+        score: 68,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('DashboardWeaknessSummary', () => {
+  it('GIVEN persisted weaknesses WHEN rendering THEN shows real categories, trend, frequency, and session links', () => {
+    render(
+      <DashboardWeaknessSummary
+        weaknesses={[
+          makeWeakness(),
+          makeWeakness({
+            id: '33333333-3333-4333-8333-333333333333',
+            category: 'edge_cases',
+            description: 'Missed empty input',
+            frequency: 1,
+            trend: 'improving',
+            lastSeenAt: '2026-01-02T00:00:00.000Z',
+            sessions: [],
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('weakness.category.time_complexity.title')).toBeInTheDocument();
+    expect(screen.getByText('Complexity analysis needs work')).toBeInTheDocument();
+    expect(screen.getAllByText('weakness.trend.worsening')).not.toHaveLength(0);
+    expect(screen.getByText('weakness.frequency:5')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Two Sum/ })).toHaveAttribute(
+      'href',
+      '/sessions/22222222-2222-4222-8222-222222222222',
+    );
+    expect(
+      screen.getByRole('progressbar', {
+        name: 'weakness.trendPoint:Two Sum:68',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('GIVEN a load error WHEN rendering THEN shows error state instead of empty data copy', () => {
+    render(<DashboardWeaknessSummary weaknesses={[]} isError />);
+
+    expect(screen.getAllByText('weakness.errorTitle')).not.toHaveLength(0);
+    expect(screen.queryByText('weakness.noDataTitle')).not.toBeInTheDocument();
+    expect(screen.queryByText('weakness.noTrendTitle')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dashboard-weakness-summary.tsx
+++ b/apps/web/src/components/dashboard-weakness-summary.tsx
@@ -1,0 +1,229 @@
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle, Progress } from '@syncode/ui';
+import { Link } from '@tanstack/react-router';
+import { Activity, ArrowUpRight, BarChart3, Target } from 'lucide-react';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { DashboardSessionRecord } from '@/lib/dashboard-session-history.js';
+
+type WeaknessCategory = 'correctness' | 'consistency' | 'pacing' | 'difficulty';
+
+type WeaknessSummaryItem = {
+  category: WeaknessCategory;
+  frequency: number;
+  sessions: DashboardSessionRecord[];
+};
+
+export function DashboardWeaknessSummary({
+  records,
+  isLoading,
+  isUnavailable,
+}: {
+  readonly records: DashboardSessionRecord[];
+  readonly isLoading?: boolean;
+  readonly isUnavailable?: boolean;
+}) {
+  const { t } = useTranslation('dashboard');
+  const { weaknesses, trend } = useMemo(() => buildWeaknessSummary(records), [records]);
+  const hasData = records.length > 0;
+
+  return (
+    <section className="mt-8 sm:mt-10">
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold tracking-tight text-foreground">
+            {t('weakness.heading')}
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">{t('weakness.sub')}</p>
+        </div>
+        <Badge variant="outline" className="w-fit">
+          <Activity className="size-3.5" />
+          {t('weakness.sessionCount', { count: records.length })}
+        </Badge>
+      </div>
+
+      <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_380px]">
+        <Card className="border border-border/50 bg-card/80 py-0 backdrop-blur-sm">
+          <CardHeader className="px-5 pt-6 pb-4 sm:px-6">
+            <CardTitle className="flex items-center gap-2">
+              <Target className="size-5 text-primary" />
+              {t('weakness.categoriesTitle')}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 px-5 pb-6 sm:px-6">
+            {isLoading || isUnavailable ? (
+              <EmptyState
+                title={isLoading ? t('weakness.loadingTitle') : t('weakness.unavailableTitle')}
+                description={
+                  isLoading
+                    ? t('weakness.loadingDescription')
+                    : t('weakness.unavailableDescription')
+                }
+              />
+            ) : null}
+
+            {!isLoading && !isUnavailable && weaknesses.length === 0 ? (
+              <EmptyState
+                title={hasData ? t('weakness.noWeaknessTitle') : t('weakness.noDataTitle')}
+                description={
+                  hasData ? t('weakness.noWeaknessDescription') : t('weakness.noDataDescription')
+                }
+              />
+            ) : null}
+
+            {weaknesses.map((item) => (
+              <WeaknessCategoryRow key={item.category} item={item} totalSessions={records.length} />
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border/50 bg-card/80 py-0 backdrop-blur-sm">
+          <CardHeader className="px-5 pt-6 pb-4 sm:px-6">
+            <CardTitle className="flex items-center gap-2">
+              <BarChart3 className="size-5 text-primary" />
+              {t('weakness.trendTitle')}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="px-5 pb-6 sm:px-6">
+            {trend.length > 0 ? (
+              <div className="flex h-56 items-end gap-2">
+                {trend.map((point) => (
+                  <div
+                    key={point.sessionId}
+                    className="flex min-w-0 flex-1 flex-col items-center gap-2"
+                  >
+                    <div className="flex h-40 w-full items-end rounded-t-md bg-muted/40">
+                      <div
+                        className="w-full rounded-t-md bg-primary/75"
+                        style={{ height: `${Math.max(8, point.score)}%` }}
+                        title={t('weakness.trendPoint', {
+                          problem: point.problemName,
+                          score: point.score,
+                        })}
+                      />
+                    </div>
+                    <span className="max-w-full truncate text-[11px] text-muted-foreground">
+                      {point.score}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <EmptyState
+                title={t('weakness.noTrendTitle')}
+                description={t('weakness.noTrendDescription')}
+              />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  );
+}
+
+function WeaknessCategoryRow({
+  item,
+  totalSessions,
+}: {
+  readonly item: WeaknessSummaryItem;
+  readonly totalSessions: number;
+}) {
+  const { t } = useTranslation('dashboard');
+  const percentage = totalSessions > 0 ? Math.round((item.frequency / totalSessions) * 100) : 0;
+  const linkedSessions = item.sessions.filter((session) => session.hasReport).slice(0, 3);
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-background/45 p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="font-medium text-foreground">
+            {t(`weakness.category.${item.category}.title`)}
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {t(`weakness.category.${item.category}.description`)}
+          </p>
+        </div>
+        <Badge variant={percentage >= 50 ? 'warning' : 'outline'}>
+          {t('weakness.frequency', { count: item.frequency })}
+        </Badge>
+      </div>
+      <Progress value={percentage} className="mt-4 h-2" />
+      {linkedSessions.length > 0 ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {linkedSessions.map((session) => (
+            <Button key={session.id} asChild size="xs" variant="outline">
+              <Link to="/sessions/$sessionId" params={{ sessionId: session.id }}>
+                <ArrowUpRight className="size-3" />
+                {session.problemName}
+              </Link>
+            </Button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function EmptyState({
+  title,
+  description,
+}: {
+  readonly title: string;
+  readonly description: string;
+}) {
+  return (
+    <div className="flex min-h-44 flex-col items-center justify-center rounded-lg border border-dashed border-border/60 px-6 py-8 text-center">
+      <p className="font-medium text-foreground">{title}</p>
+      <p className="mt-2 max-w-md text-sm text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+function buildWeaknessSummary(records: DashboardSessionRecord[]) {
+  const scoredCandidateRecords = records
+    .filter((record) => record.viewerRole === 'candidate' && typeof record.score === 'number')
+    .sort(
+      (a, b) =>
+        new Date(a.finishedAt ?? a.createdAt).getTime() -
+        new Date(b.finishedAt ?? b.createdAt).getTime(),
+    );
+
+  const categories: WeaknessSummaryItem[] = (
+    [
+      {
+        category: 'correctness',
+        sessions: scoredCandidateRecords.filter((record) => (record.score ?? 0) < 60),
+        frequency: 0,
+      },
+      {
+        category: 'consistency',
+        sessions: scoredCandidateRecords.filter(
+          (record) => (record.score ?? 0) >= 60 && (record.score ?? 0) < 75,
+        ),
+        frequency: 0,
+      },
+      {
+        category: 'pacing',
+        sessions: records.filter((record) => record.durationSeconds > 45 * 60),
+        frequency: 0,
+      },
+      {
+        category: 'difficulty',
+        sessions: scoredCandidateRecords.filter(
+          (record) => record.difficulty === 'hard' && (record.score ?? 0) < 80,
+        ),
+        frequency: 0,
+      },
+    ] satisfies WeaknessSummaryItem[]
+  ).map((item) => ({ ...item, frequency: item.sessions.length }));
+
+  return {
+    weaknesses: categories
+      .filter((item) => item.frequency > 0)
+      .sort((a, b) => b.frequency - a.frequency),
+    trend: scoredCandidateRecords.slice(-8).map((record) => ({
+      sessionId: record.id,
+      problemName: record.problemName,
+      score: Math.max(0, Math.min(100, Math.round(record.score ?? 0))),
+    })),
+  };
+}

--- a/apps/web/src/components/dashboard-weakness-summary.tsx
+++ b/apps/web/src/components/dashboard-weakness-summary.tsx
@@ -1,30 +1,54 @@
+import type { UserWeakness } from '@syncode/contracts';
 import { Badge, Button, Card, CardContent, CardHeader, CardTitle, Progress } from '@syncode/ui';
 import { Link } from '@tanstack/react-router';
 import { Activity, ArrowUpRight, BarChart3, Target } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { DashboardSessionRecord } from '@/lib/dashboard-session-history.js';
 
-type WeaknessCategory = 'correctness' | 'consistency' | 'pacing' | 'difficulty';
+type WeaknessCategory = UserWeakness['category'];
 
-type WeaknessSummaryItem = {
-  category: WeaknessCategory;
-  frequency: number;
-  sessions: DashboardSessionRecord[];
-};
+interface TrendHistoryPoint {
+  sessionId: string;
+  problemName: string | null;
+  reportedAt: string;
+  score: number;
+  categoryCount: number;
+}
 
 export function DashboardWeaknessSummary({
-  records,
+  weaknesses,
   isLoading,
   isUnavailable,
+  isError,
 }: {
-  readonly records: DashboardSessionRecord[];
+  readonly weaknesses: UserWeakness[];
   readonly isLoading?: boolean;
   readonly isUnavailable?: boolean;
+  readonly isError?: boolean;
 }) {
   const { t } = useTranslation('dashboard');
-  const { weaknesses, trend } = useMemo(() => buildWeaknessSummary(records), [records]);
-  const hasData = records.length > 0;
+  const sortedWeaknesses = useMemo(
+    () =>
+      [...weaknesses].sort(
+        (a, b) =>
+          b.frequency - a.frequency ||
+          new Date(b.lastSeenAt).getTime() - new Date(a.lastSeenAt).getTime(),
+      ),
+    [weaknesses],
+  );
+  const trendHistory = useMemo(() => buildTrendHistory(sortedWeaknesses), [sortedWeaknesses]);
+  const maxFrequency = Math.max(...sortedWeaknesses.map((item) => item.frequency), 0);
+  const isBlocked = isLoading || isUnavailable || isError;
+  const blockedTitle = isLoading
+    ? t('weakness.loadingTitle')
+    : isUnavailable
+      ? t('weakness.unavailableTitle')
+      : t('weakness.errorTitle');
+  const blockedDescription = isLoading
+    ? t('weakness.loadingDescription')
+    : isUnavailable
+      ? t('weakness.unavailableDescription')
+      : t('weakness.errorDescription');
 
   return (
     <section className="mt-8 sm:mt-10">
@@ -37,7 +61,7 @@ export function DashboardWeaknessSummary({
         </div>
         <Badge variant="outline" className="w-fit">
           <Activity className="size-3.5" />
-          {t('weakness.sessionCount', { count: records.length })}
+          {t('weakness.sessionCount', { count: sortedWeaknesses.length })}
         </Badge>
       </div>
 
@@ -50,29 +74,21 @@ export function DashboardWeaknessSummary({
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4 px-5 pb-6 sm:px-6">
-            {isLoading || isUnavailable ? (
+            {isBlocked ? (
+              <EmptyState title={blockedTitle} description={blockedDescription} />
+            ) : null}
+
+            {!isBlocked && sortedWeaknesses.length === 0 ? (
               <EmptyState
-                title={isLoading ? t('weakness.loadingTitle') : t('weakness.unavailableTitle')}
-                description={
-                  isLoading
-                    ? t('weakness.loadingDescription')
-                    : t('weakness.unavailableDescription')
-                }
+                title={t('weakness.noDataTitle')}
+                description={t('weakness.noDataDescription')}
               />
             ) : null}
 
-            {!isLoading && !isUnavailable && weaknesses.length === 0 ? (
-              <EmptyState
-                title={hasData ? t('weakness.noWeaknessTitle') : t('weakness.noDataTitle')}
-                description={
-                  hasData ? t('weakness.noWeaknessDescription') : t('weakness.noDataDescription')
-                }
-              />
-            ) : null}
-
-            {weaknesses.map((item) => (
-              <WeaknessCategoryRow key={item.category} item={item} totalSessions={records.length} />
-            ))}
+            {!isBlocked &&
+              sortedWeaknesses.map((item) => (
+                <WeaknessCategoryRow key={item.id} item={item} maxFrequency={maxFrequency} />
+              ))}
           </CardContent>
         </Card>
 
@@ -84,27 +100,12 @@ export function DashboardWeaknessSummary({
             </CardTitle>
           </CardHeader>
           <CardContent className="px-5 pb-6 sm:px-6">
-            {trend.length > 0 ? (
-              <div className="flex h-56 items-end gap-2">
-                {trend.map((point) => (
-                  <div
-                    key={point.sessionId}
-                    className="flex min-w-0 flex-1 flex-col items-center gap-2"
-                  >
-                    <div className="flex h-40 w-full items-end rounded-t-md bg-muted/40">
-                      <div
-                        className="w-full rounded-t-md bg-primary/75"
-                        style={{ height: `${Math.max(8, point.score)}%` }}
-                        title={t('weakness.trendPoint', {
-                          problem: point.problemName,
-                          score: point.score,
-                        })}
-                      />
-                    </div>
-                    <span className="max-w-full truncate text-[11px] text-muted-foreground">
-                      {point.score}
-                    </span>
-                  </div>
+            {isBlocked ? (
+              <EmptyState title={blockedTitle} description={blockedDescription} />
+            ) : trendHistory.length > 0 ? (
+              <div className="space-y-4">
+                {trendHistory.map((point) => (
+                  <TrendHistoryRow key={point.sessionId} point={point} />
                 ))}
               </div>
             ) : (
@@ -122,14 +123,14 @@ export function DashboardWeaknessSummary({
 
 function WeaknessCategoryRow({
   item,
-  totalSessions,
+  maxFrequency,
 }: {
-  readonly item: WeaknessSummaryItem;
-  readonly totalSessions: number;
+  readonly item: UserWeakness;
+  readonly maxFrequency: number;
 }) {
   const { t } = useTranslation('dashboard');
-  const percentage = totalSessions > 0 ? Math.round((item.frequency / totalSessions) * 100) : 0;
-  const linkedSessions = item.sessions.filter((session) => session.hasReport).slice(0, 3);
+  const percentage = maxFrequency > 0 ? Math.round((item.frequency / maxFrequency) * 100) : 0;
+  const linkedSessions = item.sessions.slice(0, 3);
 
   return (
     <div className="rounded-lg border border-border/50 bg-background/45 p-4">
@@ -139,26 +140,70 @@ function WeaknessCategoryRow({
             {t(`weakness.category.${item.category}.title`)}
           </h3>
           <p className="mt-1 text-sm text-muted-foreground">
-            {t(`weakness.category.${item.category}.description`)}
+            {item.description || t('weakness.descriptionFallback')}
           </p>
         </div>
-        <Badge variant={percentage >= 50 ? 'warning' : 'outline'}>
-          {t('weakness.frequency', { count: item.frequency })}
-        </Badge>
+        <div className="flex flex-wrap gap-2 sm:justify-end">
+          <Badge variant={item.trend === 'worsening' ? 'warning' : 'outline'}>
+            {t(`weakness.trend.${item.trend}`)}
+          </Badge>
+          <Badge variant="outline">{t('weakness.frequency', { count: item.frequency })}</Badge>
+        </div>
       </div>
-      <Progress value={percentage} className="mt-4 h-2" />
+      <Progress
+        value={percentage}
+        className="mt-4 h-2"
+        aria-label={t('weakness.frequencyProgress', {
+          category: t(`weakness.category.${item.category}.title`),
+          count: item.frequency,
+        })}
+      />
       {linkedSessions.length > 0 ? (
         <div className="mt-4 flex flex-wrap gap-2">
           {linkedSessions.map((session) => (
-            <Button key={session.id} asChild size="xs" variant="outline">
-              <Link to="/sessions/$sessionId" params={{ sessionId: session.id }}>
+            <Button key={session.sessionId} asChild size="xs" variant="outline">
+              <Link to="/sessions/$sessionId" params={{ sessionId: session.sessionId }}>
                 <ArrowUpRight className="size-3" />
-                {session.problemName}
+                {session.problemName ?? t('weakness.unknownProblem')}
               </Link>
             </Button>
           ))}
         </div>
       ) : null}
+    </div>
+  );
+}
+
+function TrendHistoryRow({ point }: { readonly point: TrendHistoryPoint }) {
+  const { t, i18n } = useTranslation('dashboard');
+  const reportedAt = new Date(point.reportedAt);
+  const dateLabel = new Intl.DateTimeFormat(i18n.language, {
+    month: 'short',
+    day: 'numeric',
+  }).format(reportedAt);
+  const problemName = point.problemName ?? t('weakness.unknownProblem');
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between gap-3 text-sm">
+        <div className="min-w-0">
+          <span className="block truncate font-medium text-foreground">{problemName}</span>
+          <span className="text-xs text-muted-foreground">{dateLabel}</span>
+        </div>
+        <span className="text-muted-foreground">
+          {t('weakness.trendScore', { score: point.score })}
+        </span>
+      </div>
+      <Progress
+        value={point.score}
+        aria-label={t('weakness.trendPoint', {
+          problem: problemName,
+          score: point.score,
+        })}
+      />
+      <p className="mt-1 text-xs text-muted-foreground">
+        {t('weakness.categoryCount', { count: point.categoryCount })}
+      </p>
     </div>
   );
 }
@@ -178,52 +223,52 @@ function EmptyState({
   );
 }
 
-function buildWeaknessSummary(records: DashboardSessionRecord[]) {
-  const scoredCandidateRecords = records
-    .filter((record) => record.viewerRole === 'candidate' && typeof record.score === 'number')
-    .sort(
-      (a, b) =>
-        new Date(a.finishedAt ?? a.createdAt).getTime() -
-        new Date(b.finishedAt ?? b.createdAt).getTime(),
-    );
+function buildTrendHistory(weaknesses: UserWeakness[]): TrendHistoryPoint[] {
+  const sessionsById = new Map<
+    string,
+    {
+      problemName: string | null;
+      reportedAt: string;
+      scores: number[];
+      categories: Set<WeaknessCategory>;
+    }
+  >();
 
-  const categories: WeaknessSummaryItem[] = (
-    [
-      {
-        category: 'correctness',
-        sessions: scoredCandidateRecords.filter((record) => (record.score ?? 0) < 60),
-        frequency: 0,
-      },
-      {
-        category: 'consistency',
-        sessions: scoredCandidateRecords.filter(
-          (record) => (record.score ?? 0) >= 60 && (record.score ?? 0) < 75,
-        ),
-        frequency: 0,
-      },
-      {
-        category: 'pacing',
-        sessions: records.filter((record) => record.durationSeconds > 45 * 60),
-        frequency: 0,
-      },
-      {
-        category: 'difficulty',
-        sessions: scoredCandidateRecords.filter(
-          (record) => record.difficulty === 'hard' && (record.score ?? 0) < 80,
-        ),
-        frequency: 0,
-      },
-    ] satisfies WeaknessSummaryItem[]
-  ).map((item) => ({ ...item, frequency: item.sessions.length }));
+  for (const weakness of weaknesses) {
+    for (const session of weakness.sessions) {
+      if (session.score == null) {
+        continue;
+      }
 
-  return {
-    weaknesses: categories
-      .filter((item) => item.frequency > 0)
-      .sort((a, b) => b.frequency - a.frequency),
-    trend: scoredCandidateRecords.slice(-8).map((record) => ({
-      sessionId: record.id,
-      problemName: record.problemName,
-      score: Math.max(0, Math.min(100, Math.round(record.score ?? 0))),
-    })),
-  };
+      const existing = sessionsById.get(session.sessionId);
+
+      if (!existing) {
+        sessionsById.set(session.sessionId, {
+          problemName: session.problemName,
+          reportedAt: session.reportedAt,
+          scores: [session.score],
+          categories: new Set([weakness.category]),
+        });
+        continue;
+      }
+
+      existing.scores.push(session.score);
+      existing.categories.add(weakness.category);
+
+      if (new Date(session.reportedAt).getTime() > new Date(existing.reportedAt).getTime()) {
+        existing.reportedAt = session.reportedAt;
+      }
+    }
+  }
+
+  return [...sessionsById.entries()]
+    .map(([sessionId, item]) => ({
+      sessionId,
+      problemName: item.problemName,
+      reportedAt: item.reportedAt,
+      score: Math.round(item.scores.reduce((sum, score) => sum + score, 0) / item.scores.length),
+      categoryCount: item.categories.size,
+    }))
+    .sort((a, b) => new Date(a.reportedAt).getTime() - new Date(b.reportedAt).getTime())
+    .slice(-6);
 }

--- a/apps/web/src/lib/user-weaknesses.ts
+++ b/apps/web/src/lib/user-weaknesses.ts
@@ -1,0 +1,27 @@
+import { CONTROL_API, type UserWeaknessesResponse } from '@syncode/contracts';
+import { api } from '@/lib/api-client.js';
+
+export const USER_WEAKNESSES_QUERY_KEY = ['users', 'me', 'weaknesses'] as const;
+
+export function fetchUserWeaknesses(): Promise<UserWeaknessesResponse> {
+  return api(CONTROL_API.USERS.WEAKNESSES);
+}
+
+export function removeSessionFromUserWeaknesses(
+  weaknesses: UserWeaknessesResponse,
+  sessionId: string,
+): UserWeaknessesResponse {
+  return {
+    data: weaknesses.data
+      .map((weakness) => {
+        const sessions = weakness.sessions.filter((session) => session.sessionId !== sessionId);
+
+        return {
+          ...weakness,
+          frequency: sessions.length,
+          sessions,
+        };
+      })
+      .filter((weakness) => weakness.sessions.length > 0),
+  };
+}

--- a/apps/web/src/locales/en/dashboard.json
+++ b/apps/web/src/locales/en/dashboard.json
@@ -8,6 +8,43 @@
     "averageScore": "Average Score",
     "practiceTime": "Practice Time"
   },
+  "weakness": {
+    "heading": "Weakness summary",
+    "sub": "Spot repeated practice gaps and review the sessions behind them.",
+    "sessionCount": "{{count}} sessions analyzed",
+    "categoriesTitle": "Frequent categories",
+    "trendTitle": "Improvement trend",
+    "frequency": "{{count}} hits",
+    "loadingTitle": "Loading weaknesses",
+    "loadingDescription": "We're analyzing your recent sessions.",
+    "unavailableTitle": "Weakness summary unavailable",
+    "unavailableDescription": "The summary will appear once your account session is ready.",
+    "noWeaknessTitle": "No repeated weaknesses detected",
+    "noWeaknessDescription": "Your recent candidate sessions do not show a repeated pattern yet.",
+    "noDataTitle": "No session data yet",
+    "noDataDescription": "Complete more interview sessions to unlock weakness trends.",
+    "noTrendTitle": "No scored trend yet",
+    "noTrendDescription": "Candidate sessions with scores will appear here.",
+    "trendPoint": "{{problem}} scored {{score}}",
+    "category": {
+      "correctness": {
+        "title": "Correctness",
+        "description": "Candidate sessions below the passing score."
+      },
+      "consistency": {
+        "title": "Consistency",
+        "description": "Sessions that passed but stayed below a strong score."
+      },
+      "pacing": {
+        "title": "Pacing",
+        "description": "Sessions that ran longer than the target interview window."
+      },
+      "difficulty": {
+        "title": "Hard-problem execution",
+        "description": "Hard problems where the final score left room to improve."
+      }
+    }
+  },
   "recentSessions": "Recent Sessions",
   "search": {
     "placeholder": "Search by problem name"

--- a/apps/web/src/locales/en/dashboard.json
+++ b/apps/web/src/locales/en/dashboard.json
@@ -11,37 +11,58 @@
   "weakness": {
     "heading": "Weakness summary",
     "sub": "Spot repeated practice gaps and review the sessions behind them.",
-    "sessionCount": "{{count}} sessions analyzed",
+    "sessionCount_one": "{{count}} category tracked",
+    "sessionCount_other": "{{count}} categories tracked",
     "categoriesTitle": "Frequent categories",
-    "trendTitle": "Improvement trend",
-    "frequency": "{{count}} hits",
+    "trendTitle": "Improvement over time",
+    "unknownProblem": "Untitled problem",
+    "descriptionFallback": "Review this pattern in the linked session report.",
+    "frequency_one": "{{count}} hit",
+    "frequency_other": "{{count}} hits",
+    "frequencyProgress": "{{category}} appeared {{count}} times",
+    "trendScore": "{{score}}%",
+    "categoryCount_one": "{{count}} weakness category",
+    "categoryCount_other": "{{count}} weakness categories",
     "loadingTitle": "Loading weaknesses",
-    "loadingDescription": "We're analyzing your recent sessions.",
+    "loadingDescription": "We're loading your tracked weakness categories.",
     "unavailableTitle": "Weakness summary unavailable",
     "unavailableDescription": "The summary will appear once your account session is ready.",
-    "noWeaknessTitle": "No repeated weaknesses detected",
-    "noWeaknessDescription": "Your recent candidate sessions do not show a repeated pattern yet.",
-    "noDataTitle": "No session data yet",
-    "noDataDescription": "Complete more interview sessions to unlock weakness trends.",
-    "noTrendTitle": "No scored trend yet",
-    "noTrendDescription": "Candidate sessions with scores will appear here.",
-    "trendPoint": "{{problem}} scored {{score}}",
+    "errorTitle": "Unable to load weakness summary",
+    "errorDescription": "Weakness trends could not be retrieved right now. Try again in a moment.",
+    "noDataTitle": "No weaknesses tracked yet",
+    "noDataDescription": "Weakness categories will appear here after session reports identify repeated patterns.",
+    "noTrendTitle": "No trend data yet",
+    "noTrendDescription": "Score history will appear once linked session reports are available.",
+    "trendPoint": "{{problem}} weakness score was {{score}}%",
+    "trend": {
+      "improving": "Improving",
+      "stable": "Stable",
+      "worsening": "Worsening"
+    },
     "category": {
-      "correctness": {
-        "title": "Correctness",
-        "description": "Candidate sessions below the passing score."
+      "edge_cases": {
+        "title": "Edge cases"
       },
-      "consistency": {
-        "title": "Consistency",
-        "description": "Sessions that passed but stayed below a strong score."
+      "time_complexity": {
+        "title": "Time complexity"
       },
-      "pacing": {
-        "title": "Pacing",
-        "description": "Sessions that ran longer than the target interview window."
+      "space_complexity": {
+        "title": "Space complexity"
       },
-      "difficulty": {
-        "title": "Hard-problem execution",
-        "description": "Hard problems where the final score left room to improve."
+      "variable_naming": {
+        "title": "Variable naming"
+      },
+      "code_structure": {
+        "title": "Code structure"
+      },
+      "off_by_one": {
+        "title": "Off-by-one errors"
+      },
+      "input_validation": {
+        "title": "Input validation"
+      },
+      "communication": {
+        "title": "Communication"
       }
     }
   },

--- a/apps/web/src/locales/zh/dashboard.json
+++ b/apps/web/src/locales/zh/dashboard.json
@@ -86,37 +86,55 @@
   "weakness": {
     "heading": "薄弱项总结",
     "sub": "找出重复出现的练习短板，并回看相关会话。",
-    "sessionCount": "已分析 {{count}} 场会话",
+    "sessionCount_other": "已跟踪 {{count}} 个类别",
     "categoriesTitle": "高频类别",
-    "trendTitle": "提升趋势",
-    "frequency": "{{count}} 次",
+    "trendTitle": "改善趋势",
+    "unknownProblem": "未命名题目",
+    "descriptionFallback": "请回看关联会话报告中的这个模式。",
+    "frequency_other": "{{count}} 次",
+    "frequencyProgress": "{{category}} 出现 {{count}} 次",
+    "trendScore": "{{score}}%",
+    "categoryCount_other": "{{count}} 个薄弱项类别",
     "loadingTitle": "正在加载薄弱项",
-    "loadingDescription": "正在分析你的近期会话。",
+    "loadingDescription": "正在加载已跟踪的薄弱项类别。",
     "unavailableTitle": "薄弱项总结暂不可用",
     "unavailableDescription": "账户会话就绪后将显示总结。",
-    "noWeaknessTitle": "未检测到重复薄弱项",
-    "noWeaknessDescription": "你近期的候选人会话暂未呈现重复模式。",
-    "noDataTitle": "暂无会话数据",
-    "noDataDescription": "完成更多面试会话后即可解锁薄弱项趋势。",
-    "noTrendTitle": "暂无评分趋势",
-    "noTrendDescription": "有评分的候选人会话将显示在这里。",
-    "trendPoint": "{{problem}} 得分 {{score}}",
+    "errorTitle": "无法加载薄弱项总结",
+    "errorDescription": "当前无法获取薄弱项趋势，请稍后重试。",
+    "noDataTitle": "暂无已跟踪的薄弱项",
+    "noDataDescription": "会话报告识别出重复模式后，薄弱项类别将显示在这里。",
+    "noTrendTitle": "暂无趋势数据",
+    "noTrendDescription": "关联会话报告可用后将显示得分历史。",
+    "trendPoint": "{{problem}} 的薄弱项得分为 {{score}}%",
+    "trend": {
+      "improving": "正在改善",
+      "stable": "稳定",
+      "worsening": "恶化"
+    },
     "category": {
-      "correctness": {
-        "title": "正确性",
-        "description": "低于通过分的候选人会话。"
+      "edge_cases": {
+        "title": "边界情况"
       },
-      "consistency": {
-        "title": "稳定性",
-        "description": "已通过但分数还不够稳的会话。"
+      "time_complexity": {
+        "title": "时间复杂度"
       },
-      "pacing": {
-        "title": "节奏",
-        "description": "超出目标面试时间窗口的会话。"
+      "space_complexity": {
+        "title": "空间复杂度"
       },
-      "difficulty": {
-        "title": "困难题执行",
-        "description": "最终分数仍有提升空间的困难题。"
+      "variable_naming": {
+        "title": "变量命名"
+      },
+      "code_structure": {
+        "title": "代码结构"
+      },
+      "off_by_one": {
+        "title": "边界偏差错误"
+      },
+      "input_validation": {
+        "title": "输入校验"
+      },
+      "communication": {
+        "title": "沟通表达"
       }
     }
   }

--- a/apps/web/src/locales/zh/dashboard.json
+++ b/apps/web/src/locales/zh/dashboard.json
@@ -82,5 +82,42 @@
     "noMatchDescription": "尝试调整搜索、筛选或排序条件以查看更多会话历史。",
     "noSessionsTitle": "暂无会话",
     "noSessionsDescription": "完成面试练习后，你的记录将显示在这里。"
+  },
+  "weakness": {
+    "heading": "薄弱项总结",
+    "sub": "找出重复出现的练习短板，并回看相关会话。",
+    "sessionCount": "已分析 {{count}} 场会话",
+    "categoriesTitle": "高频类别",
+    "trendTitle": "提升趋势",
+    "frequency": "{{count}} 次",
+    "loadingTitle": "正在加载薄弱项",
+    "loadingDescription": "正在分析你的近期会话。",
+    "unavailableTitle": "薄弱项总结暂不可用",
+    "unavailableDescription": "账户会话就绪后将显示总结。",
+    "noWeaknessTitle": "未检测到重复薄弱项",
+    "noWeaknessDescription": "你近期的候选人会话暂未呈现重复模式。",
+    "noDataTitle": "暂无会话数据",
+    "noDataDescription": "完成更多面试会话后即可解锁薄弱项趋势。",
+    "noTrendTitle": "暂无评分趋势",
+    "noTrendDescription": "有评分的候选人会话将显示在这里。",
+    "trendPoint": "{{problem}} 得分 {{score}}",
+    "category": {
+      "correctness": {
+        "title": "正确性",
+        "description": "低于通过分的候选人会话。"
+      },
+      "consistency": {
+        "title": "稳定性",
+        "description": "已通过但分数还不够稳的会话。"
+      },
+      "pacing": {
+        "title": "节奏",
+        "description": "超出目标面试时间窗口的会话。"
+      },
+      "difficulty": {
+        "title": "困难题执行",
+        "description": "最终分数仍有提升空间的困难题。"
+      }
+    }
   }
 }

--- a/apps/web/src/routes/_app/dashboard.tsx
+++ b/apps/web/src/routes/_app/dashboard.tsx
@@ -5,6 +5,7 @@ import type { LucideIcon } from 'lucide-react';
 import { Calendar, Clock3, Target, TrendingUp } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { DashboardRecentSessions } from '@/components/dashboard-recent-sessions.js';
+import { DashboardWeaknessSummary } from '@/components/dashboard-weakness-summary.js';
 import {
   EMPTY_DASHBOARD_STATS,
   fetchDashboardSessionHistory,
@@ -96,6 +97,12 @@ function DashboardPage() {
           ))}
         </div>
       </section>
+
+      <DashboardWeaknessSummary
+        records={sessionHistory?.records ?? []}
+        isLoading={sessionHistoryQuery.isLoading}
+        isUnavailable={isUnavailable}
+      />
 
       <DashboardRecentSessions
         viewerId={viewerId}

--- a/apps/web/src/routes/_app/dashboard.tsx
+++ b/apps/web/src/routes/_app/dashboard.tsx
@@ -12,6 +12,7 @@ import {
   getDashboardSessionHistoryQueryKey,
 } from '@/lib/dashboard-session-history.js';
 import { getUserDisplayName } from '@/lib/user-utils.js';
+import { fetchUserWeaknesses, USER_WEAKNESSES_QUERY_KEY } from '@/lib/user-weaknesses.js';
 import { useAuthStore } from '@/stores/auth.store.js';
 
 export const Route = createFileRoute('/_app/dashboard')({
@@ -35,6 +36,11 @@ function DashboardPage() {
 
       return fetchDashboardSessionHistory(viewerId);
     },
+  });
+  const weaknessesQuery = useQuery({
+    queryKey: USER_WEAKNESSES_QUERY_KEY,
+    enabled: isQueryEnabled,
+    queryFn: fetchUserWeaknesses,
   });
   const sessionHistory = sessionHistoryQuery.data;
   const isUnavailable = !isQueryEnabled;
@@ -99,9 +105,10 @@ function DashboardPage() {
       </section>
 
       <DashboardWeaknessSummary
-        records={sessionHistory?.records ?? []}
-        isLoading={sessionHistoryQuery.isLoading}
+        weaknesses={weaknessesQuery.data?.data ?? []}
+        isLoading={weaknessesQuery.isLoading}
         isUnavailable={isUnavailable}
+        isError={weaknessesQuery.isError}
       />
 
       <DashboardRecentSessions

--- a/packages/contracts/src/control/routes.ts
+++ b/packages/contracts/src/control/routes.ts
@@ -74,6 +74,7 @@ import type {
   updateUserSchema,
   userProfileResponseSchema,
   userQuotasResponseSchema,
+  userWeaknessesResponseSchema,
 } from './users.js';
 import type {
   whiteboardAssetUploadUrlRequestSchema,
@@ -113,6 +114,10 @@ export const CONTROL_API = {
   USERS: {
     PROFILE: defineRoute<void, z.infer<typeof userProfileResponseSchema>>()('users/me', 'GET'),
     QUOTAS: defineRoute<void, z.infer<typeof userQuotasResponseSchema>>()('users/me/quotas', 'GET'),
+    WEAKNESSES: defineRoute<void, z.infer<typeof userWeaknessesResponseSchema>>()(
+      'users/me/weaknesses',
+      'GET',
+    ),
     GET_BY_ID: defineRoute<void, z.infer<typeof publicUserProfileResponseSchema>>()(
       'users/:id',
       'GET',

--- a/packages/contracts/src/control/users.ts
+++ b/packages/contracts/src/control/users.ts
@@ -1,6 +1,19 @@
 import { UserRole } from '@syncode/shared';
 import { z } from 'zod';
 
+export const USER_WEAKNESS_CATEGORIES = [
+  'edge_cases',
+  'time_complexity',
+  'space_complexity',
+  'variable_naming',
+  'code_structure',
+  'off_by_one',
+  'input_validation',
+  'communication',
+] as const;
+
+export const USER_WEAKNESS_TRENDS = ['improving', 'stable', 'worsening'] as const;
+
 export const updateUserSchema = z
   .object({
     displayName: z
@@ -129,6 +142,30 @@ export const userQuotasResponseSchema = z.object({
 });
 
 export type UserQuotasResponse = z.infer<typeof userQuotasResponseSchema>;
+
+export const userWeaknessSessionSchema = z.object({
+  sessionId: z.uuid(),
+  problemName: z.string().nullable(),
+  reportedAt: z.iso.datetime(),
+  score: z.number().int().min(0).max(100).nullable(),
+});
+
+export const userWeaknessSchema = z.object({
+  id: z.uuid(),
+  category: z.enum(USER_WEAKNESS_CATEGORIES),
+  description: z.string(),
+  frequency: z.number().int().nonnegative(),
+  trend: z.enum(USER_WEAKNESS_TRENDS),
+  lastSeenAt: z.iso.datetime(),
+  sessions: z.array(userWeaknessSessionSchema).default([]),
+});
+
+export const userWeaknessesResponseSchema = z.object({
+  data: z.array(userWeaknessSchema).default([]),
+});
+
+export type UserWeakness = z.infer<typeof userWeaknessSchema>;
+export type UserWeaknessesResponse = z.infer<typeof userWeaknessesResponseSchema>;
 
 export const avatarUploadUrlResponseSchema = z.object({
   uploadUrl: z.string().describe('Presigned PUT URL for direct S3 upload'),

--- a/packages/db/drizzle/0010_eager_rafael_vega.sql
+++ b/packages/db/drizzle/0010_eager_rafael_vega.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "weakness_sessions" ADD COLUMN "description" text;--> statement-breakpoint
+ALTER TABLE "weakness_sessions" ADD COLUMN "trend" "weakness_trend";--> statement-breakpoint
+ALTER TABLE "weakness_sessions" ADD COLUMN "score" integer;--> statement-breakpoint
+ALTER TABLE "weakness_sessions" ADD COLUMN "reported_at" timestamp with time zone;

--- a/packages/db/drizzle/meta/0010_snapshot.json
+++ b/packages/db/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,4152 @@
+{
+  "id": "31974ad7-05ac-4ab8-a171-bc9dfc185cbc",
+  "prevId": "73b14bb9-5460-4ec1-abca-fafc144c4040",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_hints": {
+      "name": "ai_hints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint_level": {
+          "name": "hint_level",
+          "type": "hint_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_concepts": {
+          "name": "related_concepts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_hints_room_id_idx": {
+          "name": "ai_hints_room_id_idx",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_hints_user_id_idx": {
+          "name": "ai_hints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_hints_room_id_rooms_id_fk": {
+          "name": "ai_hints_room_id_rooms_id_fk",
+          "tableFrom": "ai_hints",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_hints_user_id_users_id_fk": {
+          "name": "ai_hints_user_id_users_id_fk",
+          "tableFrom": "ai_hints",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_messages": {
+      "name": "ai_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "ai_message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_type": {
+          "name": "follow_up_type",
+          "type": "follow_up_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_key": {
+          "name": "audio_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_messages_session_id_idx": {
+          "name": "ai_messages_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_messages_room_created_idx": {
+          "name": "ai_messages_room_created_idx",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_messages_room_id_rooms_id_fk": {
+          "name": "ai_messages_room_id_rooms_id_fk",
+          "tableFrom": "ai_messages",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_messages_session_id_sessions_id_fk": {
+          "name": "ai_messages_session_id_sessions_id_fk",
+          "tableFrom": "ai_messages",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_messages_user_id_users_id_fk": {
+          "name": "ai_messages_user_id_users_id_fk",
+          "tableFrom": "ai_messages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_reviews": {
+      "name": "ai_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_reviews_room_id_idx": {
+          "name": "ai_reviews_room_id_idx",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_reviews_user_id_idx": {
+          "name": "ai_reviews_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_reviews_room_id_rooms_id_fk": {
+          "name": "ai_reviews_room_id_rooms_id_fk",
+          "tableFrom": "ai_reviews",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_reviews_user_id_users_id_fk": {
+          "name": "ai_reviews_user_id_users_id_fk",
+          "tableFrom": "ai_reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_logs_action_idx": {
+          "name": "audit_logs_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_target_idx": {
+          "name": "audit_logs_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_actor_created_idx": {
+          "name": "audit_logs_actor_created_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_actor_id_users_id_fk": {
+          "name": "audit_logs_actor_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_problem_id_idx": {
+          "name": "bookmarks_problem_id_idx",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_problem_id_problems_id_fk": {
+          "name": "bookmarks_problem_id_problems_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "problems",
+          "columnsFrom": ["problem_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bookmarks_user_id_problem_id_pk": {
+          "name": "bookmarks_user_id_problem_id_pk",
+          "columns": ["user_id", "problem_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_snapshots": {
+      "name": "code_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "supported_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "snapshot_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "room_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lines_of_code": {
+          "name": "lines_of_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "code_snapshots_room_id_idx": {
+          "name": "code_snapshots_room_id_idx",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "code_snapshots_session_created_idx": {
+          "name": "code_snapshots_session_created_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "code_snapshots_session_id_sessions_id_fk": {
+          "name": "code_snapshots_session_id_sessions_id_fk",
+          "tableFrom": "code_snapshots",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "code_snapshots_room_id_rooms_id_fk": {
+          "name": "code_snapshots_room_id_rooms_id_fk",
+          "tableFrom": "code_snapshots",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_results": {
+      "name": "execution_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_index": {
+          "name": "test_case_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdout": {
+          "name": "stdout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stderr": {
+          "name": "stderr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected": {
+          "name": "expected",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual": {
+          "name": "actual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_usage_mb": {
+          "name": "memory_usage_mb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timed_out": {
+          "name": "timed_out",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "execution_results_submission_case_unique": {
+          "name": "execution_results_submission_case_unique",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "test_case_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "execution_results_submission_id_submissions_id_fk": {
+          "name": "execution_results_submission_id_submissions_id_fk",
+          "tableFrom": "execution_results",
+          "tableTo": "submissions",
+          "columnsFrom": ["submission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_limits": {
+      "name": "global_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idempotency_keys_user_id_idx": {
+          "name": "idempotency_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idempotency_keys_expires_at_idx": {
+          "name": "idempotency_keys_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_user_id_users_id_fk": {
+          "name": "idempotency_keys_user_id_users_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_requests": {
+      "name": "match_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "supported_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_tags": {
+          "name": "requested_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "matched_room_id": {
+          "name": "matched_room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_with_user_id": {
+          "name": "matched_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "match_requests_user_id_idx": {
+          "name": "match_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "match_requests_status_idx": {
+          "name": "match_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "match_requests_expires_at_idx": {
+          "name": "match_requests_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_requests_user_id_users_id_fk": {
+          "name": "match_requests_user_id_users_id_fk",
+          "tableFrom": "match_requests",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_requests_matched_room_id_rooms_id_fk": {
+          "name": "match_requests_matched_room_id_rooms_id_fk",
+          "tableFrom": "match_requests",
+          "tableTo": "rooms",
+          "columnsFrom": ["matched_room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_requests_matched_with_user_id_users_id_fk": {
+          "name": "match_requests_matched_with_user_id_users_id_fk",
+          "tableFrom": "match_requests",
+          "tableTo": "users",
+          "columnsFrom": ["matched_with_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_token_hash_idx": {
+          "name": "password_reset_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_tokens_user_id_idx": {
+          "name": "password_reset_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_tokens_expires_at_idx": {
+          "name": "password_reset_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peer_feedback": {
+      "name": "peer_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_solving_rating": {
+          "name": "problem_solving_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "communication_rating": {
+          "name": "communication_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_quality_rating": {
+          "name": "code_quality_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "debugging_rating": {
+          "name": "debugging_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_rating": {
+          "name": "overall_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "improvements": {
+          "name": "improvements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "would_pair_again": {
+          "name": "would_pair_again",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peer_feedback_room_reviewer_candidate_unique": {
+          "name": "peer_feedback_room_reviewer_candidate_unique",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reviewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peer_feedback_session_id_idx": {
+          "name": "peer_feedback_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peer_feedback_reviewer_id_idx": {
+          "name": "peer_feedback_reviewer_id_idx",
+          "columns": [
+            {
+              "expression": "reviewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peer_feedback_candidate_id_idx": {
+          "name": "peer_feedback_candidate_id_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peer_feedback_session_id_sessions_id_fk": {
+          "name": "peer_feedback_session_id_sessions_id_fk",
+          "tableFrom": "peer_feedback",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "peer_feedback_room_id_rooms_id_fk": {
+          "name": "peer_feedback_room_id_rooms_id_fk",
+          "tableFrom": "peer_feedback",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "peer_feedback_reviewer_id_users_id_fk": {
+          "name": "peer_feedback_reviewer_id_users_id_fk",
+          "tableFrom": "peer_feedback",
+          "tableTo": "users",
+          "columnsFrom": ["reviewer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "peer_feedback_candidate_id_users_id_fk": {
+          "name": "peer_feedback_candidate_id_users_id_fk",
+          "tableFrom": "peer_feedback",
+          "tableTo": "users",
+          "columnsFrom": ["candidate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problem_tags": {
+      "name": "problem_tags",
+      "schema": "",
+      "columns": {
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "problem_tags_tag_id_idx": {
+          "name": "problem_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_tags_problem_id_problems_id_fk": {
+          "name": "problem_tags_problem_id_problems_id_fk",
+          "tableFrom": "problem_tags",
+          "tableTo": "problems",
+          "columnsFrom": ["problem_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "problem_tags_tag_id_tags_id_fk": {
+          "name": "problem_tags_tag_id_tags_id_fk",
+          "tableFrom": "problem_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "problem_tags_problem_id_tag_id_pk": {
+          "name": "problem_tags_problem_id_tag_id_pk",
+          "columns": ["problem_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problems": {
+      "name": "problems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "constraints": {
+          "name": "constraints",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "examples": {
+          "name": "examples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_code": {
+          "name": "starter_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_limit": {
+          "name": "time_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_limit": {
+          "name": "memory_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_submissions": {
+          "name": "total_submissions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepted_submissions": {
+          "name": "accepted_submissions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problems_title_unique": {
+          "name": "problems_title_unique",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problems_difficulty_idx": {
+          "name": "problems_difficulty_idx",
+          "columns": [
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problems_title_trgm_idx": {
+          "name": "problems_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "title gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "problems_description_trgm_idx": {
+          "name": "problems_description_trgm_idx",
+          "columns": [
+            {
+              "expression": "description gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "problems_created_at_idx": {
+          "name": "problems_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recording_consents": {
+      "name": "recording_consents",
+      "schema": "",
+      "columns": {
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent": {
+          "name": "consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recording_consents_room_id_rooms_id_fk": {
+          "name": "recording_consents_room_id_rooms_id_fk",
+          "tableFrom": "recording_consents",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recording_consents_user_id_users_id_fk": {
+          "name": "recording_consents_user_id_users_id_fk",
+          "tableFrom": "recording_consents",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "recording_consents_room_id_user_id_pk": {
+          "name": "recording_consents_room_id_user_id_pk",
+          "columns": ["room_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_id_idx": {
+          "name": "refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_token_hash_idx": {
+          "name": "refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_at_idx": {
+          "name": "refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_swap_requests": {
+      "name": "role_swap_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "role_swap_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "role_swap_requests_room_id_idx": {
+          "name": "role_swap_requests_room_id_idx",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_swap_requests_requester_id_idx": {
+          "name": "role_swap_requests_requester_id_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_swap_requests_target_user_id_idx": {
+          "name": "role_swap_requests_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_swap_requests_room_id_rooms_id_fk": {
+          "name": "role_swap_requests_room_id_rooms_id_fk",
+          "tableFrom": "role_swap_requests",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_swap_requests_requester_id_users_id_fk": {
+          "name": "role_swap_requests_requester_id_users_id_fk",
+          "tableFrom": "role_swap_requests",
+          "tableTo": "users",
+          "columnsFrom": ["requester_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "role_swap_requests_target_user_id_users_id_fk": {
+          "name": "role_swap_requests_target_user_id_users_id_fk",
+          "tableFrom": "role_swap_requests",
+          "tableTo": "users",
+          "columnsFrom": ["target_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.room_doc_snapshots": {
+      "name": "room_doc_snapshots",
+      "schema": "",
+      "columns": {
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "room_doc_snapshots_room_id_rooms_id_fk": {
+          "name": "room_doc_snapshots_room_id_rooms_id_fk",
+          "tableFrom": "room_doc_snapshots",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.room_participants": {
+      "name": "room_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "room_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_ready": {
+          "name": "is_ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "room_participants_room_user_unique": {
+          "name": "room_participants_room_user_unique",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "room_participants_user_id_idx": {
+          "name": "room_participants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "room_participants_user_active_idx": {
+          "name": "room_participants_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "room_participants_active_heartbeat_idx": {
+          "name": "room_participants_active_heartbeat_idx",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"room_participants\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "room_participants_room_id_rooms_id_fk": {
+          "name": "room_participants_room_id_rooms_id_fk",
+          "tableFrom": "room_participants",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "room_participants_user_id_users_id_fk": {
+          "name": "room_participants_user_id_users_id_fk",
+          "tableFrom": "room_participants",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "supported_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "room_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "room_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "max_participants": {
+          "name": "max_participants",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "max_duration": {
+          "name": "max_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 120
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editor_locked": {
+          "name": "editor_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timer_paused": {
+          "name": "timer_paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phase_started_at": {
+          "name": "phase_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsed_ms": {
+          "name": "elapsed_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rooms_invite_code_unique": {
+          "name": "rooms_invite_code_unique",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_host_id_idx": {
+          "name": "rooms_host_id_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_problem_id_idx": {
+          "name": "rooms_problem_id_idx",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_status_idx": {
+          "name": "rooms_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_created_at_idx": {
+          "name": "rooms_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_host_id_users_id_fk": {
+          "name": "rooms_host_id_users_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "users",
+          "columnsFrom": ["host_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_problem_id_problems_id_fk": {
+          "name": "rooms_problem_id_problems_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "problems",
+          "columnsFrom": ["problem_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "supported_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stdin": {
+          "name": "stdin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "stdout": {
+          "name": "stdout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stderr": {
+          "name": "stderr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_time_ms": {
+          "name": "cpu_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_usage_mb": {
+          "name": "memory_usage_mb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timed_out": {
+          "name": "timed_out",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "output_truncated": {
+          "name": "output_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_user_id_idx": {
+          "name": "runs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_room_created_idx": {
+          "name": "runs_room_created_idx",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_job_id_idx": {
+          "name": "runs_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_user_id_users_id_fk": {
+          "name": "runs_user_id_users_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_room_id_rooms_id_fk": {
+          "name": "runs_room_id_rooms_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_deletions": {
+      "name": "session_deletions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_deletions_user_id_idx": {
+          "name": "session_deletions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_deletions_session_id_sessions_id_fk": {
+          "name": "session_deletions_session_id_sessions_id_fk",
+          "tableFrom": "session_deletions",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_deletions_user_id_users_id_fk": {
+          "name": "session_deletions_user_id_users_id_fk",
+          "tableFrom": "session_deletions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_deletions_session_id_user_id_pk": {
+          "name": "session_deletions_session_id_user_id_pk",
+          "columns": ["session_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_events": {
+      "name": "session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_events_session_timestamp_idx": {
+          "name": "session_events_session_timestamp_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_events_event_type_idx": {
+          "name": "session_events_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_events_session_id_sessions_id_fk": {
+          "name": "session_events_session_id_sessions_id_fk",
+          "tableFrom": "session_events",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_events_user_id_users_id_fk": {
+          "name": "session_events_user_id_users_id_fk",
+          "tableFrom": "session_events",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_participants": {
+      "name": "session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "room_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_participants_user_id_idx": {
+          "name": "session_participants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_participants_session_id_sessions_id_fk": {
+          "name": "session_participants_session_id_sessions_id_fk",
+          "tableFrom": "session_participants",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_participants_user_id_users_id_fk": {
+          "name": "session_participants_user_id_users_id_fk",
+          "tableFrom": "session_participants",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_participants_session_id_user_id_pk": {
+          "name": "session_participants_session_id_user_id_pk",
+          "columns": ["session_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_recordings": {
+      "name": "session_recordings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_recordings_session_id_idx": {
+          "name": "session_recordings_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_recordings_session_id_sessions_id_fk": {
+          "name": "session_recordings_session_id_sessions_id_fk",
+          "tableFrom": "session_recordings",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_reports": {
+      "name": "session_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_reports_session_user_unique": {
+          "name": "session_reports_session_user_unique",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_reports_session_id_idx": {
+          "name": "session_reports_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_reports_user_id_idx": {
+          "name": "session_reports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_reports_status_idx": {
+          "name": "session_reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_reports_session_id_sessions_id_fk": {
+          "name": "session_reports_session_id_sessions_id_fk",
+          "tableFrom": "session_reports",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_reports_user_id_users_id_fk": {
+          "name": "session_reports_user_id_users_id_fk",
+          "tableFrom": "session_reports",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "room_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "supported_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ongoing'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whiteboard_export_key": {
+          "name": "whiteboard_export_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whiteboard_captured_at": {
+          "name": "whiteboard_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_room_id_unique": {
+          "name": "sessions_room_id_unique",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_problem_id_idx": {
+          "name": "sessions_problem_id_idx",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_started_at_idx": {
+          "name": "sessions_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_room_id_rooms_id_fk": {
+          "name": "sessions_room_id_rooms_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sessions_problem_id_problems_id_fk": {
+          "name": "sessions_problem_id_problems_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "problems",
+          "columnsFrom": ["problem_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "supported_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_test_cases": {
+          "name": "total_test_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed_test_cases": {
+          "name": "passed_test_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_test_cases": {
+          "name": "failed_test_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_test_cases": {
+          "name": "error_test_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_duration_ms": {
+          "name": "total_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "submissions_user_id_idx": {
+          "name": "submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_problem_id_idx": {
+          "name": "submissions_problem_id_idx",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_room_submitted_idx": {
+          "name": "submissions_room_submitted_idx",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_room_id_rooms_id_fk": {
+          "name": "submissions_room_id_rooms_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_problem_id_problems_id_fk": {
+          "name": "submissions_problem_id_problems_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "problems",
+          "columnsFrom": ["problem_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_cases": {
+      "name": "test_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_mb": {
+          "name": "memory_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_cases_problem_sort_idx": {
+          "name": "test_cases_problem_sort_idx",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_cases_problem_id_problems_id_fk": {
+          "name": "test_cases_problem_id_problems_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "problems",
+          "columnsFrom": ["problem_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_weaknesses": {
+      "name": "user_weaknesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "weakness_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "trend": {
+          "name": "trend",
+          "type": "weakness_trend",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stable'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_weaknesses_user_category_unique": {
+          "name": "user_weaknesses_user_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_weaknesses_user_frequency_idx": {
+          "name": "user_weaknesses_user_frequency_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_weaknesses_user_id_users_id_fk": {
+          "name": "user_weaknesses_user_id_users_id_fk",
+          "tableFrom": "user_weaknesses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weakness_sessions": {
+      "name": "weakness_sessions",
+      "schema": "",
+      "columns": {
+        "weakness_id": {
+          "name": "weakness_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trend": {
+          "name": "trend",
+          "type": "weakness_trend",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "weakness_sessions_session_id_idx": {
+          "name": "weakness_sessions_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weakness_sessions_weakness_id_user_weaknesses_id_fk": {
+          "name": "weakness_sessions_weakness_id_user_weaknesses_id_fk",
+          "tableFrom": "weakness_sessions",
+          "tableTo": "user_weaknesses",
+          "columnsFrom": ["weakness_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weakness_sessions_session_id_sessions_id_fk": {
+          "name": "weakness_sessions_session_id_sessions_id_fk",
+          "tableFrom": "weakness_sessions",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "weakness_sessions_weakness_id_session_id_pk": {
+          "name": "weakness_sessions_weakness_id_session_id_pk",
+          "columns": ["weakness_id", "session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.ai_message_role": {
+      "name": "ai_message_role",
+      "schema": "public",
+      "values": ["user", "assistant"]
+    },
+    "public.difficulty": {
+      "name": "difficulty",
+      "schema": "public",
+      "values": ["easy", "medium", "hard"]
+    },
+    "public.follow_up_type": {
+      "name": "follow_up_type",
+      "schema": "public",
+      "values": ["question", "hint", "evaluation", "encouragement"]
+    },
+    "public.hint_level": {
+      "name": "hint_level",
+      "schema": "public",
+      "values": ["subtle", "moderate", "direct"]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": ["pending", "matched", "expired", "cancelled"]
+    },
+    "public.role_swap_status": {
+      "name": "role_swap_status",
+      "schema": "public",
+      "values": ["pending", "accepted", "declined", "expired"]
+    },
+    "public.room_mode": {
+      "name": "room_mode",
+      "schema": "public",
+      "values": ["ai", "peer"]
+    },
+    "public.room_role": {
+      "name": "room_role",
+      "schema": "public",
+      "values": ["interviewer", "candidate", "observer"]
+    },
+    "public.room_status": {
+      "name": "room_status",
+      "schema": "public",
+      "values": ["waiting", "warmup", "coding", "wrapup", "finished"]
+    },
+    "public.session_report_status": {
+      "name": "session_report_status",
+      "schema": "public",
+      "values": ["pending", "completed", "failed"]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": ["ongoing", "finished"]
+    },
+    "public.snapshot_trigger": {
+      "name": "snapshot_trigger",
+      "schema": "public",
+      "values": ["submission", "phase_change", "periodic", "manual", "session_end"]
+    },
+    "public.submission_status": {
+      "name": "submission_status",
+      "schema": "public",
+      "values": ["pending", "running", "completed", "failed"]
+    },
+    "public.supported_language": {
+      "name": "supported_language",
+      "schema": "public",
+      "values": ["python", "javascript", "typescript", "java", "cpp", "c", "go", "rust"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["user", "admin"]
+    },
+    "public.weakness_category": {
+      "name": "weakness_category",
+      "schema": "public",
+      "values": [
+        "edge_cases",
+        "time_complexity",
+        "space_complexity",
+        "variable_naming",
+        "code_structure",
+        "off_by_one",
+        "input_validation",
+        "communication"
+      ]
+    },
+    "public.weakness_trend": {
+      "name": "weakness_trend",
+      "schema": "public",
+      "values": ["improving", "stable", "worsening"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1777333913818,
       "tag": "0009_parched_vapor",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1779028248811,
+      "tag": "0010_eager_rafael_vega",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/weakness-sessions.ts
+++ b/packages/db/src/schema/weakness-sessions.ts
@@ -1,4 +1,5 @@
-import { index, pgTable, primaryKey, uuid } from 'drizzle-orm/pg-core';
+import { index, integer, pgTable, primaryKey, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { weaknessTrendEnum } from './enums.js';
 import { sessions } from './sessions.js';
 import { userWeaknesses } from './user-weaknesses.js';
 
@@ -11,6 +12,10 @@ export const weaknessSessions = pgTable(
     sessionId: uuid('session_id')
       .notNull()
       .references(() => sessions.id, { onDelete: 'cascade' }),
+    description: text('description'),
+    trend: weaknessTrendEnum('trend'),
+    score: integer('score'),
+    reportedAt: timestamp('reported_at', { withTimezone: true }),
   },
   (table) => [
     primaryKey({ columns: [table.weaknessId, table.sessionId] }),


### PR DESCRIPTION
Closes #154
Adds dashboard weakness categories, frequency summary, trend visualization, and links back to session reports.