### PR TITLE
fix(web): auto refresh public room browse page every 5 seconds

### DIFF
--- a/apps/web/src/routes/_app/rooms/-browse.spec.tsx
+++ b/apps/web/src/routes/_app/rooms/-browse.spec.tsx
@@ -156,6 +156,7 @@ describe('BrowseRoomsPage', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 
@@ -309,6 +310,29 @@ describe('BrowseRoomsPage', () => {
         );
       });
       expect(searchedForValue).toBe(true);
+    });
+  });
+
+  it('GIVEN participant count changes on the server WHEN the refresh interval elapses THEN the card updates', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    apiMock
+      .mockResolvedValueOnce(makeResponse([makeRoom({ participantCount: 1, maxParticipants: 2 })]))
+      .mockResolvedValue(makeResponse([makeRoom({ participantCount: 2, maxParticipants: 2 })]));
+
+    renderPage();
+
+    expect(
+      await screen.findByText('browse.card.participantFraction current=1 max=2'),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('browse.card.participantFraction current=2 max=2'),
+      ).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/routes/_app/rooms/-browse.spec.tsx
+++ b/apps/web/src/routes/_app/rooms/-browse.spec.tsx
@@ -1,5 +1,5 @@
 import { CONTROL_API } from '@syncode/contracts';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { focusManager, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HTTPError } from 'ky';
@@ -156,6 +156,7 @@ describe('BrowseRoomsPage', () => {
   });
 
   afterEach(() => {
+    focusManager.setFocused(undefined);
     vi.useRealTimers();
     vi.clearAllMocks();
   });
@@ -315,6 +316,7 @@ describe('BrowseRoomsPage', () => {
 
   it('GIVEN participant count changes on the server WHEN the refresh interval elapses THEN the card updates', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
+    focusManager.setFocused(true);
     apiMock
       .mockResolvedValueOnce(makeResponse([makeRoom({ participantCount: 1, maxParticipants: 2 })]))
       .mockResolvedValue(makeResponse([makeRoom({ participantCount: 2, maxParticipants: 2 })]));

--- a/apps/web/src/routes/_app/rooms/-browse.spec.tsx
+++ b/apps/web/src/routes/_app/rooms/-browse.spec.tsx
@@ -326,7 +326,7 @@ describe('BrowseRoomsPage', () => {
     ).toBeInTheDocument();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(5_100);
     });
 
     await waitFor(() => {

--- a/apps/web/src/routes/_app/rooms/-browse.spec.tsx
+++ b/apps/web/src/routes/_app/rooms/-browse.spec.tsx
@@ -1,6 +1,6 @@
 import { CONTROL_API } from '@syncode/contracts';
 import { focusManager, QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HTTPError } from 'ky';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -120,8 +120,11 @@ function makeRoom(
   };
 }
 
-function makeResponse(data: BrowseResponse['data']): BrowseResponse {
-  return { data, pagination: { nextCursor: null, hasMore: false } };
+function makeResponse(
+  data: BrowseResponse['data'],
+  pagination: BrowseResponse['pagination'] = { nextCursor: null, hasMore: false },
+): BrowseResponse {
+  return { data, pagination };
 }
 
 function renderPage() {
@@ -315,27 +318,109 @@ describe('BrowseRoomsPage', () => {
   });
 
   it('GIVEN participant count changes on the server WHEN the refresh interval elapses THEN the card updates', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.useFakeTimers();
     focusManager.setFocused(true);
     apiMock
-      .mockResolvedValueOnce(makeResponse([makeRoom({ participantCount: 1, maxParticipants: 2 })]))
-      .mockResolvedValue(makeResponse([makeRoom({ participantCount: 2, maxParticipants: 2 })]));
+      .mockResolvedValueOnce(makeResponse([makeRoom({ participantCount: 1, maxParticipants: 3 })]))
+      .mockResolvedValue(makeResponse([makeRoom({ participantCount: 2, maxParticipants: 3 })]));
 
     renderPage();
 
-    expect(
-      await screen.findByText('browse.card.participantFraction current=1 max=2'),
-    ).toBeInTheDocument();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByText('browse.card.participantFraction current=1 max=3')).toBeInTheDocument();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(5_100);
     });
 
-    await waitFor(() => {
-      expect(
-        screen.getByText('browse.card.participantFraction current=2 max=2'),
-      ).toBeInTheDocument();
+    expect(screen.getByText('browse.card.participantFraction current=2 max=3')).toBeInTheDocument();
+  });
+
+  it('GIVEN more rooms are loaded WHEN the refresh interval elapses THEN all visible pages refresh without stale rooms', async () => {
+    vi.useFakeTimers();
+    focusManager.setFocused(true);
+    const seenCursors: Array<string | undefined> = [];
+    apiMock.mockImplementation((_route, opts) => {
+      const cursor = (opts as { searchParams?: { cursor?: string } } | undefined)?.searchParams
+        ?.cursor;
+      seenCursors.push(cursor);
+
+      if (seenCursors.length === 1) {
+        expect(cursor).toBeUndefined();
+        return Promise.resolve(
+          makeResponse([makeRoom({ roomId: 'room-1', problemTitle: 'Old first page' })], {
+            nextCursor: 'cursor-2',
+            hasMore: true,
+          }) as never,
+        );
+      }
+
+      if (seenCursors.length === 2) {
+        expect(cursor).toBe('cursor-2');
+        return Promise.resolve(
+          makeResponse([
+            makeRoom({
+              roomId: 'room-2',
+              problemTitle: 'Second page',
+              participantCount: 1,
+              maxParticipants: 3,
+            }),
+          ]) as never,
+        );
+      }
+
+      if (seenCursors.length === 3) {
+        expect(cursor).toBeUndefined();
+        return Promise.resolve(
+          makeResponse([makeRoom({ roomId: 'room-3', problemTitle: 'New first page' })], {
+            nextCursor: 'cursor-after-new-first-page',
+            hasMore: true,
+          }) as never,
+        );
+      }
+
+      if (seenCursors.length === 4) {
+        expect(cursor).toBe('cursor-after-new-first-page');
+        return Promise.resolve(
+          makeResponse([
+            makeRoom({
+              roomId: 'room-2',
+              problemTitle: 'Second page',
+              participantCount: 2,
+              maxParticipants: 3,
+            }),
+          ]) as never,
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected browse cursor: ${String(cursor)}`));
     });
+
+    renderPage();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByText('Old first page')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /browse\.loadMore/i }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByText('Second page')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100);
+    });
+
+    expect(screen.getByText('New first page')).toBeInTheDocument();
+    expect(screen.getByText('Second page')).toBeInTheDocument();
+    expect(screen.getByText('browse.card.participantFraction current=2 max=3')).toBeInTheDocument();
+    expect(screen.queryByText('Old first page')).not.toBeInTheDocument();
+    expect(seenCursors).toEqual([undefined, 'cursor-2', undefined, 'cursor-after-new-first-page']);
   });
 
   it('GIVEN a room WHERE isParticipant is true THEN the card shows Enter and an already-joined indicator', async () => {

--- a/apps/web/src/routes/_app/rooms/browse.tsx
+++ b/apps/web/src/routes/_app/rooms/browse.tsx
@@ -10,7 +10,7 @@ import {
   type SupportedLanguage,
 } from '@syncode/shared';
 import { Button, Input } from '@syncode/ui';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { Compass, Loader2, Search, Sparkles, X } from 'lucide-react';
 import { motion } from 'motion/react';
@@ -68,55 +68,41 @@ function BrowseRoomsPage() {
   }, [isAuthenticated, navigate]);
 
   const [filters, setFilters] = useState<BrowseFilters>(emptyFilters);
-  const [cursor, setCursor] = useState<string | undefined>(undefined);
-  const [accumulated, setAccumulated] = useState<PublicRoomSummary[]>([]);
 
   const deferredSearch = useDeferredValue(filters.search);
   const normalizedSearch = deferredSearch.trim();
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: filter changes are the intended trigger
-  useEffect(() => {
-    setAccumulated([]);
-    setCursor(undefined);
-  }, [normalizedSearch, filters.language, filters.difficulty, filters.status]);
-
   const searchParams = useMemo(
     () => ({
       limit: BROWSE_PAGE_SIZE,
-      cursor,
       language: filters.language ?? undefined,
       difficulty: filters.difficulty ?? undefined,
       status: filters.status ?? undefined,
       search: normalizedSearch.length > 0 ? normalizedSearch : undefined,
     }),
-    [cursor, filters.difficulty, filters.language, filters.status, normalizedSearch],
+    [filters.difficulty, filters.language, filters.status, normalizedSearch],
   );
 
-  const browseQuery = useQuery({
+  const browseQuery = useInfiniteQuery({
     queryKey: ['rooms', 'browse', searchParams],
-    queryFn: () => api(CONTROL_API.ROOMS.BROWSE_PUBLIC, { searchParams }),
-    placeholderData: (previous) => previous,
+    queryFn: ({ pageParam }) =>
+      api(CONTROL_API.ROOMS.BROWSE_PUBLIC, {
+        searchParams: { ...searchParams, cursor: pageParam },
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.pagination.nextCursor ?? undefined,
     refetchInterval: BROWSE_REFRESH_INTERVAL_MS,
   });
 
-  useEffect(() => {
-    const data = browseQuery.data;
-    if (!data) return;
-
-    setAccumulated((previous) => {
-      if (cursor === undefined) {
-        return data.data;
-      }
-      const seen = new Set(previous.map((room) => room.roomId));
-      const next = data.data.filter((room) => !seen.has(room.roomId));
-      const updates = new Map(data.data.map((room) => [room.roomId, room]));
-      const merged = previous.map((room) => updates.get(room.roomId) ?? room);
-      return next.length === 0 ? merged : [...merged, ...next];
+  const accumulated = useMemo(() => {
+    const rooms = browseQuery.data?.pages.flatMap((page) => page.data) ?? [];
+    const seen = new Set<string>();
+    return rooms.filter((room) => {
+      if (seen.has(room.roomId)) return false;
+      seen.add(room.roomId);
+      return true;
     });
-  }, [browseQuery.data, cursor]);
-
-  const hasMore = browseQuery.data?.pagination.hasMore === true;
-  const nextCursor = browseQuery.data?.pagination.nextCursor ?? null;
+  }, [browseQuery.data]);
 
   const joinMutation = useMutation({
     mutationFn: (roomId: string) =>
@@ -295,10 +281,11 @@ function BrowseRoomsPage() {
         listLabel={t('browse.heading')}
         handleJoin={handleJoin}
         joinPendingRoomId={joinMutation.isPending ? (joinMutation.variables ?? null) : null}
-        hasMore={hasMore}
-        nextCursor={nextCursor}
-        isFetching={browseQuery.isFetching}
-        onLoadMore={(c) => setCursor(c)}
+        hasMore={browseQuery.hasNextPage}
+        isFetchingMore={browseQuery.isFetchingNextPage}
+        onLoadMore={() => {
+          browseQuery.fetchNextPage().catch(() => undefined);
+        }}
         loadMoreLabel={t('browse.loadMore')}
       />
     </div>
@@ -314,9 +301,8 @@ type BrowseResultsProps = {
   handleJoin: (roomId: string) => void;
   joinPendingRoomId: string | null;
   hasMore: boolean;
-  nextCursor: string | null;
-  isFetching: boolean;
-  onLoadMore: (cursor: string) => void;
+  isFetchingMore: boolean;
+  onLoadMore: () => void;
   loadMoreLabel: string;
 };
 
@@ -329,8 +315,7 @@ function BrowseResults({
   handleJoin,
   joinPendingRoomId,
   hasMore,
-  nextCursor,
-  isFetching,
+  isFetchingMore,
   onLoadMore,
   loadMoreLabel,
 }: BrowseResultsProps) {
@@ -360,16 +345,20 @@ function BrowseResults({
         ))}
       </ul>
 
-      {hasMore && nextCursor !== null && (
+      {hasMore && (
         <div className="mt-10 flex justify-center">
           <Button
             variant="outline"
             size="lg"
-            disabled={isFetching}
-            onClick={() => onLoadMore(nextCursor)}
+            disabled={isFetchingMore}
+            onClick={onLoadMore}
             className="gap-2"
           >
-            {isFetching ? <Loader2 size={16} className="animate-spin" /> : <Compass size={16} />}
+            {isFetchingMore ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Compass size={16} />
+            )}
             {loadMoreLabel}
           </Button>
         </div>

--- a/apps/web/src/routes/_app/rooms/browse.tsx
+++ b/apps/web/src/routes/_app/rooms/browse.tsx
@@ -40,6 +40,7 @@ export const Route = createFileRoute('/_app/rooms/browse')({
 export { BrowseRoomsPage };
 
 const BROWSE_PAGE_SIZE = 12;
+const BROWSE_REFRESH_INTERVAL_MS = 5_000;
 
 type BrowseFilters = {
   search: string;
@@ -95,6 +96,7 @@ function BrowseRoomsPage() {
     queryKey: ['rooms', 'browse', searchParams],
     queryFn: () => api(CONTROL_API.ROOMS.BROWSE_PUBLIC, { searchParams }),
     placeholderData: (previous) => previous,
+    refetchInterval: BROWSE_REFRESH_INTERVAL_MS,
   });
 
   useEffect(() => {
@@ -107,7 +109,9 @@ function BrowseRoomsPage() {
       }
       const seen = new Set(previous.map((room) => room.roomId));
       const next = data.data.filter((room) => !seen.has(room.roomId));
-      return next.length === 0 ? previous : [...previous, ...next];
+      const updates = new Map(data.data.map((room) => [room.roomId, room]));
+      const merged = previous.map((room) => updates.get(room.roomId) ?? room);
+      return next.length === 0 ? merged : [...merged, ...next];
     });
   }, [browseQuery.data, cursor]);
 


### PR DESCRIPTION
Refs #44

Adds periodic refresh for the public room browse page so visible room capacity/status stays current while users are choosing a room. This does not close #44; the broader Join Interview Room story remains open.