### PR TITLE
Restore AI interviewer UI

### DIFF
--- a/apps/control-plane/src/modules/rooms/dto/rooms.dto.ts
+++ b/apps/control-plane/src/modules/rooms/dto/rooms.dto.ts
@@ -15,6 +15,8 @@ import {
   mediaTokenResponseSchema,
   requestRoomAiHintResponseSchema,
   requestRoomAiHintSchema,
+  requestRoomAiInterviewResponseSchema,
+  requestRoomAiInterviewSchema,
   requestRoomCodeAnalysisResponseSchema,
   requestRoomCodeAnalysisSchema,
   roomChatMediaUploadRequestSchema,
@@ -55,6 +57,10 @@ export class DestroyRoomResponseDto extends createZodDto(destroyRoomResponseSche
 export class RunCodeResponseDto extends createZodDto(runCodeResponseSchema) {}
 export class SubmitCodeResponseDto extends createZodDto(submitResponseSchema) {}
 export class RequestRoomAiHintResponseDto extends createZodDto(requestRoomAiHintResponseSchema) {}
+export class RequestRoomAiInterviewDto extends createZodDto(requestRoomAiInterviewSchema) {}
+export class RequestRoomAiInterviewResponseDto extends createZodDto(
+  requestRoomAiInterviewResponseSchema,
+) {}
 export class RequestRoomCodeAnalysisResponseDto extends createZodDto(
   requestRoomCodeAnalysisResponseSchema,
 ) {}
@@ -80,6 +86,33 @@ export class GetRoomAiHintResultResponseDto {
 
   @ApiProperty({ required: false })
   reflectionPrompt?: string;
+}
+
+export class GetRoomAiInterviewResultResponseDto {
+  @ApiProperty({ enum: ['pending', 'ready', 'failed'] })
+  status!: 'pending' | 'ready' | 'failed';
+
+  @ApiProperty({ description: 'AI interview job ID' })
+  jobId!: string;
+
+  @ApiProperty({ required: false, description: 'AI interviewer message (when status=ready)' })
+  message?: string;
+
+  @ApiProperty({ required: false })
+  followUpQuestion?: string;
+
+  @ApiProperty({
+    required: false,
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: { line: { type: 'number' }, comment: { type: 'string' } },
+    },
+  })
+  codeAnnotations?: Array<{ line: number; comment: string }>;
+
+  @ApiProperty({ required: false, description: 'Presigned audio URL (when status=ready)' })
+  audioUrl?: string;
 }
 
 export class GetRoomCodeAnalysisResultResponseDto {

--- a/apps/control-plane/src/modules/rooms/rooms.controller.integration.spec.ts
+++ b/apps/control-plane/src/modules/rooms/rooms.controller.integration.spec.ts
@@ -3,7 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 import { Test } from '@nestjs/testing';
-import { AI_CLIENT, COLLAB_CLIENT, EXECUTION_CLIENT } from '@syncode/contracts';
+import { AI_CLIENT, COLLAB_CLIENT, ERROR_CODES, EXECUTION_CLIENT } from '@syncode/contracts';
 import type { Database } from '@syncode/db';
 import { aiHints } from '@syncode/db';
 import { CACHE_SERVICE, MEDIA_SERVICE, STORAGE_SERVICE } from '@syncode/shared/ports';
@@ -1055,6 +1055,124 @@ describe('POST /rooms/:id/ai/code-analysis', () => {
       .expect(403);
 
     expect(result.body.message).toBe('No ai:request-hint capability');
+  });
+});
+
+describe('POST /rooms/:id/ai/interview', () => {
+  async function createAiInterviewRoom() {
+    const candidate = await insertUser(db);
+    const problem = await insertProblem(db);
+    const room = await insertRoom(db, candidate.id, {
+      mode: 'ai',
+      status: 'coding',
+      problemId: problem.id,
+      language: 'python',
+    });
+    await insertParticipant(db, room.id, candidate.id, 'candidate');
+
+    return { candidate, problem, room };
+  }
+
+  it('GIVEN AI room candidate and selected problem WHEN requesting interview response THEN returns ready interview result', async () => {
+    const { candidate, room } = await createAiInterviewRoom();
+    mockAiClient.getInterviewResult.mockResolvedValueOnce({
+      message: 'Explain why your hash map lookup is correct.',
+      followUpQuestion: 'What happens with duplicate numbers?',
+      codeAnnotations: [{ line: 3, comment: 'Mention how this handles repeated values.' }],
+      audio: {
+        audioKey: 'ai/interview/ai-interview-job.mp3',
+        mimeType: 'audio/mpeg',
+        downloadUrl: 'https://media.example.com/interview.mp3',
+      },
+    });
+
+    const submission = await asUser(
+      request(app.getHttpServer()).post(`/rooms/${room.id}/ai/interview`),
+      candidate,
+    )
+      .send({
+        userMessage: 'I would scan once and store complements.',
+        conversationHistory: [{ role: 'assistant', content: 'How would you solve this?' }],
+        currentCode: 'def two_sum(nums, target):\n    return []',
+      })
+      .expect(202);
+
+    expect(submission.body.jobId).toBe('ai-interview-job');
+    expect(mockAiClient.submitInterviewResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: room.id,
+        participantId: candidate.id,
+        language: 'python',
+        userMessage: 'I would scan once and store complements.',
+        conversationHistory: [{ role: 'assistant', content: 'How would you solve this?' }],
+      }),
+    );
+
+    const result = await asUser(
+      request(app.getHttpServer()).get(`/rooms/${room.id}/ai/interview/${submission.body.jobId}`),
+      candidate,
+    ).expect(200);
+
+    expect(result.body).toEqual({
+      status: 'ready',
+      jobId: submission.body.jobId,
+      message: 'Explain why your hash map lookup is correct.',
+      followUpQuestion: 'What happens with duplicate numbers?',
+      codeAnnotations: [{ line: 3, comment: 'Mention how this handles repeated values.' }],
+      audioUrl: 'https://media.example.com/interview.mp3',
+    });
+  });
+
+  it('GIVEN peer room WHEN requesting interview response THEN returns ROOM_NOT_AI_MODE', async () => {
+    const interviewer = await insertUser(db);
+    const candidate = await insertUser(db);
+    const problem = await insertProblem(db);
+    const room = await insertRoom(db, interviewer.id, {
+      mode: 'peer',
+      status: 'coding',
+      problemId: problem.id,
+      language: 'python',
+    });
+    await insertParticipant(db, room.id, interviewer.id, 'interviewer');
+    await insertParticipant(db, room.id, candidate.id, 'candidate');
+
+    const result = await asUser(
+      request(app.getHttpServer()).post(`/rooms/${room.id}/ai/interview`),
+      candidate,
+    )
+      .send({
+        userMessage: 'Can we do an AI interview here?',
+        conversationHistory: [],
+        currentCode: 'print("hello")',
+      })
+      .expect(400);
+
+    expect(result.body.code).toBe(ERROR_CODES.ROOM_NOT_AI_MODE);
+    expect(mockAiClient.submitInterviewResponse).not.toHaveBeenCalled();
+  });
+
+  it('GIVEN another participant owns interview job WHEN polling with wrong user THEN returns 404', async () => {
+    const { candidate, room } = await createAiInterviewRoom();
+    const intruder = await insertUser(db);
+    await insertParticipant(db, room.id, intruder.id, 'observer');
+
+    const submission = await asUser(
+      request(app.getHttpServer()).post(`/rooms/${room.id}/ai/interview`),
+      candidate,
+    )
+      .send({
+        userMessage: 'I would use two pointers.',
+        conversationHistory: [],
+        currentCode: 'print("hello")',
+      })
+      .expect(202);
+
+    const result = await asUser(
+      request(app.getHttpServer()).get(`/rooms/${room.id}/ai/interview/${submission.body.jobId}`),
+      intruder,
+    ).expect(404);
+
+    expect(result.body.message).toBe('Interview job not found');
   });
 });
 

--- a/apps/control-plane/src/modules/rooms/rooms.controller.ts
+++ b/apps/control-plane/src/modules/rooms/rooms.controller.ts
@@ -49,6 +49,7 @@ import {
   DestroyRoomResponseDto,
   EnsureCollabResponseDto,
   GetRoomAiHintResultResponseDto,
+  GetRoomAiInterviewResultResponseDto,
   GetRoomCodeAnalysisResultResponseDto,
   JoinRoomDto,
   JoinRoomResponseDto,
@@ -58,6 +59,8 @@ import {
   MediaTokenResponseDto,
   RequestRoomAiHintDto,
   RequestRoomAiHintResponseDto,
+  RequestRoomAiInterviewDto,
+  RequestRoomAiInterviewResponseDto,
   RequestRoomCodeAnalysisDto,
   RequestRoomCodeAnalysisResponseDto,
   RoomChatMediaUploadDto,
@@ -382,6 +385,58 @@ export class RoomsController {
     @Param('jobId') jobId: string,
   ): Promise<GetRoomAiHintResultResponseDto> {
     return this.roomsService.getAiHintResult(id, user.id, jobId);
+  }
+
+  @Post(CONTROL_API.ROOMS.AI_INTERVIEW.route)
+  @HttpCode(202)
+  @ApiOperation({
+    summary: 'Submit AI interview response',
+    description:
+      'Returns immediately with the job ID. Poll GET /rooms/:id/ai/interview/:jobId for the result.',
+  })
+  @ApiParam({ name: 'id', description: 'Room ID (UUID)' })
+  @ApiBody({ type: RequestRoomAiInterviewDto })
+  @ApiResponse({
+    status: 202,
+    type: RequestRoomAiInterviewResponseDto,
+    description: 'Interview job submitted; poll GET /rooms/:id/ai/interview/:jobId for the result',
+  })
+  @ApiResponse({
+    status: 403,
+    type: ErrorResponseDto,
+    description: 'No ai:request-hint capability',
+  })
+  @ApiResponse({ status: 404, type: ErrorResponseDto, description: 'No problem selected in room' })
+  @ApiResponse({ status: 503, type: ErrorResponseDto, description: 'AI service unavailable' })
+  async requestAiInterview(
+    @CurrentUser() user: AuthUser,
+    @Param('id') id: string,
+    @Body() body: RequestRoomAiInterviewDto,
+  ): Promise<RequestRoomAiInterviewResponseDto> {
+    return this.roomsService.requestAiInterview(id, user.id, body);
+  }
+
+  @Get(CONTROL_API.ROOMS.AI_INTERVIEW_RESULT.route)
+  @ApiOperation({ summary: 'Poll AI interview job result' })
+  @ApiParam({ name: 'id', description: 'Room ID (UUID)' })
+  @ApiParam({ name: 'jobId', description: 'AI interview job ID returned from POST /ai/interview' })
+  @ApiResponse({
+    status: 200,
+    type: GetRoomAiInterviewResultResponseDto,
+    description: 'Interview job status: pending, ready, or failed',
+  })
+  @ApiResponse({
+    status: 403,
+    type: ErrorResponseDto,
+    description: 'Not a participant of this room',
+  })
+  @ApiResponse({ status: 404, type: ErrorResponseDto, description: 'Job not found or expired' })
+  async getAiInterviewResult(
+    @CurrentUser() user: AuthUser,
+    @Param('id') id: string,
+    @Param('jobId') jobId: string,
+  ): Promise<GetRoomAiInterviewResultResponseDto> {
+    return this.roomsService.getAiInterviewResult(id, user.id, jobId);
   }
 
   @Post(CONTROL_API.ROOMS.CODE_ANALYSIS.route)

--- a/apps/control-plane/src/modules/rooms/rooms.service.ts
+++ b/apps/control-plane/src/modules/rooms/rooms.service.ts
@@ -2316,6 +2316,13 @@ export class RoomsService {
       });
     }
 
+    if (label === 'Interview' && room.mode !== 'ai') {
+      throw new BadRequestException({
+        message: 'AI interview is only available in AI rooms',
+        code: ERROR_CODES.ROOM_NOT_AI_MODE,
+      });
+    }
+
     const capabilities = resolveRoomPermissions(participant.role, {
       isHost: room.hostId === userId,
     });

--- a/apps/control-plane/src/modules/rooms/rooms.service.ts
+++ b/apps/control-plane/src/modules/rooms/rooms.service.ts
@@ -29,6 +29,7 @@ import {
   type JoinRoomInput,
   type ListRoomsQuery,
   type RequestRoomAiHintInput,
+  type RequestRoomAiInterviewInput,
   type RequestRoomCodeAnalysisInput,
   type RoleAssignmentReason,
   type RoomChatMediaUploadInput,
@@ -89,11 +90,13 @@ import type {
   CreateRoomResult,
   DestroyRoomResult,
   GetRoomAiHintResult,
+  GetRoomAiInterviewResult,
   GetRoomCodeAnalysisResult,
   JoinRoomResult,
   MediaTokenResult,
   PublicRoomSummaryResult,
   RequestRoomAiHintResult,
+  RequestRoomAiInterviewResult,
   RequestRoomCodeAnalysisResult,
   RoomChatMediaUploadResult,
   RoomDetailResult,
@@ -114,6 +117,11 @@ interface HintJobMapping {
 }
 
 interface CodeAnalysisJobMapping {
+  roomId: string;
+  userId: string;
+}
+
+interface InterviewJobMapping {
   roomId: string;
   userId: string;
 }
@@ -1252,6 +1260,94 @@ export class RoomsService {
     };
   }
 
+  async requestAiInterview(
+    roomId: string,
+    userId: string,
+    body: RequestRoomAiInterviewInput,
+  ): Promise<RequestRoomAiInterviewResult> {
+    const { problemId, activeLanguage } = await this.getAiRequestRoomContext(
+      roomId,
+      userId,
+      undefined,
+      'Interview',
+    );
+    const problemDescription = await this.loadAiProblemDescription(problemId);
+
+    let submitted: { jobId: JobId<'ai:interview'> };
+    try {
+      submitted = await this.aiClient.submitInterviewResponse({
+        roomId,
+        participantId: userId,
+        problemDescription,
+        currentCode: body.currentCode,
+        language: activeLanguage,
+        userMessage: body.userMessage,
+        conversationHistory: body.conversationHistory,
+      });
+    } catch (error) {
+      this.logger.warn(`AI interview submission failed for room ${roomId}`, error);
+      throw new ServiceUnavailableException({
+        message: 'AI service unavailable',
+        code: ERROR_CODES.AI_SERVICE_UNAVAILABLE,
+      });
+    }
+
+    await this.cacheService.set<InterviewJobMapping>(
+      `${RoomsService.AI_INTERVIEW_JOB_CACHE_PREFIX}${submitted.jobId}`,
+      {
+        roomId,
+        userId,
+      },
+      RoomsService.AI_INTERVIEW_JOB_CACHE_TTL_SECONDS,
+    );
+
+    return { jobId: submitted.jobId };
+  }
+
+  async getAiInterviewResult(
+    roomId: string,
+    userId: string,
+    jobId: string,
+  ): Promise<GetRoomAiInterviewResult> {
+    const [, participant] = await this.getRoomContext(roomId, userId);
+    if (!participant) {
+      throw new ForbiddenException({
+        message: 'Not a participant of this room',
+        code: ERROR_CODES.ROOM_ACCESS_DENIED,
+      });
+    }
+
+    const mapping = await this.cacheService.get<InterviewJobMapping>(
+      `${RoomsService.AI_INTERVIEW_JOB_CACHE_PREFIX}${jobId}`,
+    );
+    if (!mapping || mapping.roomId !== roomId || mapping.userId !== userId) {
+      throw new NotFoundException({
+        message: 'Interview job not found',
+        code: ERROR_CODES.VALIDATION_FAILED,
+      });
+    }
+
+    const typedJobId = jobId as JobId<'ai:interview'>;
+    const interviewResult = await this.aiClient.getInterviewResult(typedJobId);
+
+    if (!interviewResult) {
+      const status = await this.aiClient.getInterviewJobStatus(typedJobId);
+      if (status === 'failed') {
+        return { status: 'failed', jobId };
+      }
+      return { status: 'pending', jobId };
+    }
+
+    return {
+      status: 'ready',
+      jobId,
+      message: interviewResult.message,
+      followUpQuestion: interviewResult.followUpQuestion,
+      codeAnnotations: interviewResult.codeAnnotations,
+      audioUrl: interviewResult.audio?.downloadUrl,
+    };
+  }
+
   async requestCodeAnalysis(
     roomId: string,
     userId: string,
@@ -1451,6 +1547,8 @@ export class RoomsService {
   private static readonly AI_HINT_CHAT_HISTORY_LIMIT = 50;
   private static readonly AI_HINT_JOB_CACHE_PREFIX = 'ai-hint-job:';
   private static readonly AI_HINT_JOB_CACHE_TTL_SECONDS = 60 * 60;
+  private static readonly AI_INTERVIEW_JOB_CACHE_PREFIX = 'ai-interview-job:';
+  private static readonly AI_INTERVIEW_JOB_CACHE_TTL_SECONDS = 60 * 60;
   private static readonly AI_CODE_ANALYSIS_MAX_CODE_LENGTH = 16_000;
   private static readonly AI_CODE_ANALYSIS_LIMIT_COUNT = 10;
   private static readonly AI_CODE_ANALYSIS_LIMIT_WINDOW_SECONDS = 5 * 60;
@@ -2206,8 +2304,8 @@ export class RoomsService {
   private async getAiRequestRoomContext(
     roomId: string,
     userId: string,
-    language: SupportedLanguage,
-    label: 'Hint' | 'Analysis',
+    language: SupportedLanguage | undefined,
+    label: 'Hint' | 'Analysis' | 'Interview',
   ): Promise<{ problemId: string; activeLanguage: SupportedLanguage }> {
     const [room, participant] = await this.getRoomContext(roomId, userId);
 
@@ -2236,7 +2334,7 @@ export class RoomsService {
       });
     }
 
-    if (room.language && language !== room.language) {
+    if (room.language && language && language !== room.language) {
       throw new BadRequestException({
         message: `${label} language must match room language (${room.language})`,
         code: ERROR_CODES.VALIDATION_FAILED,
@@ -2245,7 +2343,7 @@ export class RoomsService {
 
     return {
       problemId: room.problemId,
-      activeLanguage: room.language ?? language,
+      activeLanguage: room.language ?? language ?? 'python',
     };
   }
 

--- a/apps/control-plane/src/modules/rooms/rooms.types.ts
+++ b/apps/control-plane/src/modules/rooms/rooms.types.ts
@@ -167,6 +167,22 @@ export type GetRoomCodeAnalysisResult =
     }
   | { status: 'failed'; jobId: string };
 
+export interface RequestRoomAiInterviewResult {
+  jobId: string;
+}
+
+export type GetRoomAiInterviewResult =
+  | { status: 'pending'; jobId: string }
+  | {
+      status: 'ready';
+      jobId: string;
+      message: string;
+      followUpQuestion?: string;
+      codeAnnotations?: Array<{ line: number; comment: string }>;
+      audioUrl?: string;
+    }
+  | { status: 'failed'; jobId: string };
+
 export interface RoomChatMediaUploadResult {
   key: string;
   uploadUrl: string;

--- a/apps/web/src/components/room-ai-interview-panel.spec.tsx
+++ b/apps/web/src/components/room-ai-interview-panel.spec.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+import { RoomAiInterviewPanel } from './room-ai-interview-panel.js';
+
+describe('RoomAiInterviewPanel', () => {
+  it('GIVEN no messages WHEN rendered THEN shows empty state', () => {
+    render(
+      <RoomAiInterviewPanel
+        messages={[]}
+        isLoading={false}
+        error={null}
+        onSendMessage={vi.fn()}
+        canSendMessage={true}
+      />,
+    );
+    expect(screen.getByText('workspace.aiInterviewEmpty')).toBeInTheDocument();
+  });
+
+  it('GIVEN messages WHEN rendered THEN shows user and assistant bubbles', () => {
+    render(
+      <RoomAiInterviewPanel
+        messages={[
+          { role: 'user', content: 'Hello interviewer' },
+          { role: 'assistant', content: 'Tell me about your approach.' },
+        ]}
+        isLoading={false}
+        error={null}
+        onSendMessage={vi.fn()}
+        canSendMessage={true}
+      />,
+    );
+    expect(screen.getByText('Hello interviewer')).toBeInTheDocument();
+    expect(screen.getByText('Tell me about your approach.')).toBeInTheDocument();
+  });
+
+  it('GIVEN isLoading WHEN rendered THEN shows sending indicator', () => {
+    render(
+      <RoomAiInterviewPanel
+        messages={[]}
+        isLoading={true}
+        error={null}
+        onSendMessage={vi.fn()}
+        canSendMessage={true}
+      />,
+    );
+    expect(screen.getAllByText('workspace.aiInterviewSending').length).toBeGreaterThan(0);
+  });
+
+  it('GIVEN an error WHEN rendered THEN shows error message', () => {
+    render(
+      <RoomAiInterviewPanel
+        messages={[]}
+        isLoading={false}
+        error="Something went wrong"
+        onSendMessage={vi.fn()}
+        canSendMessage={true}
+      />,
+    );
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('GIVEN user types and submits WHEN Enter pressed THEN onSendMessage called', async () => {
+    const onSend = vi.fn();
+    render(
+      <RoomAiInterviewPanel
+        messages={[]}
+        isLoading={false}
+        error={null}
+        onSendMessage={onSend}
+        canSendMessage={true}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText('workspace.aiInterviewPlaceholder');
+    await userEvent.type(textarea, 'My answer{Enter}');
+    expect(onSend).toHaveBeenCalledWith('My answer');
+  });
+
+  it('GIVEN assistant message with codeAnnotations WHEN rendered THEN shows annotations', () => {
+    render(
+      <RoomAiInterviewPanel
+        messages={[
+          {
+            role: 'assistant',
+            content: 'Check line 3.',
+            codeAnnotations: [{ line: 3, comment: 'Off-by-one error here.' }],
+          },
+        ]}
+        isLoading={false}
+        error={null}
+        onSendMessage={vi.fn()}
+        canSendMessage={true}
+      />,
+    );
+    expect(screen.getByText('L3')).toBeInTheDocument();
+    expect(screen.getByText('Off-by-one error here.')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/room-ai-interview-panel.tsx
+++ b/apps/web/src/components/room-ai-interview-panel.tsx
@@ -1,0 +1,191 @@
+import { Button } from '@syncode/ui';
+import { Bot, Send, User } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export interface AiInterviewMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  followUpQuestion?: string;
+  codeAnnotations?: Array<{ line: number; comment: string }>;
+  audioUrl?: string;
+}
+
+export function RoomAiInterviewPanel({
+  messages,
+  isLoading,
+  error,
+  onSendMessage,
+  canSendMessage,
+}: {
+  messages: AiInterviewMessage[];
+  isLoading: boolean;
+  error: string | null;
+  onSendMessage: (message: string) => void;
+  canSendMessage: boolean;
+}) {
+  const { t } = useTranslation('rooms');
+  const [draft, setDraft] = useState('');
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const latestAudioUrl = [...messages]
+    .reverse()
+    .find((m) => m.role === 'assistant' && m.audioUrl)?.audioUrl;
+
+  const messageCount = messages.length;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on new message
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messageCount]);
+
+  useEffect(() => {
+    if (!latestAudioUrl) return;
+    if (audioRef.current) {
+      audioRef.current.pause();
+    }
+    const audio = new Audio(latestAudioUrl);
+    audioRef.current = audio;
+    void audio.play().catch(() => {});
+    return () => {
+      audio.pause();
+    };
+  }, [latestAudioUrl]);
+
+  function handleSend() {
+    const trimmed = draft.trim();
+    if (!trimmed || isLoading) return;
+    onSendMessage(trimmed);
+    setDraft('');
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 space-y-3 overflow-y-auto p-3">
+        {messages.length === 0 ? (
+          <p className="pt-4 text-center text-xs text-muted-foreground">
+            {t('workspace.aiInterviewEmpty')}
+          </p>
+        ) : (
+          messages.map((msg, index) => (
+            <AiInterviewMessageBubble
+              key={`${msg.role}-${index}-${msg.content.slice(0, 20)}`}
+              message={msg}
+              t={t}
+            />
+          ))
+        )}
+        {isLoading ? (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Bot className="size-3 shrink-0 animate-pulse text-primary" />
+            <span className="animate-pulse">{t('workspace.aiInterviewSending')}</span>
+          </div>
+        ) : null}
+        {error ? (
+          <p className="rounded-lg bg-destructive/10 px-3 py-2 text-xs text-destructive">{error}</p>
+        ) : null}
+        <div ref={bottomRef} />
+      </div>
+
+      <div className="space-y-2 border-t border-border p-3">
+        <textarea
+          value={draft}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={t('workspace.aiInterviewPlaceholder')}
+          disabled={!canSendMessage || isLoading}
+          rows={3}
+          className="w-full resize-none rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
+        />
+        <Button
+          size="sm"
+          className="w-full gap-1.5"
+          disabled={!draft.trim() || !canSendMessage || isLoading}
+          onClick={handleSend}
+        >
+          <Send className="size-3.5" />
+          {isLoading ? t('workspace.aiInterviewSending') : t('workspace.aiInterviewSend')}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function AiInterviewMessageBubble({
+  message,
+  t,
+}: {
+  message: AiInterviewMessage;
+  t: (key: string) => string;
+}) {
+  const isUser = message.role === 'user';
+
+  return (
+    <div className={`flex gap-2 ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
+      <div className="mt-0.5 shrink-0">
+        {isUser ? (
+          <div className="flex size-6 items-center justify-center rounded-full bg-primary/20">
+            <User className="size-3 text-primary" />
+          </div>
+        ) : (
+          <div className="flex size-6 items-center justify-center rounded-full bg-muted">
+            <Bot className="size-3 text-muted-foreground" />
+          </div>
+        )}
+      </div>
+
+      <div
+        className={`flex max-w-[85%] flex-col space-y-1.5 ${isUser ? 'items-end' : 'items-start'}`}
+      >
+        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          {isUser ? t('workspace.aiInterviewYou') : t('workspace.aiInterviewAi')}
+        </p>
+        <div
+          className={`rounded-xl px-3 py-2 text-sm leading-6 ${
+            isUser
+              ? 'bg-primary/15 text-foreground'
+              : 'bg-muted/60 text-foreground ring-1 ring-border/50'
+          }`}
+        >
+          {message.content}
+        </div>
+
+        {message.followUpQuestion ? (
+          <div className="rounded-xl bg-primary/5 px-3 py-2 text-sm leading-6 ring-1 ring-primary/20">
+            <p className="mb-1 text-[10px] font-medium uppercase tracking-wider text-primary/70">
+              {t('workspace.aiInterviewFollowUp')}
+            </p>
+            {message.followUpQuestion}
+          </div>
+        ) : null}
+
+        {message.codeAnnotations && message.codeAnnotations.length > 0 ? (
+          <div className="w-full rounded-xl bg-muted/40 px-3 py-2 ring-1 ring-border/40">
+            <p className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              {t('workspace.aiInterviewAnnotations')}
+            </p>
+            <ul className="space-y-1">
+              {message.codeAnnotations.map((annotation) => (
+                <li
+                  key={`L${annotation.line}-${annotation.comment.slice(0, 20)}`}
+                  className="flex gap-2 text-xs text-muted-foreground"
+                >
+                  <span className="shrink-0 font-mono text-primary/70">L{annotation.line}</span>
+                  <span>{annotation.comment}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/room-ai-interview-panel.tsx
+++ b/apps/web/src/components/room-ai-interview-panel.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@syncode/ui';
 import { Bot, Send, User } from 'lucide-react';
+import type { KeyboardEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -60,7 +61,7 @@ export function RoomAiInterviewPanel({
     setDraft('');
   }
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSend();
@@ -102,6 +103,7 @@ export function RoomAiInterviewPanel({
           onKeyDown={handleKeyDown}
           placeholder={t('workspace.aiInterviewPlaceholder')}
           disabled={!canSendMessage || isLoading}
+          maxLength={2000}
           rows={3}
           className="w-full resize-none rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
         />

--- a/apps/web/src/components/room-workspace.tsx
+++ b/apps/web/src/components/room-workspace.tsx
@@ -56,6 +56,7 @@ import { HostControlPanel } from './host-control-panel.js';
 import { InviteLinkInline } from './invite-link-inline.js';
 import { LanguagePicker } from './language-picker.js';
 import { LANGUAGE_VERSIONED_LABELS } from './language-selector.data.js';
+import { type AiInterviewMessage, RoomAiInterviewPanel } from './room-ai-interview-panel.js';
 import { RoomChatPanel } from './room-chat-panel.js';
 import { RoomHeaderBar } from './room-header-bar.js';
 import { type Participant, RoomParticipantCard } from './room-participant-card.js';
@@ -265,6 +266,10 @@ export function RoomWorkspace({
   const [hintFollowUpLoadingHintId, setHintFollowUpLoadingHintId] = useState<string | null>(null);
   const [hintError, setHintError] = useState<string | null>(null);
 
+  const [aiInterviewMessages, setAiInterviewMessages] = useState<AiInterviewMessage[]>([]);
+  const [aiInterviewLoading, setAiInterviewLoading] = useState(false);
+  const [aiInterviewError, setAiInterviewError] = useState<string | null>(null);
+
   useEffect(() => {
     if (!room.problemId) return;
     let cancelled = false;
@@ -300,7 +305,9 @@ export function RoomWorkspace({
   const [leftCollapsed, setLeftCollapsed] = useState(false);
   const [rightCollapsed, setRightCollapsed] = useState(false);
   const [rightNarrow, setRightNarrow] = useState(false);
-  const [activeRightTab, setActiveRightTab] = useState<'participants' | 'chat'>('participants');
+  const [activeRightTab, setActiveRightTab] = useState<'participants' | 'chat' | 'interview'>(
+    'participants',
+  );
   const [bottomCollapsed, setBottomCollapsed] = useState(false);
   const [activeCenterTab, setActiveCenterTab] = useState<'code' | 'whiteboard'>('code');
   const [whiteboardViewMode, setWhiteboardViewMode] = useState<'tab' | 'floating'>('tab');
@@ -957,6 +964,75 @@ export function RoomWorkspace({
     [getCode, language, roomId, t],
   );
 
+  const handleSendInterviewMessage = useCallback(
+    async (userMessage: string) => {
+      setAiInterviewError(null);
+      setAiInterviewLoading(true);
+
+      const userEntry: AiInterviewMessage = { role: 'user', content: userMessage };
+      setAiInterviewMessages((prev) => [...prev, userEntry]);
+
+      const history = aiInterviewMessages.map((m) => ({ role: m.role, content: m.content }));
+
+      try {
+        const submission = await api(CONTROL_API.ROOMS.AI_INTERVIEW, {
+          params: { id: roomId },
+          body: {
+            userMessage,
+            conversationHistory: history,
+            currentCode: getCode(),
+          },
+        });
+
+        const POLL_INTERVAL_MS = 1500;
+        const MAX_POLLS = 40;
+        let polls = 0;
+
+        const poll = async (): Promise<void> => {
+          if (polls >= MAX_POLLS) {
+            setAiInterviewError(t('workspace.aiInterviewFailed'));
+            setAiInterviewLoading(false);
+            return;
+          }
+          polls += 1;
+
+          const result = await api(CONTROL_API.ROOMS.AI_INTERVIEW_RESULT, {
+            params: { id: roomId, jobId: submission.jobId },
+          });
+
+          if (result.status === 'pending') {
+            setTimeout(() => void poll(), POLL_INTERVAL_MS);
+            return;
+          }
+
+          if (result.status === 'failed') {
+            setAiInterviewError(t('workspace.aiInterviewFailed'));
+            setAiInterviewLoading(false);
+            return;
+          }
+
+          setAiInterviewMessages((prev) => [
+            ...prev,
+            {
+              role: 'assistant',
+              content: result.message,
+              followUpQuestion: result.followUpQuestion,
+              codeAnnotations: result.codeAnnotations,
+              audioUrl: result.audioUrl,
+            },
+          ]);
+          setAiInterviewLoading(false);
+        };
+
+        void poll();
+      } catch {
+        setAiInterviewError(t('workspace.aiInterviewUnavailable'));
+        setAiInterviewLoading(false);
+      }
+    },
+    [aiInterviewMessages, getCode, roomId, t],
+  );
+
   return (
     <div className="fixed inset-0 z-40 flex flex-col overflow-hidden bg-background">
       <StageTransitionOverlay status={room.status} />
@@ -1342,7 +1418,9 @@ export function RoomWorkspace({
                 <div
                   className={`border-b border-border ${rightNarrow ? 'px-2 py-2' : 'px-3 py-2.5'}`}
                 >
-                  <div className="grid grid-cols-2 gap-1 rounded-md border border-border/70 bg-background/40 p-1">
+                  <div
+                    className={`grid gap-1 rounded-md border border-border/70 bg-background/40 p-1 ${room.mode === 'ai' ? 'grid-cols-3' : 'grid-cols-2'}`}
+                  >
                     <button
                       type="button"
                       onClick={() => setActiveRightTab('participants')}
@@ -1372,6 +1450,20 @@ export function RoomWorkspace({
                         </span>
                       ) : null}
                     </button>
+                    {room.mode === 'ai' ? (
+                      <button
+                        type="button"
+                        onClick={() => setActiveRightTab('interview')}
+                        className={cn(
+                          'rounded px-2 py-1 text-xs font-medium transition-colors',
+                          activeRightTab === 'interview'
+                            ? 'bg-primary/20 text-primary'
+                            : 'text-muted-foreground hover:bg-background/70 hover:text-foreground',
+                        )}
+                      >
+                        {t('workspace.aiInterviewHeading')}
+                      </button>
+                    ) : null}
                   </div>
                 </div>
                 <div className="min-h-0 flex-1 overflow-y-auto">
@@ -1449,7 +1541,7 @@ export function RoomWorkspace({
                         ))}
                       </div>
                     </div>
-                  ) : (
+                  ) : activeRightTab === 'chat' ? (
                     <div className="h-full p-2">
                       <RoomChatPanel
                         currentUserId={currentUserId}
@@ -1463,6 +1555,14 @@ export function RoomWorkspace({
                         readAt={currentUserReadAt}
                       />
                     </div>
+                  ) : (
+                    <RoomAiInterviewPanel
+                      messages={aiInterviewMessages}
+                      isLoading={aiInterviewLoading}
+                      error={aiInterviewError}
+                      onSendMessage={(msg) => void handleSendInterviewMessage(msg)}
+                      canSendMessage={canRequestHint}
+                    />
                   )}
                 </div>
               </motion.div>

--- a/apps/web/src/components/room-workspace.tsx
+++ b/apps/web/src/components/room-workspace.tsx
@@ -269,6 +269,8 @@ export function RoomWorkspace({
   const [aiInterviewMessages, setAiInterviewMessages] = useState<AiInterviewMessage[]>([]);
   const [aiInterviewLoading, setAiInterviewLoading] = useState(false);
   const [aiInterviewError, setAiInterviewError] = useState<string | null>(null);
+  const aiInterviewPollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const aiInterviewRequestSeqRef = useRef(0);
 
   useEffect(() => {
     if (!room.problemId) return;
@@ -308,6 +310,24 @@ export function RoomWorkspace({
   const [activeRightTab, setActiveRightTab] = useState<'participants' | 'chat' | 'interview'>(
     'participants',
   );
+
+  useEffect(() => {
+    if (room.mode !== 'ai' && activeRightTab === 'interview') {
+      setActiveRightTab('participants');
+    }
+  }, [activeRightTab, room.mode]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: roomId changes must cancel stale interview polling before the new room renders
+  useEffect(() => {
+    return () => {
+      aiInterviewRequestSeqRef.current += 1;
+      if (aiInterviewPollTimeoutRef.current) {
+        clearTimeout(aiInterviewPollTimeoutRef.current);
+        aiInterviewPollTimeoutRef.current = null;
+      }
+    };
+  }, [roomId]);
+
   const [bottomCollapsed, setBottomCollapsed] = useState(false);
   const [activeCenterTab, setActiveCenterTab] = useState<'code' | 'whiteboard'>('code');
   const [whiteboardViewMode, setWhiteboardViewMode] = useState<'tab' | 'floating'>('tab');
@@ -966,13 +986,24 @@ export function RoomWorkspace({
 
   const handleSendInterviewMessage = useCallback(
     async (userMessage: string) => {
+      aiInterviewRequestSeqRef.current += 1;
+      const requestSeq = aiInterviewRequestSeqRef.current;
+      if (aiInterviewPollTimeoutRef.current) {
+        clearTimeout(aiInterviewPollTimeoutRef.current);
+        aiInterviewPollTimeoutRef.current = null;
+      }
+
+      const isCurrentRequest = () => aiInterviewRequestSeqRef.current === requestSeq;
+
       setAiInterviewError(null);
       setAiInterviewLoading(true);
 
       const userEntry: AiInterviewMessage = { role: 'user', content: userMessage };
       setAiInterviewMessages((prev) => [...prev, userEntry]);
 
-      const history = aiInterviewMessages.map((m) => ({ role: m.role, content: m.content }));
+      const history = aiInterviewMessages
+        .slice(-AI_INTERVIEW_HISTORY_LIMIT)
+        .map((m) => ({ role: m.role, content: m.content }));
 
       try {
         const submission = await api(CONTROL_API.ROOMS.AI_INTERVIEW, {
@@ -984,49 +1015,74 @@ export function RoomWorkspace({
           },
         });
 
-        const POLL_INTERVAL_MS = 1500;
-        const MAX_POLLS = 40;
         let polls = 0;
 
         const poll = async (): Promise<void> => {
-          if (polls >= MAX_POLLS) {
+          if (!isCurrentRequest()) return;
+          if (polls >= AI_INTERVIEW_MAX_POLLS) {
             setAiInterviewError(t('workspace.aiInterviewFailed'));
             setAiInterviewLoading(false);
             return;
           }
           polls += 1;
 
-          const result = await api(CONTROL_API.ROOMS.AI_INTERVIEW_RESULT, {
-            params: { id: roomId, jobId: submission.jobId },
-          });
+          try {
+            const result = await api(CONTROL_API.ROOMS.AI_INTERVIEW_RESULT, {
+              params: { id: roomId, jobId: submission.jobId },
+            });
 
-          if (result.status === 'pending') {
-            setTimeout(() => void poll(), POLL_INTERVAL_MS);
-            return;
-          }
+            if (!isCurrentRequest()) return;
 
-          if (result.status === 'failed') {
-            setAiInterviewError(t('workspace.aiInterviewFailed'));
+            if (result.status === 'pending') {
+              aiInterviewPollTimeoutRef.current = setTimeout(() => {
+                aiInterviewPollTimeoutRef.current = null;
+                void poll();
+              }, AI_INTERVIEW_POLL_INTERVAL_MS);
+              return;
+            }
+
+            if (result.status === 'failed') {
+              setAiInterviewError(t('workspace.aiInterviewFailed'));
+              setAiInterviewLoading(false);
+              return;
+            }
+
+            setAiInterviewMessages((prev) => [
+              ...prev,
+              {
+                role: 'assistant',
+                content: result.message,
+                followUpQuestion: result.followUpQuestion,
+                codeAnnotations: result.codeAnnotations,
+                audioUrl: result.audioUrl,
+              },
+            ]);
             setAiInterviewLoading(false);
-            return;
+          } catch (error) {
+            if (!isCurrentRequest()) return;
+            const apiError = await readApiError(error);
+            const message = resolveErrorMessage(
+              apiError,
+              INTERVIEW_ERROR_KEYS,
+              'workspace.aiInterviewUnavailable',
+              t,
+            );
+            setAiInterviewError(message);
+            setAiInterviewLoading(false);
           }
-
-          setAiInterviewMessages((prev) => [
-            ...prev,
-            {
-              role: 'assistant',
-              content: result.message,
-              followUpQuestion: result.followUpQuestion,
-              codeAnnotations: result.codeAnnotations,
-              audioUrl: result.audioUrl,
-            },
-          ]);
-          setAiInterviewLoading(false);
         };
 
         void poll();
-      } catch {
-        setAiInterviewError(t('workspace.aiInterviewUnavailable'));
+      } catch (error) {
+        if (!isCurrentRequest()) return;
+        const apiError = await readApiError(error);
+        const message = resolveErrorMessage(
+          apiError,
+          INTERVIEW_ERROR_KEYS,
+          'workspace.aiInterviewUnavailable',
+          t,
+        );
+        setAiInterviewError(message);
         setAiInterviewLoading(false);
       }
     },
@@ -1933,8 +1989,19 @@ const HINT_ERROR_KEYS: Partial<Record<string, string>> = {
   [ERROR_CODES.AI_SERVICE_UNAVAILABLE]: 'workspace.hintUnavailable',
 };
 
+const INTERVIEW_ERROR_KEYS: Partial<Record<string, string>> = {
+  [ERROR_CODES.ROOM_PERMISSION_DENIED]: 'workspace.hintPermissionDenied',
+  [ERROR_CODES.ROOM_ACCESS_DENIED]: 'workspace.hintPermissionDenied',
+  [ERROR_CODES.ROOM_NOT_AI_MODE]: 'workspace.aiInterviewUnavailable',
+  [ERROR_CODES.PROBLEM_NOT_FOUND]: 'workspace.problemNotFound',
+  [ERROR_CODES.AI_SERVICE_UNAVAILABLE]: 'workspace.aiInterviewUnavailable',
+};
+
 const HINT_POLL_INTERVAL_MS = 750;
 const HINT_POLL_TIMEOUT_MS = 30_000;
+const AI_INTERVIEW_POLL_INTERVAL_MS = 1500;
+const AI_INTERVIEW_MAX_POLLS = 40;
+const AI_INTERVIEW_HISTORY_LIMIT = 20;
 
 class AiHintTimeoutError extends Error {
   constructor() {

--- a/apps/web/src/locales/en/rooms.json
+++ b/apps/web/src/locales/en/rooms.json
@@ -390,7 +390,18 @@
     "hintFollowUpFailed": "Failed to generate AI follow-up hint.",
     "hintRateLimited": "Hint rate limit exceeded (3 per 5 minutes).",
     "hintUnavailable": "AI hint service is temporarily unavailable.",
-    "hintPermissionDenied": "You do not have permission to request AI hints in this room."
+    "hintPermissionDenied": "You do not have permission to request AI hints in this room.",
+    "aiInterviewHeading": "AI Interviewer",
+    "aiInterviewPlaceholder": "Type your response to the interviewer...",
+    "aiInterviewSend": "Send",
+    "aiInterviewSending": "Sending...",
+    "aiInterviewYou": "You",
+    "aiInterviewAi": "AI Interviewer",
+    "aiInterviewEmpty": "The AI interviewer will ask you questions about the problem. Type your response below.",
+    "aiInterviewFailed": "Failed to get a response from the AI interviewer.",
+    "aiInterviewUnavailable": "AI interviewer service is temporarily unavailable.",
+    "aiInterviewFollowUp": "Follow-up",
+    "aiInterviewAnnotations": "Code annotations"
   },
   "whiteboard": {
     "layer": "Layer",

--- a/apps/web/src/locales/en/rooms.json
+++ b/apps/web/src/locales/en/rooms.json
@@ -137,6 +137,8 @@
     "modeAi": "AI interviewer",
     "modeAiDesc": "An AI plays the interviewer. Solo practice, anytime.",
     "modeAiUnavailable": "Coming soon",
+    "aiRequiresSavedProblem": "AI interviewer rooms require a saved backend problem.",
+    "aiRequiresSavedProblemBadge": "Saved problem",
     "button": "Create Collaborative Room",
     "provisioning": "Provisioning Workspace...",
     "noMatchingProblems": "No matching problems",

--- a/apps/web/src/locales/zh/rooms.json
+++ b/apps/web/src/locales/zh/rooms.json
@@ -364,7 +364,18 @@
     "hintFollowUpFailed": "生成 AI 追问提示失败。",
     "hintRateLimited": "提示请求过于频繁（5 分钟内最多 3 次）。",
     "hintUnavailable": "AI 提示服务暂时不可用。",
-    "hintPermissionDenied": "你没有权限在此房间请求 AI 提示。"
+    "hintPermissionDenied": "你没有权限在此房间请求 AI 提示。",
+    "aiInterviewHeading": "AI 面试官",
+    "aiInterviewPlaceholder": "输入你对面试官的回复...",
+    "aiInterviewSend": "发送",
+    "aiInterviewSending": "发送中...",
+    "aiInterviewYou": "你",
+    "aiInterviewAi": "AI 面试官",
+    "aiInterviewEmpty": "AI 面试官将就题目向你提问，请在下方输入你的回复。",
+    "aiInterviewFailed": "获取 AI 面试官回复失败。",
+    "aiInterviewUnavailable": "AI 面试官服务暂时不可用。",
+    "aiInterviewFollowUp": "追问",
+    "aiInterviewAnnotations": "代码注释"
   },
   "whiteboard": {
     "layer": "图层",

--- a/apps/web/src/locales/zh/rooms.json
+++ b/apps/web/src/locales/zh/rooms.json
@@ -111,6 +111,8 @@
     "modeAi": "AI 面试官",
     "modeAiDesc": "由 AI 扮演面试官，随时可进行单人练习。",
     "modeAiUnavailable": "即将推出",
+    "aiRequiresSavedProblem": "AI 面试官房间需要选择后端已保存的题目。",
+    "aiRequiresSavedProblemBadge": "需真实题目",
     "button": "创建协作房间",
     "provisioning": "正在配置工作区...",
     "noMatchingProblems": "没有匹配的题目",

--- a/apps/web/src/routes/_app/rooms_.create.tsx
+++ b/apps/web/src/routes/_app/rooms_.create.tsx
@@ -174,7 +174,10 @@ function CreateRoomPage() {
   });
 
   const selectedProblemId = watch('problemId');
-  const selectedProblemLabel = availableProblems.find((p) => p.value === selectedProblemId)?.label;
+  const selectedMode = watch('mode');
+  const selectedProblem = availableProblems.find((p) => p.value === selectedProblemId);
+  const selectedProblemLabel = selectedProblem?.label;
+  const selectedProblemIsMock = selectedProblem?.isMock ?? false;
 
   const { problemId: problemIdFromSearch } = Route.useSearch();
   const [hasAppliedInitialProblem, setHasAppliedInitialProblem] = useState(false);
@@ -191,6 +194,12 @@ function CreateRoomPage() {
     setValue('problemId', problemIdFromSearch, { shouldValidate: true });
     setHasAppliedInitialProblem(true);
   }, [availableProblems, hasAppliedInitialProblem, problemIdFromSearch, setValue]);
+
+  useEffect(() => {
+    if (selectedMode === 'ai' && selectedProblemIsMock) {
+      setValue('mode', 'peer', { shouldValidate: true });
+    }
+  }, [selectedMode, selectedProblemIsMock, setValue]);
 
   const createRoomMutation = useMutation({
     mutationFn: (data: CreateRoomFormData) =>
@@ -214,6 +223,11 @@ function CreateRoomPage() {
 
   const onSubmit = async (data: CreateRoomFormData) => {
     setSubmissionError(null);
+
+    if (data.mode === 'ai' && isMockProblemId(data.problemId)) {
+      setSubmissionError(t('create.aiRequiresSavedProblem'));
+      return;
+    }
 
     try {
       const room = await createRoomMutation.mutateAsync(data);
@@ -447,21 +461,36 @@ function CreateRoomPage() {
                       <button
                         type="button"
                         aria-pressed={field.value === 'ai'}
-                        aria-disabled="true"
-                        disabled
-                        className="flex cursor-not-allowed flex-col gap-2 rounded-lg border border-border bg-muted/20 p-4 text-left opacity-70"
+                        aria-disabled={selectedProblemIsMock}
+                        disabled={selectedProblemIsMock}
+                        onClick={() => field.onChange('ai')}
+                        className={cn(
+                          'flex cursor-pointer flex-col gap-2 rounded-lg border p-4 text-left transition-colors',
+                          selectedProblemIsMock
+                            ? 'cursor-not-allowed border-border bg-muted/20 opacity-70'
+                            : field.value === 'ai'
+                              ? 'border-primary bg-primary/5 ring-1 ring-primary/30'
+                              : 'border-border hover:bg-muted/30',
+                        )}
                       >
                         <div className="flex items-center gap-2">
-                          <Bot size={18} className="text-muted-foreground/60" />
+                          <Bot
+                            size={18}
+                            className={
+                              field.value === 'ai' ? 'text-primary' : 'text-muted-foreground/70'
+                            }
+                          />
                           <span className="text-sm font-semibold text-foreground">
                             {t('create.modeAi')}
                           </span>
-                          <Badge
-                            variant="outline"
-                            className="ml-auto px-1.5 py-0 text-[10px] font-medium"
-                          >
-                            {t('create.modeAiUnavailable')}
-                          </Badge>
+                          {selectedProblemIsMock ? (
+                            <Badge
+                              variant="outline"
+                              className="ml-auto px-1.5 py-0 text-[10px] font-medium"
+                            >
+                              {t('create.aiRequiresSavedProblemBadge')}
+                            </Badge>
+                          ) : null}
                         </div>
                         <span className="text-xs text-muted-foreground">
                           {t('create.modeAiDesc')}

--- a/packages/contracts/src/control/rooms.ts
+++ b/packages/contracts/src/control/rooms.ts
@@ -173,6 +173,58 @@ export const getRoomAiHintResultResponseSchema = z.discriminatedUnion('status', 
 
 export type GetRoomAiHintResultResponse = z.infer<typeof getRoomAiHintResultResponseSchema>;
 
+export const requestRoomAiInterviewSchema = z
+  .object({
+    userMessage: z
+      .string()
+      .min(1)
+      .max(2000)
+      .describe('Candidate message to the AI interviewer'),
+    conversationHistory: z
+      .array(
+        z.object({
+          role: z.enum(['user', 'assistant']),
+          content: z.string(),
+        }),
+      )
+      .describe('Prior conversation turns'),
+    currentCode: z.string().describe('Current code in the editor'),
+  })
+  .strict();
+
+export type RequestRoomAiInterviewInput = z.infer<typeof requestRoomAiInterviewSchema>;
+
+export const requestRoomAiInterviewResponseSchema = z.object({
+  jobId: z
+    .string()
+    .describe('AI interview job ID — poll GET /rooms/:id/ai/interview/:jobId for the result'),
+});
+
+export type RequestRoomAiInterviewResponse = z.infer<typeof requestRoomAiInterviewResponseSchema>;
+
+export const getRoomAiInterviewResultResponseSchema = z.discriminatedUnion('status', [
+  z.object({
+    status: z.literal('pending'),
+    jobId: z.string(),
+  }),
+  z.object({
+    status: z.literal('ready'),
+    jobId: z.string(),
+    message: z.string(),
+    followUpQuestion: z.string().optional(),
+    codeAnnotations: z.array(z.object({ line: z.number().int(), comment: z.string() })).optional(),
+    audioUrl: z.string().url().optional(),
+  }),
+  z.object({
+    status: z.literal('failed'),
+    jobId: z.string(),
+  }),
+]);
+
+export type GetRoomAiInterviewResultResponse = z.infer<
+  typeof getRoomAiInterviewResultResponseSchema
+>;
+
 export const requestRoomCodeAnalysisSchema = z
   .object({
     code: z

--- a/packages/contracts/src/control/rooms.ts
+++ b/packages/contracts/src/control/rooms.ts
@@ -175,20 +175,17 @@ export type GetRoomAiHintResultResponse = z.infer<typeof getRoomAiHintResultResp
 
 export const requestRoomAiInterviewSchema = z
   .object({
-    userMessage: z
-      .string()
-      .min(1)
-      .max(2000)
-      .describe('Candidate message to the AI interviewer'),
+    userMessage: z.string().min(1).max(2000).describe('Candidate message to the AI interviewer'),
     conversationHistory: z
       .array(
         z.object({
           role: z.enum(['user', 'assistant']),
-          content: z.string(),
+          content: z.string().max(4000),
         }),
       )
+      .max(40)
       .describe('Prior conversation turns'),
-    currentCode: z.string().describe('Current code in the editor'),
+    currentCode: z.string().max(16_000).describe('Current code in the editor'),
   })
   .strict();
 

--- a/packages/contracts/src/control/routes.ts
+++ b/packages/contracts/src/control/routes.ts
@@ -38,6 +38,7 @@ import type {
   destroyRoomResponseSchema,
   ensureCollabResponseSchema,
   getRoomAiHintResultResponseSchema,
+  getRoomAiInterviewResultResponseSchema,
   getRoomCodeAnalysisResultResponseSchema,
   joinRoomResponseSchema,
   joinRoomSchema,
@@ -47,6 +48,8 @@ import type {
   mediaTokenResponseSchema,
   requestRoomAiHintResponseSchema,
   requestRoomAiHintSchema,
+  requestRoomAiInterviewResponseSchema,
+  requestRoomAiInterviewSchema,
   requestRoomCodeAnalysisResponseSchema,
   requestRoomCodeAnalysisSchema,
   roomChatMediaUploadRequestSchema,
@@ -185,6 +188,14 @@ export const CONTROL_API = {
       'rooms/:id/ai/hint/:jobId',
       'GET',
     ),
+    AI_INTERVIEW: defineRoute<
+      z.infer<typeof requestRoomAiInterviewSchema>,
+      z.infer<typeof requestRoomAiInterviewResponseSchema>
+    >()('rooms/:id/ai/interview', 'POST'),
+    AI_INTERVIEW_RESULT: defineRoute<
+      void,
+      z.infer<typeof getRoomAiInterviewResultResponseSchema>
+    >()('rooms/:id/ai/interview/:jobId', 'GET'),
     CODE_ANALYSIS: defineRoute<
       z.infer<typeof requestRoomCodeAnalysisSchema>,
       z.infer<typeof requestRoomCodeAnalysisResponseSchema>


### PR DESCRIPTION
## Summary
- restore AI interview contracts, control-plane endpoints, DTOs, and result polling
- restore the room AI interviewer panel and make AI room creation reachable for saved problems
- harden the flow with AI-room-only enforcement, bounded payloads, polling cleanup, and integration coverage

Closes #146

## Verification
- pnpm check
- pnpm --filter @syncode/web typecheck
- pnpm --filter @syncode/control-plane typecheck
- pnpm --filter @syncode/contracts typecheck
- pnpm --filter @syncode/web exec vitest run src/components/room-ai-interview-panel.spec.tsx
- pnpm --filter @syncode/control-plane exec vitest run --config vitest.integration.config.ts src/modules/rooms/rooms.controller.integration.spec.ts

## No-loss checks
- origin/develop is an ancestor of HEAD
- no restored AI interviewer feature paths are deleted
- code-analysis, report comparison, matchmaking, chat/media upload, whiteboard, and remote execution paths remain present