### PR TITLE
Fix PR 329 room finish and whiteboard regressions

### DIFF
--- a/apps/control-plane/src/modules/rooms/rooms.service.integration.spec.ts
+++ b/apps/control-plane/src/modules/rooms/rooms.service.integration.spec.ts
@@ -11,6 +11,7 @@ import { Test } from '@nestjs/testing';
 import { AI_CLIENT, COLLAB_CLIENT, ERROR_CODES, EXECUTION_CLIENT } from '@syncode/contracts';
 import type { Database } from '@syncode/db';
 import {
+  codeSnapshots,
   roomDocSnapshots,
   roomParticipants,
   rooms,
@@ -65,6 +66,13 @@ beforeEach(async () => {
   mockCollabClient = createMockCollabClient();
   mockSessionReportsService = createMockSessionReportsService();
   mockStorageService = createMockStorageService();
+  mockCollabClient.updateRoomState.mockImplementation(async (request) => {
+    if (request.phase === 'finished' && request.language) {
+      await insertSessionEndSnapshotForRoom(request.roomId, request.language);
+    }
+
+    return { success: true };
+  });
 
   const module = await Test.createTestingModule({
     providers: [
@@ -89,6 +97,28 @@ beforeEach(async () => {
 afterEach(async () => {
   await cleanup();
 });
+
+async function insertSessionEndSnapshotForRoom(roomId: string, language = 'python') {
+  const [session] = await db
+    .select({ id: sessions.id })
+    .from(sessions)
+    .where(eq(sessions.roomId, roomId))
+    .limit(1);
+
+  if (!session) {
+    return;
+  }
+
+  await db.insert(codeSnapshots).values({
+    sessionId: session.id,
+    roomId,
+    code: 'print("done")',
+    language,
+    trigger: 'session_end',
+    phase: 'finished',
+    linesOfCode: 1,
+  });
+}
 
 describe('createRoom', () => {
   it('GIVEN valid input WHEN creating room THEN persists room with DB defaults and interviewer participant for the host', async () => {
@@ -1094,6 +1124,27 @@ describe('transitionPhase (multi-step)', () => {
     expect(mockSessionReportsService.enqueueForFinishedSession).toHaveBeenCalledWith(session.id);
   });
 
+  it('GIVEN report enqueue fails WHEN transitioning to finished THEN surfaces the failure', async () => {
+    const host = await insertUser(db);
+    const candidate = await insertUser(db);
+    const room = await insertRoom(db, host.id, { status: 'wrapup', language: 'python' });
+    await insertParticipant(db, room.id, host.id, 'interviewer');
+    await insertParticipant(db, room.id, candidate.id, 'candidate');
+
+    const session = await insertSession(db, room.id, { status: 'ongoing' });
+    await insertSessionParticipant(db, session.id, host.id, 'interviewer');
+    await insertSessionParticipant(db, session.id, candidate.id, 'candidate');
+    mockSessionReportsService.enqueueForFinishedSession.mockRejectedValueOnce(
+      new Error('report queue down'),
+    );
+
+    await expect(service.transitionPhase(room.id, host.id, 'finished')).rejects.toThrow(
+      'report queue down',
+    );
+
+    expect(mockSessionReportsService.enqueueForFinishedSession).toHaveBeenCalledWith(session.id);
+  });
+
   it('GIVEN session finishes WHEN transitioning to finished THEN waits for final collab snapshot before enqueuing reports', async () => {
     const host = await insertUser(db);
     const candidate = await insertUser(db);
@@ -1182,7 +1233,7 @@ describe('transitionPhase (multi-step)', () => {
     expect(sessionAfterFailure?.status).toBe('ongoing');
   });
 
-  it('GIVEN final collab snapshot update fails WHEN transitioning to finished THEN still enqueues reports', async () => {
+  it('GIVEN final collab snapshot update fails WHEN transitioning to finished THEN fails closed without enqueuing reports', async () => {
     const host = await insertUser(db);
     const candidate = await insertUser(db);
     const room = await insertRoom(db, host.id, { status: 'wrapup', language: 'python' });
@@ -1194,17 +1245,52 @@ describe('transitionPhase (multi-step)', () => {
     await insertSessionParticipant(db, session.id, candidate.id, 'candidate');
     mockCollabClient.updateRoomState.mockRejectedValueOnce(new Error('collab down'));
 
-    await service.transitionPhase(room.id, host.id, 'finished');
+    await expect(service.transitionPhase(room.id, host.id, 'finished')).rejects.toThrow(
+      'collab down',
+    );
 
-    expect(mockSessionReportsService.enqueueForFinishedSession).toHaveBeenCalledWith(session.id);
+    expect(mockSessionReportsService.enqueueForFinishedSession).not.toHaveBeenCalledWith(
+      session.id,
+    );
 
     const [roomAfterTransition] = await db.select().from(rooms).where(eq(rooms.id, room.id));
     const [sessionAfterTransition] = await db
       .select()
       .from(sessions)
       .where(eq(sessions.id, session.id));
-    expect(roomAfterTransition?.status).toBe('finished');
-    expect(sessionAfterTransition?.status).toBe('finished');
+    expect(roomAfterTransition?.status).toBe('wrapup');
+    expect(sessionAfterTransition?.status).toBe('ongoing');
+  });
+
+  it('GIVEN final collab update succeeds without session_end snapshot WHEN transitioning to finished THEN fails before finalizing', async () => {
+    const host = await insertUser(db);
+    const candidate = await insertUser(db);
+    const room = await insertRoom(db, host.id, { status: 'wrapup', language: 'python' });
+    await insertParticipant(db, room.id, host.id, 'interviewer');
+    await insertParticipant(db, room.id, candidate.id, 'candidate');
+
+    const session = await insertSession(db, room.id, { status: 'ongoing' });
+    await insertSessionParticipant(db, session.id, host.id, 'interviewer');
+    await insertSessionParticipant(db, session.id, candidate.id, 'candidate');
+    mockCollabClient.updateRoomState.mockResolvedValueOnce({ success: true });
+
+    await expect(service.transitionPhase(room.id, host.id, 'finished')).rejects.toMatchObject({
+      response: expect.objectContaining({
+        code: ERROR_CODES.INTERNAL_ERROR,
+      }),
+    });
+
+    expect(mockSessionReportsService.enqueueForFinishedSession).not.toHaveBeenCalledWith(
+      session.id,
+    );
+
+    const [roomAfterTransition] = await db.select().from(rooms).where(eq(rooms.id, room.id));
+    const [sessionAfterTransition] = await db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.id, session.id));
+    expect(roomAfterTransition?.status).toBe('wrapup');
+    expect(sessionAfterTransition?.status).toBe('ongoing');
   });
 
   it('GIVEN DB update fails after final collab snapshot WHEN transitioning to finished THEN restores collab phase', async () => {
@@ -1268,6 +1354,7 @@ describe('transitionPhase (multi-step)', () => {
     const session = await insertSession(db, room.id, { status: 'ongoing' });
     await insertSessionParticipant(db, session.id, host.id, 'interviewer');
     await insertSessionParticipant(db, session.id, candidate.id, 'candidate');
+    await insertSessionEndSnapshotForRoom(room.id, 'python');
     await db.execute(sql`
       CREATE FUNCTION fail_room_finish_update_restore()
       RETURNS trigger AS $$

--- a/apps/control-plane/src/modules/rooms/rooms.service.ts
+++ b/apps/control-plane/src/modules/rooms/rooms.service.ts
@@ -1769,7 +1769,7 @@ export class RoomsService {
           .select()
           .from(rooms)
           .where(eq(rooms.id, roomId))
-          .for('update');
+          .for('no key update');
 
         if (!lockedRoom) {
           throw new NotFoundException({
@@ -1792,6 +1792,7 @@ export class RoomsService {
           targetStatus,
           userId,
         );
+        await this.assertFinalSessionEndSnapshotReady(tx, roomId, lockedStatus, targetStatus);
 
         const roomUpdate = this.buildPhaseTransitionUpdate(
           lockedStatus,
@@ -1842,6 +1843,7 @@ export class RoomsService {
           `Failed to enqueue session reports for session ${finishedSessionId}`,
           error,
         );
+        throw error;
       }
     }
 
@@ -1949,6 +1951,41 @@ export class RoomsService {
       message: 'Cannot finish a room before selecting a programming language',
       code: ERROR_CODES.VALIDATION_FAILED,
     });
+  }
+
+  private async assertFinalSessionEndSnapshotReady(
+    tx: Parameters<Parameters<Database['transaction']>[0]>[0],
+    roomId: string,
+    previousStatus: RoomStatus,
+    targetStatus: RoomStatus,
+  ): Promise<void> {
+    if (targetStatus !== RoomStatus.FINISHED || previousStatus === RoomStatus.WAITING) {
+      return;
+    }
+
+    const [session] = await tx
+      .select({ id: sessions.id })
+      .from(sessions)
+      .where(eq(sessions.roomId, roomId))
+      .limit(1);
+
+    if (!session) {
+      return;
+    }
+
+    const [snapshot] = await tx
+      .select({ id: codeSnapshots.id })
+      .from(codeSnapshots)
+      .where(and(eq(codeSnapshots.sessionId, session.id), eq(codeSnapshots.trigger, 'session_end')))
+      .orderBy(desc(codeSnapshots.createdAt))
+      .limit(1);
+
+    if (!snapshot) {
+      throw new InternalServerErrorException({
+        message: 'Cannot finish room before persisting the final session code snapshot',
+        code: ERROR_CODES.INTERNAL_ERROR,
+      });
+    }
   }
 
   private buildPhaseTransitionUpdate(
@@ -2496,17 +2533,8 @@ export class RoomsService {
     editorLocked: boolean,
     language: SupportedLanguage,
     changedBy?: string,
-  ): Promise<boolean> {
-    try {
-      await this.collabClient.updateRoomState({ roomId, phase, editorLocked, changedBy, language });
-      return true;
-    } catch (error) {
-      this.logger.warn(
-        `Failed to confirm final collab room state for room ${roomId}; continuing finish transition`,
-        error,
-      );
-      return false;
-    }
+  ): Promise<void> {
+    await this.collabClient.updateRoomState({ roomId, phase, editorLocked, changedBy, language });
   }
 
   private async restoreCollabRoomStateStrict(

--- a/apps/web/src/components/collaborative-editor.tsx
+++ b/apps/web/src/components/collaborative-editor.tsx
@@ -39,6 +39,7 @@ interface CollaborativeEditorProps {
   readonly onSubmitCode: () => void;
   readonly onActiveLineChange?: (lineNumber: number) => void;
   readonly onCodeContextChange?: (context: EditorCodeContext) => void;
+  readonly onFocusChange?: (isFocused: boolean) => void;
 }
 
 interface DisposableLike {
@@ -64,6 +65,8 @@ interface EditorLike {
   onDidScrollChange: (listener: () => void) => DisposableLike;
   onDidLayoutChange: (listener: () => void) => DisposableLike;
   onDidChangeModelContent: (listener: () => void) => DisposableLike;
+  onDidFocusEditorWidget: (listener: () => void) => DisposableLike;
+  onDidBlurEditorWidget: (listener: () => void) => DisposableLike;
   onMouseDown: (listener: (event: EditorMouseEventLike) => void) => DisposableLike;
   getVisibleRanges: () => Array<{ startLineNumber: number; endLineNumber: number }>;
   getLayoutInfo: () => {
@@ -140,6 +143,7 @@ export function CollaborativeEditor({
   onSubmitCode,
   onActiveLineChange = () => {},
   onCodeContextChange = () => {},
+  onFocusChange = () => {},
 }: CollaborativeEditorProps) {
   const { t } = useTranslation('rooms');
   const bindingRef = useRef<MonacoBinding | null>(null);
@@ -164,6 +168,8 @@ export function CollaborativeEditor({
   onActiveLineChangeRef.current = onActiveLineChange;
   const onCodeContextChangeRef = useRef(onCodeContextChange);
   onCodeContextChangeRef.current = onCodeContextChange;
+  const onFocusChangeRef = useRef(onFocusChange);
+  onFocusChangeRef.current = onFocusChange;
 
   const editorOptions = useMemo(() => ({ ...EDITOR_OPTIONS_BASE, readOnly }), [readOnly]);
 
@@ -314,6 +320,12 @@ export function CollaborativeEditor({
     const contentDisposable = editorApi.onDidChangeModelContent(() => {
       emitCodeContext(editorApi);
     });
+    const focusDisposable = editorApi.onDidFocusEditorWidget(() => {
+      onFocusChangeRef.current(true);
+    });
+    const blurDisposable = editorApi.onDidBlurEditorWidget(() => {
+      onFocusChangeRef.current(false);
+    });
 
     const mouseDisposable = editorApi.onMouseDown((event) => {
       const lineNumber = event.target.position?.lineNumber;
@@ -338,6 +350,8 @@ export function CollaborativeEditor({
       cursorDisposable.dispose();
       selectionDisposable.dispose();
       contentDisposable.dispose();
+      focusDisposable.dispose();
+      blurDisposable.dispose();
       mouseDisposable.dispose();
     };
   }, [editor, commentLineSet, emitCodeContext]);

--- a/apps/web/src/components/room-whiteboard-keyboard.spec.ts
+++ b/apps/web/src/components/room-whiteboard-keyboard.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  applyWhiteboardKeyboardShortcutsState,
+  shouldEnableWhiteboardKeyboardShortcuts,
+  type WhiteboardKeyboardFocusController,
+} from './room-whiteboard-keyboard.js';
+
+describe('shouldEnableWhiteboardKeyboardShortcuts', () => {
+  it('enables shortcuts when the whiteboard tab is active', () => {
+    expect(
+      shouldEnableWhiteboardKeyboardShortcuts({
+        activeCenterTab: 'whiteboard',
+        whiteboardViewMode: 'tab',
+        isCodeEditorFocused: true,
+        whiteboardHasKeyboardFocus: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('disables floating whiteboard shortcuts while the code editor is focused', () => {
+    expect(
+      shouldEnableWhiteboardKeyboardShortcuts({
+        activeCenterTab: 'code',
+        whiteboardViewMode: 'floating',
+        isCodeEditorFocused: true,
+        whiteboardHasKeyboardFocus: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('enables floating whiteboard shortcuts after the user focuses the whiteboard', () => {
+    expect(
+      shouldEnableWhiteboardKeyboardShortcuts({
+        activeCenterTab: 'code',
+        whiteboardViewMode: 'floating',
+        isCodeEditorFocused: false,
+        whiteboardHasKeyboardFocus: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps shortcuts disabled for a hidden docked whiteboard', () => {
+    expect(
+      shouldEnableWhiteboardKeyboardShortcuts({
+        activeCenterTab: 'code',
+        whiteboardViewMode: 'tab',
+        isCodeEditorFocused: false,
+        whiteboardHasKeyboardFocus: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('applyWhiteboardKeyboardShortcutsState', () => {
+  it('uses transient editor focus instead of persistent user preferences', () => {
+    const editor: WhiteboardKeyboardFocusController & {
+      user: { updateUserPreferences: ReturnType<typeof vi.fn> };
+    } = {
+      focus: vi.fn(),
+      blur: vi.fn(),
+      user: { updateUserPreferences: vi.fn() },
+    };
+
+    applyWhiteboardKeyboardShortcutsState(editor, true);
+    applyWhiteboardKeyboardShortcutsState(editor, false);
+
+    expect(editor.focus).toHaveBeenCalledWith({ focusContainer: false });
+    expect(editor.blur).toHaveBeenCalledWith({ blurContainer: false });
+    expect(editor.user.updateUserPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/room-whiteboard-keyboard.ts
+++ b/apps/web/src/components/room-whiteboard-keyboard.ts
@@ -1,0 +1,39 @@
+export type RoomCenterTab = 'code' | 'whiteboard';
+export type WhiteboardViewMode = 'tab' | 'floating';
+
+export interface WhiteboardKeyboardFocusController {
+  focus: (options?: { focusContainer?: boolean }) => unknown;
+  blur: (options?: { blurContainer?: boolean }) => unknown;
+}
+
+export interface WhiteboardKeyboardShortcutState {
+  activeCenterTab: RoomCenterTab;
+  whiteboardViewMode: WhiteboardViewMode;
+  isCodeEditorFocused: boolean;
+  whiteboardHasKeyboardFocus: boolean;
+}
+
+export function shouldEnableWhiteboardKeyboardShortcuts({
+  activeCenterTab,
+  whiteboardViewMode,
+  isCodeEditorFocused,
+  whiteboardHasKeyboardFocus,
+}: WhiteboardKeyboardShortcutState): boolean {
+  if (activeCenterTab === 'whiteboard') {
+    return true;
+  }
+
+  return whiteboardViewMode === 'floating' && whiteboardHasKeyboardFocus && !isCodeEditorFocused;
+}
+
+export function applyWhiteboardKeyboardShortcutsState(
+  editor: WhiteboardKeyboardFocusController,
+  enabled: boolean,
+): void {
+  if (enabled) {
+    editor.focus({ focusContainer: false });
+    return;
+  }
+
+  editor.blur({ blurContainer: false });
+}

--- a/apps/web/src/components/room-whiteboard-panel.tsx
+++ b/apps/web/src/components/room-whiteboard-panel.tsx
@@ -29,6 +29,7 @@ import type { Awareness } from 'y-protocols/awareness';
 import type * as Y from 'yjs';
 import { api } from '@/lib/api-client.js';
 import { useYjsTldrawStore } from '@/lib/yjs-tldraw-store.js';
+import { applyWhiteboardKeyboardShortcutsState } from './room-whiteboard-keyboard.js';
 import { WhiteboardAuthorLegend } from './whiteboard-author-legend.js';
 
 export interface RoomWhiteboardPanelProps {
@@ -159,9 +160,7 @@ export function RoomWhiteboardPanel({
   const handleMount = useCallback(
     (editor: Editor) => {
       editorRef.current = editor;
-      editor.user.updateUserPreferences({
-        areKeyboardShortcutsEnabled: keyboardShortcutsEnabled,
-      });
+      applyWhiteboardKeyboardShortcutsState(editor, keyboardShortcutsEnabled);
 
       // Expose for ad-hoc browser-console debugging in dev only.
       if (import.meta.env?.DEV && typeof window !== 'undefined') {
@@ -267,9 +266,7 @@ export function RoomWhiteboardPanel({
       return;
     }
 
-    editor.user.updateUserPreferences({
-      areKeyboardShortcutsEnabled: keyboardShortcutsEnabled,
-    });
+    applyWhiteboardKeyboardShortcutsState(editor, keyboardShortcutsEnabled);
   }, [keyboardShortcutsEnabled]);
 
   // (D) Switch the active tldraw tool when the user toggles layer mode.

--- a/apps/web/src/components/room-workspace.tsx
+++ b/apps/web/src/components/room-workspace.tsx
@@ -66,6 +66,7 @@ import { RoomHeaderBar } from './room-header-bar.js';
 import { type Participant, RoomParticipantCard } from './room-participant-card.js';
 import { type ProblemData, type RoomHintItem, RoomProblemPanel } from './room-problem-panel.js';
 import { RoomStatusBar } from './room-status-bar.js';
+import { shouldEnableWhiteboardKeyboardShortcuts } from './room-whiteboard-keyboard.js';
 import { RoomWhiteboardPanel } from './room-whiteboard-panel.js';
 import {
   type CaseRunState,
@@ -374,6 +375,8 @@ export function RoomWorkspace({
   const [inlineWhiteboardHost, setInlineWhiteboardHost] = useState<HTMLDivElement | null>(null);
   const [floatingWhiteboardHost, setFloatingWhiteboardHost] = useState<HTMLDivElement | null>(null);
   const [whiteboardParkingHost, setWhiteboardParkingHost] = useState<HTMLDivElement | null>(null);
+  const [isCodeEditorFocused, setIsCodeEditorFocused] = useState(false);
+  const [whiteboardHasKeyboardFocus, setWhiteboardHasKeyboardFocus] = useState(false);
   const [_activeCommentLine, _setActiveCommentLine] = useState(1);
   const rightMountedRef = useRef(false);
   const rightContentRef = useRef<HTMLDivElement>(null);
@@ -395,8 +398,16 @@ export function RoomWorkspace({
   const [multiRunState, setMultiRunState] = useState<MultiRunState>({ status: 'idle' });
   const cancelMultiRunRef = useRef(new Map<string, () => void>());
   const nextCustomId = useRef(1);
-  const isWhiteboardKeyboardActive =
-    activeCenterTab === 'whiteboard' || whiteboardViewMode === 'floating';
+  const isWhiteboardKeyboardActive = shouldEnableWhiteboardKeyboardShortcuts({
+    activeCenterTab,
+    whiteboardViewMode,
+    isCodeEditorFocused,
+    whiteboardHasKeyboardFocus,
+  });
+  const markWhiteboardKeyboardFocus = useCallback(() => {
+    setWhiteboardHasKeyboardFocus(true);
+    setIsCodeEditorFocused(false);
+  }, []);
 
   useEffect(() => {
     const sourceCases = problem?.testCases ?? (isMockPreview ? MOCK_WORKSPACE_TEST_CASES : null);
@@ -1396,6 +1407,7 @@ export function RoomWorkspace({
                         onRunCode={() => void handleRunCodeRef.current()}
                         onSubmitCode={() => void requestSubmitCodeRef.current()}
                         onCodeContextChange={setEditorCodeContext}
+                        onFocusChange={setIsCodeEditorFocused}
                       />
                     ) : (
                       EDITOR_LOADING
@@ -1784,33 +1796,39 @@ export function RoomWorkspace({
               whiteboardParkingHost,
             )}
           >
-            <RoomWhiteboardPanel
-              doc={doc}
-              awareness={awareness}
-              roomId={roomId}
-              userId={currentUserId}
-              userName={currentUserName}
-              userColor={authorColor(currentUserId)}
-              canDraw={room.myCapabilities.includes('whiteboard:draw')}
-              canAnnotate={room.myCapabilities.includes('whiteboard:annotate')}
-              participantNames={
-                new Map(
-                  // Use displayName when set, otherwise the user's @username
-                  // — never the raw userId UUID, which leaks an identifier
-                  // and isn't human-readable. Include even inactive
-                  // participants so historical authors still show up in
-                  // the legend with their proper name.
-                  room.participants.map((p) => [p.userId, p.displayName ?? p.username] as const),
-                )
-              }
-              onPopOut={
-                whiteboardViewMode === 'tab' ? () => setWhiteboardViewMode('floating') : undefined
-              }
-              onDock={
-                whiteboardViewMode === 'floating' ? () => setWhiteboardViewMode('tab') : undefined
-              }
-              keyboardShortcutsEnabled={isWhiteboardKeyboardActive}
-            />
+            <div
+              className="h-full"
+              onFocusCapture={markWhiteboardKeyboardFocus}
+              onPointerDownCapture={markWhiteboardKeyboardFocus}
+            >
+              <RoomWhiteboardPanel
+                doc={doc}
+                awareness={awareness}
+                roomId={roomId}
+                userId={currentUserId}
+                userName={currentUserName}
+                userColor={authorColor(currentUserId)}
+                canDraw={room.myCapabilities.includes('whiteboard:draw')}
+                canAnnotate={room.myCapabilities.includes('whiteboard:annotate')}
+                participantNames={
+                  new Map(
+                    // Use displayName when set, otherwise the user's @username
+                    // — never the raw userId UUID, which leaks an identifier
+                    // and isn't human-readable. Include even inactive
+                    // participants so historical authors still show up in
+                    // the legend with their proper name.
+                    room.participants.map((p) => [p.userId, p.displayName ?? p.username] as const),
+                  )
+                }
+                onPopOut={
+                  whiteboardViewMode === 'tab' ? () => setWhiteboardViewMode('floating') : undefined
+                }
+                onDock={
+                  whiteboardViewMode === 'floating' ? () => setWhiteboardViewMode('tab') : undefined
+                }
+                keyboardShortcutsEnabled={isWhiteboardKeyboardActive}
+              />
+            </div>
           </WhiteboardPortal>
         </>
       ) : null}


### PR DESCRIPTION
## Summary
- fail closed when finishing a room without a confirmed final session_end snapshot
- avoid hiding report enqueue failures after room finish
- gate tldraw shortcuts using local focus state so Monaco input is not hijacked and tldraw preferences are not persisted

## Verification
- pnpm check
- pnpm typecheck
- pnpm --filter @syncode/web exec vitest run src/components/room-whiteboard-keyboard.spec.ts
- pnpm --filter @syncode/control-plane exec vitest run --config vitest.integration.config.ts src/modules/rooms/rooms.service.integration.spec.ts

Follow-up to #329.