### PR TITLE
fix(dx): stabilize room e2e regressions

### DIFF
--- a/apps/ai-plane/src/ai/ai.processor.spec.ts
+++ b/apps/ai-plane/src/ai/ai.processor.spec.ts
@@ -79,6 +79,13 @@ function createMockStorageService(): IStorageService {
   };
 }
 
+const resultJobOptions = {
+  attempts: 3,
+  backoff: { type: 'exponential', delay: 1500 },
+  removeOnComplete: 100,
+  removeOnFail: false,
+};
+
 describe('AiProcessor', () => {
   const { mock: mockQueueService, handlers } = createMockQueueService();
 
@@ -288,6 +295,7 @@ describe('AiProcessor', () => {
         AI_HINT_RESULT_QUEUE,
         'hint-result',
         expect.objectContaining({ jobId: 'hint-job-1', hint: expect.any(String) }),
+        resultJobOptions,
       );
     });
   });
@@ -319,6 +327,7 @@ describe('AiProcessor', () => {
           summary: expect.any(String),
           followUpQuestions: expect.any(Array),
         }),
+        resultJobOptions,
       );
     });
   });
@@ -373,6 +382,7 @@ describe('AiProcessor', () => {
           recurringPatterns: expect.any(Array),
           weaknesses: expect.any(Array),
         }),
+        resultJobOptions,
       );
     });
   });
@@ -404,6 +414,7 @@ describe('AiProcessor', () => {
           overallScore: expect.any(Number),
           categories: expect.any(Array),
         }),
+        resultJobOptions,
       );
     });
   });
@@ -442,6 +453,7 @@ describe('AiProcessor', () => {
             downloadUrl: 'https://storage.example/interview-audio.mp3',
           }),
         }),
+        resultJobOptions,
       );
     });
   });
@@ -544,6 +556,7 @@ describe('AiProcessor', () => {
             }),
           ],
         }),
+        resultJobOptions,
       );
     });
   });

--- a/apps/ai-plane/src/ai/ai.processor.ts
+++ b/apps/ai-plane/src/ai/ai.processor.ts
@@ -23,6 +23,13 @@ import type { IQueueService, QueueJob } from '@syncode/shared/ports';
 import { QUEUE_SERVICE } from '@syncode/shared/ports';
 import { AiService } from './ai.service.js';
 
+const RESULT_JOB_OPTIONS = {
+  attempts: 3,
+  backoff: { type: 'exponential', delay: 1500 },
+  removeOnComplete: 100,
+  removeOnFail: false,
+} as const;
+
 @Injectable()
 export class AiProcessor implements OnModuleInit {
   private readonly logger = new Logger(AiProcessor.name);
@@ -94,7 +101,15 @@ export class AiProcessor implements OnModuleInit {
 
     // Errors should propagate so BullMQ retries on transient failures.
     const result = await this.aiService.generateHint(request);
-    await this.queueService.enqueue(AI_HINT_RESULT_QUEUE, 'hint-result', { ...result, jobId });
+    await this.queueService.enqueue(
+      AI_HINT_RESULT_QUEUE,
+      'hint-result',
+      {
+        ...result,
+        jobId,
+      },
+      RESULT_JOB_OPTIONS,
+    );
 
     this.logger.log(`Hint job ${jobId} completed`);
   }
@@ -104,10 +119,15 @@ export class AiProcessor implements OnModuleInit {
     this.logger.log(`Processing code analysis job ${jobId}`);
 
     const result = await this.aiService.analyzeCode(request);
-    await this.queueService.enqueue(AI_CODE_ANALYSIS_RESULT_QUEUE, 'code-analysis-result', {
-      ...result,
-      jobId,
-    });
+    await this.queueService.enqueue(
+      AI_CODE_ANALYSIS_RESULT_QUEUE,
+      'code-analysis-result',
+      {
+        ...result,
+        jobId,
+      },
+      RESULT_JOB_OPTIONS,
+    );
 
     this.logger.log(`Code analysis job ${jobId} completed`);
   }
@@ -119,10 +139,15 @@ export class AiProcessor implements OnModuleInit {
     this.logger.log(`Processing weakness analysis job ${jobId} for session ${request.sessionId}`);
 
     const result = await this.aiService.generateWeaknessAnalysis(request);
-    await this.queueService.enqueue(AI_WEAKNESS_ANALYSIS_RESULT_QUEUE, 'weakness-analysis-result', {
-      ...result,
-      jobId,
-    });
+    await this.queueService.enqueue(
+      AI_WEAKNESS_ANALYSIS_RESULT_QUEUE,
+      'weakness-analysis-result',
+      {
+        ...result,
+        jobId,
+      },
+      RESULT_JOB_OPTIONS,
+    );
 
     this.logger.log(`Weakness analysis job ${jobId} completed`);
   }
@@ -133,7 +158,15 @@ export class AiProcessor implements OnModuleInit {
 
     // Errors should propagate so BullMQ retries on transient failures.
     const result = await this.aiService.reviewCode(request);
-    await this.queueService.enqueue(AI_REVIEW_RESULT_QUEUE, 'review-result', { ...result, jobId });
+    await this.queueService.enqueue(
+      AI_REVIEW_RESULT_QUEUE,
+      'review-result',
+      {
+        ...result,
+        jobId,
+      },
+      RESULT_JOB_OPTIONS,
+    );
 
     this.logger.log(`Review job ${jobId} completed`);
   }
@@ -144,10 +177,15 @@ export class AiProcessor implements OnModuleInit {
 
     // Errors should propagate so BullMQ retries on transient failures.
     const result = await this.aiService.generateInterviewResponse(request);
-    await this.queueService.enqueue(AI_INTERVIEW_RESULT_QUEUE, 'interview-result', {
-      ...result,
-      jobId,
-    });
+    await this.queueService.enqueue(
+      AI_INTERVIEW_RESULT_QUEUE,
+      'interview-result',
+      {
+        ...result,
+        jobId,
+      },
+      RESULT_JOB_OPTIONS,
+    );
 
     this.logger.log(`Interview job ${jobId} completed`);
   }
@@ -157,10 +195,15 @@ export class AiProcessor implements OnModuleInit {
     this.logger.log(`Processing session report job ${jobId} for session ${request.sessionId}`);
     try {
       const result = await this.aiService.generateSessionReport(request);
-      await this.queueService.enqueue(AI_SESSION_REPORT_RESULT_QUEUE, 'session-report-result', {
-        ...result,
-        jobId,
-      });
+      await this.queueService.enqueue(
+        AI_SESSION_REPORT_RESULT_QUEUE,
+        'session-report-result',
+        {
+          ...result,
+          jobId,
+        },
+        RESULT_JOB_OPTIONS,
+      );
 
       this.logger.log(`Session report job ${jobId} completed`);
     } catch (error) {

--- a/apps/control-plane/src/modules/rooms/rooms.controller.integration.spec.ts
+++ b/apps/control-plane/src/modules/rooms/rooms.controller.integration.spec.ts
@@ -227,6 +227,15 @@ describe('GET /rooms/public', () => {
 });
 
 describe('GET /rooms/:id', () => {
+  it('GIVEN malformed room id WHEN getting room THEN returns 400 instead of reaching storage', async () => {
+    const user = await insertUser(db);
+
+    const res = await asUser(request(app.getHttpServer()).get('/rooms/not-a-uuid'), user);
+
+    expect(res.status).toBe(400);
+    expect(res.body.statusCode).toBe(400);
+  });
+
   it('GIVEN user is participant WHEN getting room THEN returns detail with ISO timestamps on participants', async () => {
     const user = await insertUser(db);
     const room = await insertRoom(db, user.id);
@@ -1218,6 +1227,20 @@ describe('POST /rooms/:id/chat/media/upload-url', () => {
         sizeBytes: 42,
       })
       .expect(400);
+  });
+});
+
+describe('POST /rooms/:id/collab/ensure', () => {
+  it('GIVEN malformed room id WHEN ensuring collab THEN returns 400 instead of reaching storage', async () => {
+    const user = await insertUser(db);
+
+    const res = await asUser(
+      request(app.getHttpServer()).post('/rooms/not-a-uuid/collab/ensure'),
+      user,
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.statusCode).toBe(400);
   });
 });
 

--- a/apps/control-plane/src/modules/rooms/rooms.controller.ts
+++ b/apps/control-plane/src/modules/rooms/rooms.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   HttpCode,
   Param,
+  ParseUUIDPipe,
   Patch,
   Post,
   Query,
@@ -162,7 +163,10 @@ export class RoomsController {
   @ApiOperation({ summary: 'Get room details' })
   @ApiParam({ name: 'id', description: 'Room ID (UUID)' })
   @ApiResponse({ status: 200, type: RoomDetailDto })
-  async getRoom(@CurrentUser() user: AuthUser, @Param('id') id: string): Promise<RoomDetailDto> {
+  async getRoom(
+    @CurrentUser() user: AuthUser,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<RoomDetailDto> {
     const result = await this.roomsService.getRoom(id, user.id);
     return this.serializeRoomDetail(result);
   }
@@ -175,7 +179,7 @@ export class RoomsController {
   @ApiResponse({ status: 200, type: JoinRoomResponseDto })
   async joinRoom(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: JoinRoomDto,
   ): Promise<JoinRoomResponseDto> {
     const result = await this.roomsService.joinRoom(id, user.id, body);
@@ -198,7 +202,7 @@ export class RoomsController {
   @ApiResponse({ status: 200, type: TransferRoomOwnershipResponseDto })
   async transferOwnership(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: TransferRoomOwnershipDto,
   ): Promise<TransferRoomOwnershipResponseDto> {
     const result = await this.roomsService.transferOwnership(id, user.id, body.targetUserId);
@@ -214,8 +218,8 @@ export class RoomsController {
   @ApiResponse({ status: 200, type: UpdateRoomParticipantResponseDto })
   async updateParticipantRole(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
-    @Param('participantUserId') participantUserId: string,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('participantUserId', ParseUUIDPipe) participantUserId: string,
     @Body() body: UpdateRoomParticipantDto,
   ): Promise<UpdateRoomParticipantResponseDto> {
     const result = await this.roomsService.updateParticipantRole(
@@ -255,8 +259,8 @@ export class RoomsController {
   })
   async removeParticipant(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
-    @Param('userId') userId: string,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('userId', ParseUUIDPipe) userId: string,
   ): Promise<void> {
     await this.roomsService.removeParticipant(id, user.id, userId);
   }
@@ -267,7 +271,7 @@ export class RoomsController {
   @ApiResponse({ status: 200, type: DestroyRoomResponseDto })
   async destroyRoom(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
   ): Promise<DestroyRoomResponseDto> {
     const result = await this.roomsService.destroyRoom(id, user.id);
     return {
@@ -295,7 +299,7 @@ export class RoomsController {
   @ApiResponse({ status: 504, type: ErrorResponseDto, description: 'Execution service timeout' })
   async runCode(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: RunCodeDto,
   ): Promise<RunCodeResponseDto> {
     return this.roomsService.runCode(id, user.id, body);
@@ -312,7 +316,7 @@ export class RoomsController {
   @ApiResponse({ status: 409, type: ErrorResponseDto, description: 'Editor is locked' })
   async submitProblem(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: SubmitProblemDto,
   ): Promise<SubmitCodeResponseDto> {
     return this.roomsService.submitProblem(id, user.id, body);
@@ -354,7 +358,7 @@ export class RoomsController {
   })
   async requestAiHint(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: RequestRoomAiHintDto,
   ): Promise<RequestRoomAiHintResponseDto> {
     return this.roomsService.requestAiHint(id, user.id, body);
@@ -381,7 +385,7 @@ export class RoomsController {
   })
   async getAiHintResult(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Param('jobId') jobId: string,
   ): Promise<GetRoomAiHintResultResponseDto> {
     return this.roomsService.getAiHintResult(id, user.id, jobId);
@@ -410,7 +414,7 @@ export class RoomsController {
   @ApiResponse({ status: 503, type: ErrorResponseDto, description: 'AI service unavailable' })
   async requestAiInterview(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: RequestRoomAiInterviewDto,
   ): Promise<RequestRoomAiInterviewResponseDto> {
     return this.roomsService.requestAiInterview(id, user.id, body);
@@ -433,7 +437,7 @@ export class RoomsController {
   @ApiResponse({ status: 404, type: ErrorResponseDto, description: 'Job not found or expired' })
   async getAiInterviewResult(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Param('jobId') jobId: string,
   ): Promise<GetRoomAiInterviewResultResponseDto> {
     return this.roomsService.getAiInterviewResult(id, user.id, jobId);
@@ -480,7 +484,7 @@ export class RoomsController {
   })
   async requestCodeAnalysis(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: RequestRoomCodeAnalysisDto,
   ): Promise<RequestRoomCodeAnalysisResponseDto> {
     return this.roomsService.requestCodeAnalysis(id, user.id, body);
@@ -510,7 +514,7 @@ export class RoomsController {
   })
   async getCodeAnalysisResult(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Param('jobId') jobId: string,
   ): Promise<GetRoomCodeAnalysisResultResponseDto> {
     return this.roomsService.getCodeAnalysisResult(id, user.id, jobId);
@@ -539,7 +543,7 @@ export class RoomsController {
   @ApiResponse({ status: 404, type: ErrorResponseDto, description: 'Room not found' })
   async getChatMediaUploadUrl(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: RoomChatMediaUploadDto,
   ): Promise<RoomChatMediaUploadResponseDto> {
     return this.roomsService.getRoomChatMediaUploadUrl(id, user.id, body);
@@ -552,7 +556,7 @@ export class RoomsController {
   @ApiResponse({ status: 200, type: RoomDetailDto })
   async toggleReady(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
   ): Promise<RoomDetailDto> {
     const result = await this.roomsService.toggleReady(id, user.id);
     return this.serializeRoomDetail(result);
@@ -569,7 +573,7 @@ export class RoomsController {
   @ApiResponse({ status: 404, type: ErrorResponseDto })
   async changeLanguage(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: ChangeRoomLanguageDto,
   ): Promise<RoomDetailDto> {
     const result = await this.roomsService.changeLanguage(id, user.id, body.language);
@@ -584,7 +588,7 @@ export class RoomsController {
   @ApiResponse({ status: 200, type: TransitionRoomPhaseResponseDto })
   async transitionPhase(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: TransitionRoomPhaseDto,
   ): Promise<TransitionRoomPhaseResponseDto> {
     const result = await this.roomsService.transitionPhase(id, user.id, body.targetStatus);
@@ -601,7 +605,7 @@ export class RoomsController {
   @ApiResponse({ status: 409, type: ErrorResponseDto, description: 'Room has already finished' })
   async lockEditor(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
   ): Promise<LockEditorResponseDto> {
     const result = await this.roomsService.setEditorLock(id, user.id, true);
     return {
@@ -624,7 +628,7 @@ export class RoomsController {
   @ApiResponse({ status: 409, type: ErrorResponseDto, description: 'Room has already finished' })
   async unlockEditor(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
   ): Promise<UnlockEditorResponseDto> {
     const result = await this.roomsService.setEditorLock(id, user.id, false);
     return {
@@ -657,7 +661,7 @@ export class RoomsController {
   })
   async ensureCollab(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
   ): Promise<EnsureCollabResponseDto> {
     return this.roomsService.ensureCollab(id, user.id);
   }
@@ -681,7 +685,7 @@ export class RoomsController {
   @ApiResponse({ status: 504, type: ErrorResponseDto, description: 'Media service timeout' })
   async generateMediaToken(
     @CurrentUser() user: AuthUser,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
   ): Promise<MediaTokenResponseDto> {
     const result = await this.roomsService.generateMediaToken(id, user.id);
     return { ...result, expiresAt: result.expiresAt.toISOString() };

--- a/apps/web/src/components/collaborative-editor.tsx
+++ b/apps/web/src/components/collaborative-editor.tsx
@@ -281,9 +281,8 @@ export function CollaborativeEditor({
       };
     });
 
-    let cancelled = false;
-    queueMicrotask(() => {
-      if (cancelled) {
+    const frame = globalThis.window.requestAnimationFrame(() => {
+      if (!editor.getModel()) {
         return;
       }
 
@@ -294,7 +293,7 @@ export function CollaborativeEditor({
     });
 
     return () => {
-      cancelled = true;
+      globalThis.window.cancelAnimationFrame(frame);
     };
   }, [editor, commentLineSet, selectedLine, threadLine]);
 

--- a/apps/web/src/components/lobby-bot.tsx
+++ b/apps/web/src/components/lobby-bot.tsx
@@ -199,36 +199,36 @@ export function LobbyBot({
 
         {/* Left eye */}
         <motion.ellipse
+          cx={38}
+          cy={eyeBaseY}
           rx={eyeRx}
           ry={eyeRy}
           animate={{
-            cx: mood === 'sleeping' ? 38 : undefined,
-            cy: mood === 'sleeping' ? eyeBaseY : undefined,
             rx: eyeRx,
             ry: eyeRy,
             fill: eyeColor,
           }}
           style={{
-            cx: mood === 'sleeping' ? undefined : leftPupilCx,
-            cy: mood === 'sleeping' ? undefined : leftPupilCy,
+            cx: mood === 'sleeping' ? 38 : leftPupilCx,
+            cy: mood === 'sleeping' ? eyeBaseY : leftPupilCy,
           }}
           transition={{ type: 'spring', stiffness: 180, damping: 16 }}
         />
 
         {/* Right eye */}
         <motion.ellipse
+          cx={62}
+          cy={eyeBaseY}
           rx={eyeRx}
           ry={eyeRy}
           animate={{
-            cx: mood === 'sleeping' ? 62 : undefined,
-            cy: mood === 'sleeping' ? eyeBaseY : undefined,
             rx: eyeRx,
             ry: eyeRy,
             fill: eyeColor,
           }}
           style={{
-            cx: mood === 'sleeping' ? undefined : rightPupilCx,
-            cy: mood === 'sleeping' ? undefined : rightPupilCy,
+            cx: mood === 'sleeping' ? 62 : rightPupilCx,
+            cy: mood === 'sleeping' ? eyeBaseY : rightPupilCy,
           }}
           transition={{ type: 'spring', stiffness: 180, damping: 16 }}
         />

--- a/apps/web/src/components/media-settings-panel.spec.tsx
+++ b/apps/web/src/components/media-settings-panel.spec.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MediaSettingsPanel } from './media-settings-panel.js';
 
@@ -70,18 +69,20 @@ describe('MediaSettingsPanel', () => {
   });
 
   it('GIVEN no prior permissions WHEN panel opened THEN shows both grant buttons', async () => {
-    setupNavigatorMocks({ cameraState: 'prompt', micState: 'prompt', devices: [] });
-    const user = userEvent.setup();
+    const { enumerateDevices } = setupNavigatorMocks({
+      cameraState: 'prompt',
+      micState: 'prompt',
+      devices: [],
+    });
 
     render(<MediaSettingsPanel {...baseProps} />);
-    await user.click(screen.getByRole('button', { name: /media settings/i }));
+    fireEvent.click(screen.getByRole('button', { name: /media settings/i }));
 
-    expect(
-      await screen.findByRole('button', { name: /grant camera permission/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /grant camera permission/i })).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /grant microphone permission/i }),
     ).toBeInTheDocument();
+    await waitFor(() => expect(enumerateDevices).toHaveBeenCalled());
   });
 
   it('GIVEN camera already granted via Permissions API WHEN opened THEN camera section shows device picker and no grant button', async () => {
@@ -90,10 +91,9 @@ describe('MediaSettingsPanel', () => {
       micState: 'prompt',
       devices: [{ kind: 'videoinput', deviceId: 'cam-1', label: 'FaceTime HD' }],
     });
-    const user = userEvent.setup();
 
     render(<MediaSettingsPanel {...baseProps} />);
-    await user.click(screen.getByRole('button', { name: /media settings/i }));
+    fireEvent.click(screen.getByRole('button', { name: /media settings/i }));
 
     await waitFor(() => {
       expect(
@@ -115,10 +115,9 @@ describe('MediaSettingsPanel', () => {
         query: vi.fn().mockRejectedValue(new TypeError('unsupported')),
       },
     });
-    const user = userEvent.setup();
 
     render(<MediaSettingsPanel {...baseProps} />);
-    await user.click(screen.getByRole('button', { name: /media settings/i }));
+    fireEvent.click(screen.getByRole('button', { name: /media settings/i }));
 
     await waitFor(() => {
       expect(
@@ -157,12 +156,11 @@ describe('MediaSettingsPanel', () => {
       },
     });
 
-    const user = userEvent.setup();
     render(<MediaSettingsPanel {...baseProps} />);
-    await user.click(screen.getByRole('button', { name: /media settings/i }));
+    fireEvent.click(screen.getByRole('button', { name: /media settings/i }));
 
     const grantBtn = await screen.findByRole('button', { name: /grant camera permission/i });
-    await user.click(grantBtn);
+    fireEvent.click(grantBtn);
 
     await waitFor(() => {
       expect(getUserMedia).toHaveBeenCalledWith({ video: true });
@@ -189,12 +187,11 @@ describe('MediaSettingsPanel', () => {
       },
     });
 
-    const user = userEvent.setup();
     render(<MediaSettingsPanel {...baseProps} />);
-    await user.click(screen.getByRole('button', { name: /media settings/i }));
+    fireEvent.click(screen.getByRole('button', { name: /media settings/i }));
 
     const grantBtn = await screen.findByRole('button', { name: /grant microphone permission/i });
-    await user.click(grantBtn);
+    fireEvent.click(grantBtn);
 
     expect(await screen.findByText(/permission denied/i)).toBeInTheDocument();
     expect(

--- a/apps/web/src/components/room-ai-interview-panel.spec.tsx
+++ b/apps/web/src/components/room-ai-interview-panel.spec.tsx
@@ -84,6 +84,27 @@ describe('RoomAiInterviewPanel', () => {
     expect(onSend).toHaveBeenCalledWith('My answer');
   });
 
+  it('GIVEN user submits rapidly WHEN send button is double-clicked THEN emits one message', async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(
+      <RoomAiInterviewPanel
+        messages={[]}
+        isLoading={false}
+        error={null}
+        onSendMessage={onSend}
+        canSendMessage={true}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText('workspace.aiInterviewPlaceholder');
+    await user.type(textarea, 'My answer');
+    await user.dblClick(screen.getByRole('button', { name: 'workspace.aiInterviewSend' }));
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend).toHaveBeenCalledWith('My answer');
+  });
+
   it('GIVEN assistant message with codeAnnotations WHEN rendered THEN shows annotations', () => {
     render(
       <RoomAiInterviewPanel

--- a/apps/web/src/components/room-workspace.tsx
+++ b/apps/web/src/components/room-workspace.tsx
@@ -271,6 +271,7 @@ export function RoomWorkspace({
   const [aiInterviewError, setAiInterviewError] = useState<string | null>(null);
   const aiInterviewPollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const aiInterviewRequestSeqRef = useRef(0);
+  const aiInterviewInFlightRef = useRef(false);
 
   useEffect(() => {
     if (!room.problemId) return;
@@ -321,6 +322,7 @@ export function RoomWorkspace({
   useEffect(() => {
     return () => {
       aiInterviewRequestSeqRef.current += 1;
+      aiInterviewInFlightRef.current = false;
       if (aiInterviewPollTimeoutRef.current) {
         clearTimeout(aiInterviewPollTimeoutRef.current);
         aiInterviewPollTimeoutRef.current = null;
@@ -986,6 +988,11 @@ export function RoomWorkspace({
 
   const handleSendInterviewMessage = useCallback(
     async (userMessage: string) => {
+      if (aiInterviewInFlightRef.current) {
+        return;
+      }
+
+      aiInterviewInFlightRef.current = true;
       aiInterviewRequestSeqRef.current += 1;
       const requestSeq = aiInterviewRequestSeqRef.current;
       if (aiInterviewPollTimeoutRef.current) {
@@ -1022,6 +1029,7 @@ export function RoomWorkspace({
           if (polls >= AI_INTERVIEW_MAX_POLLS) {
             setAiInterviewError(t('workspace.aiInterviewFailed'));
             setAiInterviewLoading(false);
+            aiInterviewInFlightRef.current = false;
             return;
           }
           polls += 1;
@@ -1044,6 +1052,7 @@ export function RoomWorkspace({
             if (result.status === 'failed') {
               setAiInterviewError(t('workspace.aiInterviewFailed'));
               setAiInterviewLoading(false);
+              aiInterviewInFlightRef.current = false;
               return;
             }
 
@@ -1058,6 +1067,7 @@ export function RoomWorkspace({
               },
             ]);
             setAiInterviewLoading(false);
+            aiInterviewInFlightRef.current = false;
           } catch (error) {
             if (!isCurrentRequest()) return;
             const apiError = await readApiError(error);
@@ -1069,6 +1079,7 @@ export function RoomWorkspace({
             );
             setAiInterviewError(message);
             setAiInterviewLoading(false);
+            aiInterviewInFlightRef.current = false;
           }
         };
 
@@ -1084,6 +1095,7 @@ export function RoomWorkspace({
         );
         setAiInterviewError(message);
         setAiInterviewLoading(false);
+        aiInterviewInFlightRef.current = false;
       }
     },
     [aiInterviewMessages, getCode, roomId, t],

--- a/apps/web/src/lib/yjs-collab-provider.spec.ts
+++ b/apps/web/src/lib/yjs-collab-provider.spec.ts
@@ -717,5 +717,22 @@ describe('YjsCollabProvider', () => {
       vi.advanceTimersByTime(60_000);
       expect(MockWebSocket.instances.length).toBe(wsBefore);
     });
+
+    it('GIVEN already destroyed provider WHEN destroy is called again THEN cleanup is silent', () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { provider, ws } = connectProvider();
+      const sentBeforeDestroy = ws.sent.length;
+
+      provider.destroy();
+      const sentOnFirstDestroy = ws.sent.slice(sentBeforeDestroy);
+      provider.destroy();
+
+      expect(sentOnFirstDestroy).toHaveLength(1);
+      expect(sentOnFirstDestroy[0]).toBeInstanceOf(Uint8Array);
+      expect((sentOnFirstDestroy[0] as Uint8Array)[0]).toBe(1);
+      expect(ws.sent).toHaveLength(sentBeforeDestroy + 1);
+      expect(consoleError).not.toHaveBeenCalled();
+      consoleError.mockRestore();
+    });
   });
 });

--- a/apps/web/src/lib/yjs-collab-provider.ts
+++ b/apps/web/src/lib/yjs-collab-provider.ts
@@ -196,6 +196,8 @@ export class YjsCollabProvider {
   }
 
   destroy(): void {
+    if (this.disposed) return;
+
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
 
     // Broadcast our own awareness removal BEFORE tearing down handlers/WS so

--- a/apps/web/src/lib/yjs-tldraw-store.spec.ts
+++ b/apps/web/src/lib/yjs-tldraw-store.spec.ts
@@ -166,10 +166,15 @@ describe('createYjsTldrawStore', () => {
   it('GIVEN dispose WHEN called twice THEN does not throw', () => {
     const doc = new Y.Doc();
     const result = makeStore(doc, 'alice');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
     expect(() => {
       result.dispose();
       result.dispose();
     }).not.toThrow();
+    expect(consoleError).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
     doc.destroy();
   });
 

--- a/apps/web/src/lib/yjs-tldraw-store.ts
+++ b/apps/web/src/lib/yjs-tldraw-store.ts
@@ -466,6 +466,7 @@ export function createYjsTldrawStore({
     trackedOrigins: new Set([localOrigin]),
     captureTimeout: 500,
   });
+  let disposed = false;
 
   // Awareness: broadcast a minimal whiteboard presence under its own key so
   // the same Awareness instance can multiplex code-editor and whiteboard
@@ -489,6 +490,9 @@ export function createYjsTldrawStore({
     attachLocalStoreForwarder,
     setLocalApplyTarget,
     dispose: () => {
+      if (disposed) return;
+      disposed = true;
+
       beforeShapeCreate();
       beforeAssetCreate();
       yRecords.unobserve(onYRecordsChange);

--- a/apps/web/src/routes/_app/-admin.audit-logs.spec.tsx
+++ b/apps/web/src/routes/_app/-admin.audit-logs.spec.tsx
@@ -116,17 +116,19 @@ describe('AdminAuditLogsPage', () => {
             resolveNext = resolve;
           }) as never,
       );
-    const user = userEvent.setup();
 
     renderPage();
 
     expect(await screen.findByText('auth.login')).toBeInTheDocument();
 
+    const user = userEvent.setup();
+
     await user.type(screen.getByLabelText('audit.filters.searchLabel'), 'ban');
 
-    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(2));
     expect(screen.queryByText('auth.login')).not.toBeInTheDocument();
     expect(screen.getAllByText('loading')).not.toHaveLength(0);
+
+    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(2), { timeout: 3_000 });
 
     await act(async () => {
       resolveNext(makeResponse([makeLog({ action: 'admin.user.ban' })]));

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
     passWithNoTests: true,
+    testTimeout: 60_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
## Summary
- Harden room endpoints with UUID param validation so malformed room IDs return 400 instead of reaching storage paths.
- Stabilize the restored AI interviewer and collaborative room UI, including duplicate-send guarding, Monaco decoration scheduling, SVG cleanup, and idempotent Yjs teardown without dropping the awareness leave frame.
- Add retries/backoff to AI result queue jobs after real e2e exposed transient result-write loss, and stabilize related web specs/timeouts.

## Root cause
The follow-up e2e pass found a few regressions from the PR merge process and real-stack behavior: restored AI room UI paths needed duplicate-send protection, malformed room params could still fall through to lower layers, and AI result jobs had no retry options even though result publication depends on Redis. A later adversarial review also caught that the first Yjs destroy path could become idempotent while silently losing the local awareness removal broadcast.

## Validation
- `pnpm check`
- `pnpm --filter @syncode/web typecheck`
- `pnpm --filter @syncode/control-plane typecheck`
- `pnpm --filter @syncode/ai-plane typecheck`
- `pnpm --filter @syncode/web exec vitest run` (`42` files, `265` tests)
- `pnpm --filter @syncode/control-plane exec vitest run --config vitest.integration.config.ts --reporter=verbose src/modules/rooms/rooms.controller.integration.spec.ts` (`65` tests)
- `pnpm --filter @syncode/ai-plane exec vitest run src/ai/ai.processor.spec.ts` (`7` tests)
- Real API e2e against `pnpm infra:up` stack with control/collab/web/ai services, including room transitions, media token/upload URL, execution stub result, and real AI hint/code-analysis/interview completion.
- Playwright CLI two-client browser e2e covering room load, candidate Monaco edit, cross-client code sync, chat sync, and Run Code.

## Notes
- Execution was still validated through the configured execution stub because no E2B key was available.
- Follow-up to #325.
