### PR TITLE
feat(ai-plane): add evidence display in session report

### DIFF
--- a/apps/web/src/components/session-report/report-dimension-card.tsx
+++ b/apps/web/src/components/session-report/report-dimension-card.tsx
@@ -2,7 +2,7 @@ import type { SessionReportDimension } from '@syncode/contracts';
 import type { SupportedLanguage } from '@syncode/shared';
 import type { ReactNode } from 'react';
 import { AiFeedbackText } from './ai-feedback-rich-text.js';
-import { ReportSnapshotCodeViewer } from './report-snapshot-code-viewer.js';
+import { EvidenceCard } from './report-evidence-card.js';
 
 export function ReportDimensionCard({
   title,
@@ -41,22 +41,11 @@ export function ReportDimensionCard({
       {dimension.evidence.length > 0 ? (
         <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
           {dimension.evidence.slice(0, 2).map((item, index) => (
-            <li
+            <EvidenceCard
               key={`${item.type}-${item.reference}-${index}`}
-              className="rounded-xl bg-background/60 px-3 py-2.5"
-            >
-              <p className="font-medium text-foreground">
-                <AiFeedbackText text={item.description} />
-              </p>
-              {item.type === 'code_snippet' && language ? (
-                <ReportSnapshotCodeViewer
-                  code={item.reference}
-                  language={language}
-                  linesOfCode={Math.max(item.reference.split('\n').length, 1)}
-                  compact
-                />
-              ) : null}
-            </li>
+              item={item}
+              language={language}
+            />
           ))}
         </ul>
       ) : null}

--- a/apps/web/src/components/session-report/report-evidence-card.spec.tsx
+++ b/apps/web/src/components/session-report/report-evidence-card.spec.tsx
@@ -3,7 +3,18 @@ import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
+    t: (key: string, opts?: { defaultValue?: string }) =>
+      (
+        ({
+          'evidence.type.code_line': 'Code line',
+          'evidence.type.code_snippet': 'Code snippet',
+          'evidence.type.event_timestamp': 'Session event',
+          'evidence.type.unknown': 'Evidence',
+          'evidence.referenceUnavailable': 'Reference unavailable',
+        }) as Record<string, string>
+      )[key] ??
+      opts?.defaultValue ??
+      key,
     i18n: { language: 'en' },
   }),
 }));
@@ -69,6 +80,55 @@ describe('EvidenceCard', () => {
     expect(screen.getByText('Transitioned to wrapup.')).toBeInTheDocument();
   });
 
+  it('GIVEN an invalid event_timestamp reference WHEN rendered THEN shows the raw reference', () => {
+    render(
+      <ul>
+        <EvidenceCard
+          item={{
+            type: 'event_timestamp',
+            reference: 'not-a-date',
+            description: 'Malformed timestamp.',
+          }}
+        />
+      </ul>,
+    );
+
+    expect(screen.getByText('not-a-date')).toBeInTheDocument();
+    expect(screen.queryByText('Invalid Date')).not.toBeInTheDocument();
+  });
+
+  it('GIVEN an empty code_line reference WHEN rendered THEN shows unavailable fallback', () => {
+    render(
+      <ul>
+        <EvidenceCard
+          item={{ type: 'code_line', reference: '   ', description: 'Missing reference.' }}
+        />
+      </ul>,
+    );
+
+    expect(screen.getByText('Reference unavailable')).toBeInTheDocument();
+  });
+
+  it('GIVEN a long code_line reference WHEN rendered THEN allows wrapping inside the card', () => {
+    const longReference = `L1: ${'x'.repeat(160)}`;
+
+    render(
+      <ul>
+        <EvidenceCard
+          item={{
+            type: 'code_line',
+            reference: longReference,
+            description: 'Long line.',
+          }}
+        />
+      </ul>,
+    );
+
+    const reference = screen.getByText(longReference);
+    expect(reference).toHaveClass('whitespace-pre-wrap');
+    expect(reference).toHaveClass('break-words');
+  });
+
   it('GIVEN an unknown evidence type WHEN rendered THEN shows raw reference as fallback', () => {
     render(
       <ul>
@@ -79,6 +139,8 @@ describe('EvidenceCard', () => {
     );
 
     expect(screen.getByText('Some description.')).toBeInTheDocument();
+    expect(screen.getByText('Evidence')).toBeInTheDocument();
     expect(screen.getByText('some-ref')).toBeInTheDocument();
+    expect(screen.queryByText('unknown_type')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/session-report/report-evidence-card.spec.tsx
+++ b/apps/web/src/components/session-report/report-evidence-card.spec.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+vi.mock('@monaco-editor/react', () => ({
+  default: ({ value }: { value: string }) => <pre data-testid="monaco-editor">{value}</pre>,
+}));
+
+vi.mock('@/components/room-workspace-utils.js', () => ({
+  EDITOR_LOADING: null,
+  EDITOR_OPTIONS_BASE: {},
+  handleEditorWillMount: vi.fn(),
+  toMonacoLanguage: (lang: string) => lang,
+}));
+
+import { EvidenceCard } from './report-evidence-card.js';
+
+describe('EvidenceCard', () => {
+  it('GIVEN a code_line evidence item WHEN rendered THEN shows description and reference', () => {
+    render(
+      <ul>
+        <EvidenceCard
+          item={{
+            type: 'code_line',
+            reference: 'L3: return [0, 1]',
+            description: 'Returns early.',
+          }}
+        />
+      </ul>,
+    );
+
+    expect(screen.getByText('Returns early.')).toBeInTheDocument();
+    expect(screen.getByText('L3: return [0, 1]')).toBeInTheDocument();
+  });
+
+  it('GIVEN a code_snippet evidence item with language WHEN rendered THEN shows Monaco editor', () => {
+    render(
+      <ul>
+        <EvidenceCard
+          item={{ type: 'code_snippet', reference: 'return [0, 1]', description: 'Final return.' }}
+          language="typescript"
+        />
+      </ul>,
+    );
+
+    expect(screen.getByText('Final return.')).toBeInTheDocument();
+    expect(screen.getByTestId('monaco-editor')).toBeInTheDocument();
+  });
+
+  it('GIVEN an event_timestamp evidence item WHEN rendered THEN shows formatted time', () => {
+    render(
+      <ul>
+        <EvidenceCard
+          item={{
+            type: 'event_timestamp',
+            reference: '2026-04-20T01:01:00.000Z',
+            description: 'Transitioned to wrapup.',
+          }}
+        />
+      </ul>,
+    );
+
+    expect(screen.getByText('Transitioned to wrapup.')).toBeInTheDocument();
+  });
+
+  it('GIVEN an unknown evidence type WHEN rendered THEN shows raw reference as fallback', () => {
+    render(
+      <ul>
+        <EvidenceCard
+          item={{ type: 'unknown_type', reference: 'some-ref', description: 'Some description.' }}
+        />
+      </ul>,
+    );
+
+    expect(screen.getByText('Some description.')).toBeInTheDocument();
+    expect(screen.getByText('some-ref')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/session-report/report-evidence-card.tsx
+++ b/apps/web/src/components/session-report/report-evidence-card.tsx
@@ -16,15 +16,19 @@ function EvidenceTypeIcon({ type }: { type: string }) {
 }
 
 function formatTimestampReference(reference: string): string {
-  try {
-    return new Date(reference).toLocaleTimeString([], {
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-    });
-  } catch {
+  const timestamp = new Date(reference);
+  if (Number.isNaN(timestamp.getTime())) {
     return reference;
   }
+  return timestamp.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function isKnownEvidenceType(type: string) {
+  return type === 'code_line' || type === 'code_snippet' || type === 'event_timestamp';
 }
 
 export function EvidenceCard({
@@ -35,6 +39,11 @@ export function EvidenceCard({
   language?: SupportedLanguage;
 }) {
   const { t } = useTranslation('feedback');
+  const reference = item.reference.trim();
+  const referenceFallback = t('evidence.referenceUnavailable');
+  const typeLabel = isKnownEvidenceType(item.type)
+    ? t(`evidence.type.${item.type}`)
+    : t('evidence.type.unknown');
 
   return (
     <li className="rounded-xl bg-background/60 px-3 py-2.5">
@@ -42,30 +51,36 @@ export function EvidenceCard({
         <EvidenceTypeIcon type={item.type} />
         <div className="min-w-0 flex-1 space-y-1.5">
           <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-            {t(`evidence.type.${item.type}`, { defaultValue: item.type })}
+            {typeLabel}
           </p>
 
           <p className="text-sm font-medium text-foreground">
             <AiFeedbackText text={item.description} />
           </p>
 
-          {item.type === 'code_snippet' && language ? (
+          {item.type === 'code_snippet' && language && reference ? (
             <ReportSnapshotCodeViewer
-              code={item.reference}
+              code={reference}
               language={language}
-              linesOfCode={Math.max(item.reference.split('\n').length, 1)}
+              linesOfCode={Math.max(reference.split('\n').length, 1)}
               compact
             />
           ) : item.type === 'code_line' ? (
-            <p className="mt-1 rounded-md bg-muted/50 px-2 py-1 font-mono text-[11px] text-muted-foreground">
-              {item.reference}
+            <p className="mt-1 overflow-x-auto rounded-md bg-muted/50 px-2 py-1 font-mono text-[11px] text-muted-foreground">
+              <span className="whitespace-pre-wrap break-words">
+                {reference || referenceFallback}
+              </span>
             </p>
           ) : item.type === 'event_timestamp' ? (
-            <p className="mt-1 font-mono text-[11px] text-primary/70">
-              {formatTimestampReference(item.reference)}
+            <p className="mt-1 overflow-x-auto font-mono text-[11px] text-primary/70">
+              <span className="whitespace-pre-wrap break-words">
+                {reference ? formatTimestampReference(reference) : referenceFallback}
+              </span>
             </p>
           ) : (
-            <p className="mt-1 text-[11px] text-muted-foreground">{item.reference}</p>
+            <p className="mt-1 whitespace-pre-wrap break-words text-[11px] text-muted-foreground">
+              {reference || referenceFallback}
+            </p>
           )}
         </div>
       </div>

--- a/apps/web/src/components/session-report/report-evidence-card.tsx
+++ b/apps/web/src/components/session-report/report-evidence-card.tsx
@@ -1,0 +1,74 @@
+import type { SessionReportEvidence } from '@syncode/contracts';
+import type { SupportedLanguage } from '@syncode/shared';
+import { Clock, Code, FileCode } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { AiFeedbackText } from './ai-feedback-rich-text.js';
+import { ReportSnapshotCodeViewer } from './report-snapshot-code-viewer.js';
+
+function EvidenceTypeIcon({ type }: { type: string }) {
+  if (type === 'code_line' || type === 'code_snippet') {
+    return <FileCode className="size-3 shrink-0 text-primary/70" />;
+  }
+  if (type === 'event_timestamp') {
+    return <Clock className="size-3 shrink-0 text-primary/70" />;
+  }
+  return <Code className="size-3 shrink-0 text-muted-foreground" />;
+}
+
+function formatTimestampReference(reference: string): string {
+  try {
+    return new Date(reference).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  } catch {
+    return reference;
+  }
+}
+
+export function EvidenceCard({
+  item,
+  language,
+}: {
+  item: SessionReportEvidence;
+  language?: SupportedLanguage;
+}) {
+  const { t } = useTranslation('feedback');
+
+  return (
+    <li className="rounded-xl bg-background/60 px-3 py-2.5">
+      <div className="flex items-start gap-1.5">
+        <EvidenceTypeIcon type={item.type} />
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+            {t(`evidence.type.${item.type}`, { defaultValue: item.type })}
+          </p>
+
+          <p className="text-sm font-medium text-foreground">
+            <AiFeedbackText text={item.description} />
+          </p>
+
+          {item.type === 'code_snippet' && language ? (
+            <ReportSnapshotCodeViewer
+              code={item.reference}
+              language={language}
+              linesOfCode={Math.max(item.reference.split('\n').length, 1)}
+              compact
+            />
+          ) : item.type === 'code_line' ? (
+            <p className="mt-1 rounded-md bg-muted/50 px-2 py-1 font-mono text-[11px] text-muted-foreground">
+              {item.reference}
+            </p>
+          ) : item.type === 'event_timestamp' ? (
+            <p className="mt-1 font-mono text-[11px] text-primary/70">
+              {formatTimestampReference(item.reference)}
+            </p>
+          ) : (
+            <p className="mt-1 text-[11px] text-muted-foreground">{item.reference}</p>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/apps/web/src/locales/en/feedback.json
+++ b/apps/web/src/locales/en/feedback.json
@@ -178,8 +178,10 @@
     "type": {
       "code_line": "Code line",
       "code_snippet": "Code snippet",
-      "event_timestamp": "Session event"
-    }
+      "event_timestamp": "Session event",
+      "unknown": "Evidence"
+    },
+    "referenceUnavailable": "Reference unavailable"
   },
   "breakdown": {
     "pass": "Pass",

--- a/apps/web/src/locales/en/feedback.json
+++ b/apps/web/src/locales/en/feedback.json
@@ -174,6 +174,13 @@
       "debugging": "Debugging"
     }
   },
+  "evidence": {
+    "type": {
+      "code_line": "Code line",
+      "code_snippet": "Code snippet",
+      "event_timestamp": "Session event"
+    }
+  },
   "breakdown": {
     "pass": "Pass",
     "timeout": "Timeout",

--- a/apps/web/src/locales/zh/feedback.json
+++ b/apps/web/src/locales/zh/feedback.json
@@ -178,8 +178,10 @@
     "type": {
       "code_line": "代码行",
       "code_snippet": "代码片段",
-      "event_timestamp": "会话事件"
-    }
+      "event_timestamp": "会话事件",
+      "unknown": "证据"
+    },
+    "referenceUnavailable": "引用不可用"
   },
   "breakdown": {
     "pass": "通过",

--- a/apps/web/src/locales/zh/feedback.json
+++ b/apps/web/src/locales/zh/feedback.json
@@ -174,6 +174,13 @@
       "debugging": "调试能力"
     }
   },
+  "evidence": {
+    "type": {
+      "code_line": "代码行",
+      "code_snippet": "代码片段",
+      "event_timestamp": "会话事件"
+    }
+  },
   "breakdown": {
     "pass": "通过",
     "timeout": "超时",


### PR DESCRIPTION
## Summary

- add EvidenceCard component rendering code_line, code_snippet, and event_timestamp evidence types
- update ReportDimensionCard to use EvidenceCard for all evidence items
- add i18n keys for evidence types in en and zh locales

Closes #185