### PR TITLE
fix(control-plane): filter problems by attempt status

### DIFF
--- a/apps/control-plane/src/modules/problems/problems.controller.ts
+++ b/apps/control-plane/src/modules/problems/problems.controller.ts
@@ -8,7 +8,7 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { CONTROL_API, SORT_ORDER_OPTIONS } from '@syncode/contracts';
+import { CONTROL_API, PROBLEM_LIST_STATUSES, SORT_ORDER_OPTIONS } from '@syncode/contracts';
 import { PROBLEM_DIFFICULTIES, PROBLEMS_SORT_BY_OPTIONS } from '@syncode/shared';
 import { CurrentUser } from '@/common/decorators/current-user.decorator.js';
 import { ErrorResponseDto } from '@/common/dto/error-response.dto.js';
@@ -40,6 +40,14 @@ export class ProblemsController {
     enum: [...PROBLEM_DIFFICULTIES],
     isArray: true,
     description: 'Filter by difficulties; repeat the query param or pass a comma-separated list',
+  })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: [...PROBLEM_LIST_STATUSES],
+    isArray: true,
+    description:
+      'Filter by current user attempt status; repeat the query param or pass a comma-separated list',
   })
   @ApiQuery({
     name: 'tags',

--- a/apps/control-plane/src/modules/problems/problems.service.integration.spec.ts
+++ b/apps/control-plane/src/modules/problems/problems.service.integration.spec.ts
@@ -199,6 +199,69 @@ describe('listProblems', () => {
     expect(result.data[0].attemptStatus).toBe('attempted');
   });
 
+  it('GIVEN mixed user attempts WHEN filtering by status THEN returns only matching problems for that user', async () => {
+    const user = await insertUser(db);
+    const otherUser = await insertUser(db);
+    const room = await insertRoom(db, user.id);
+    const otherRoom = await insertRoom(db, otherUser.id);
+    const attempted = await insertProblem(db, { title: 'Attempted Only' });
+    const solved = await insertProblem(db, { title: 'Solved Problem' });
+    await insertProblem(db, { title: 'Todo Problem' });
+    const otherUserAttempted = await insertProblem(db, { title: 'Other User Attempted' });
+
+    await insertSubmission(db, user.id, room.id, attempted.id, {
+      status: 'completed',
+      totalTestCases: 3,
+      passedTestCases: 1,
+    });
+    await insertSubmission(db, user.id, room.id, solved.id, {
+      status: 'completed',
+      totalTestCases: 3,
+      passedTestCases: 3,
+    });
+    await insertSubmission(db, otherUser.id, otherRoom.id, otherUserAttempted.id, {
+      status: 'completed',
+      totalTestCases: 2,
+      passedTestCases: 1,
+    });
+
+    const attemptedResult = await service.listProblems(user.id, {
+      limit: 20,
+      sortBy: 'title',
+      sortOrder: 'asc',
+      status: ['attempted'],
+    });
+    const solvedResult = await service.listProblems(user.id, {
+      limit: 20,
+      sortBy: 'title',
+      sortOrder: 'asc',
+      status: ['solved'],
+    });
+    const todoResult = await service.listProblems(user.id, {
+      limit: 20,
+      sortBy: 'title',
+      sortOrder: 'asc',
+      status: ['todo'],
+    });
+    const attemptedOrSolvedResult = await service.listProblems(user.id, {
+      limit: 20,
+      sortBy: 'title',
+      sortOrder: 'asc',
+      status: ['attempted', 'solved'],
+    });
+
+    expect(attemptedResult.data.map((problem) => problem.title)).toEqual(['Attempted Only']);
+    expect(solvedResult.data.map((problem) => problem.title)).toEqual(['Solved Problem']);
+    expect(todoResult.data.map((problem) => problem.title)).toEqual([
+      'Other User Attempted',
+      'Todo Problem',
+    ]);
+    expect(attemptedOrSolvedResult.data.map((problem) => problem.title)).toEqual([
+      'Attempted Only',
+      'Solved Problem',
+    ]);
+  });
+
   it('GIVEN problem with submissions WHEN listing THEN computes acceptance rate', async () => {
     const user = await insertUser(db);
     await insertProblem(db, { totalSubmissions: 200, acceptedSubmissions: 150 });

--- a/apps/control-plane/src/modules/problems/problems.service.ts
+++ b/apps/control-plane/src/modules/problems/problems.service.ts
@@ -65,6 +65,11 @@ export class ProblemsService {
           conditions.push(inArray(problems.difficulty, query.difficulty));
         }
 
+        const attemptStatusCondition = this.buildAttemptStatusCondition(userId, query.status);
+        if (attemptStatusCondition) {
+          conditions.push(attemptStatusCondition);
+        }
+
         if (query.company) {
           conditions.push(eq(problems.company, query.company));
         }
@@ -465,24 +470,64 @@ export class ProblemsService {
     )`.as('is_bookmarked');
   }
 
+  private buildAttemptStatusCondition(
+    userId: string,
+    statuses: ProblemsListQuery['status'],
+  ): SQL | undefined {
+    if (!statuses?.length) {
+      return undefined;
+    }
+
+    const uniqueStatuses = new Set(statuses);
+    const conditions: SQL[] = [];
+
+    if (uniqueStatuses.has('solved')) {
+      conditions.push(this.hasSolvedSubmissionExpr(userId));
+    }
+
+    if (uniqueStatuses.has('attempted')) {
+      conditions.push(
+        sql`(${this.hasAnySubmissionExpr(userId)} AND NOT (${this.hasSolvedSubmissionExpr(userId)}))`,
+      );
+    }
+
+    if (uniqueStatuses.has('todo')) {
+      conditions.push(sql`NOT (${this.hasAnySubmissionExpr(userId)})`);
+    }
+
+    if (conditions.length === 0) {
+      return undefined;
+    }
+
+    return conditions.length === 1 ? conditions[0] : or(...conditions);
+  }
+
   private attemptStatusExpr(userId: string) {
     return sql<string | null>`(
       CASE
-        WHEN EXISTS (
-          SELECT 1 FROM submissions s
-          WHERE s.problem_id = "problems"."id"
-          AND s.user_id = ${userId}
-          AND s.status = 'completed'
-          AND s.passed_test_cases = s.total_test_cases
-        ) THEN 'solved'
-        WHEN EXISTS (
-          SELECT 1 FROM submissions s
-          WHERE s.problem_id = "problems"."id"
-          AND s.user_id = ${userId}
-        ) THEN 'attempted'
+        WHEN ${this.hasSolvedSubmissionExpr(userId)} THEN 'solved'
+        WHEN ${this.hasAnySubmissionExpr(userId)} THEN 'attempted'
         ELSE NULL
       END
     )`.as('attempt_status');
+  }
+
+  private hasSolvedSubmissionExpr(userId: string) {
+    return sql<boolean>`EXISTS (
+      SELECT 1 FROM submissions s
+      WHERE s.problem_id = "problems"."id"
+      AND s.user_id = ${userId}
+      AND s.status = 'completed'
+      AND s.passed_test_cases = s.total_test_cases
+    )`;
+  }
+
+  private hasAnySubmissionExpr(userId: string) {
+    return sql<boolean>`EXISTS (
+      SELECT 1 FROM submissions s
+      WHERE s.problem_id = "problems"."id"
+      AND s.user_id = ${userId}
+    )`;
   }
 
   private acceptanceRateExpr() {

--- a/packages/contracts/src/control/problems.spec.ts
+++ b/packages/contracts/src/control/problems.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest';
+import { problemsListQuerySchema } from './problems.js';
+
+describe('problemsListQuerySchema', () => {
+  test('GIVEN comma-separated status filters WHEN parsed THEN returns normalized status array', () => {
+    const result = problemsListQuerySchema.parse({ status: 'attempted,todo,attempted' });
+
+    expect(result.status).toEqual(['attempted', 'todo']);
+  });
+
+  test('GIVEN invalid status filter WHEN parsed THEN rejects', () => {
+    const result = problemsListQuerySchema.safeParse({ status: 'finished' });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/control/problems.ts
+++ b/packages/contracts/src/control/problems.ts
@@ -8,10 +8,16 @@ import { z } from 'zod';
 import { paginationQuerySchema, paginationSchema } from './pagination.js';
 import { parseQueryMultiSelect } from './query-parsers.js';
 
+export const PROBLEM_LIST_STATUSES = [...PROBLEM_ATTEMPT_STATUSES, 'todo'] as const;
+export type ProblemListStatus = (typeof PROBLEM_LIST_STATUSES)[number];
+
 export const problemsListQuerySchema = paginationQuerySchema.extend({
   difficulty: z
     .preprocess(parseQueryMultiSelect, z.array(z.enum(PROBLEM_DIFFICULTIES)).optional())
     .describe('Filter by difficulties; accepts repeated or comma-separated query params'),
+  status: z
+    .preprocess(parseQueryMultiSelect, z.array(z.enum(PROBLEM_LIST_STATUSES)).optional())
+    .describe('Filter by current user attempt status; accepts repeated or comma-separated values'),
   tags: z.string().optional().describe('Comma-separated tag slugs'),
   company: z.string().optional().describe('Company slug filter'),
   search: z.string().optional().describe('Full-text search on title + description'),


### PR DESCRIPTION
## Summary
- add `status=solved|attempted|todo` to the problems list contract and Swagger docs
- apply attempt-status filtering in the control-plane query before pagination
- cover parser behavior and DB-backed per-user status semantics

## Root Cause
The web app was sending `status=attempted`, but `GET /problems` did not define or apply a `status` query parameter. The backend ignored it and returned the normal paginated problem list.

## Test Plan
- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter @syncode/shared build`
- `pnpm --filter @syncode/contracts test`
- `pnpm --filter @syncode/control-plane exec vitest run --config vitest.integration.config.ts src/modules/problems/problems.service.integration.spec.ts`
- `git diff --check`
