### PR TITLE
fix(web): repair inline comment behavior

### DIFF
--- a/apps/web/src/components/collaborative-editor.spec.tsx
+++ b/apps/web/src/components/collaborative-editor.spec.tsx
@@ -1,6 +1,145 @@
-import { describe, expect, it } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Awareness } from 'y-protocols/awareness';
 import * as Y from 'yjs';
 import { codeTextKey } from '@/lib/yjs-collab-provider.js';
+import { CollaborativeEditor } from './collaborative-editor.js';
+
+const fakeMonacoState = vi.hoisted(() => ({
+  editor: null as FakeEditor | null,
+  monaco: {
+    KeyMod: { CtrlCmd: 2048, Shift: 1024 },
+    KeyCode: { Enter: 3 },
+    editor: {
+      MouseTargetType: {
+        GUTTER_GLYPH_MARGIN: 2,
+        GUTTER_LINE_NUMBERS: 3,
+        GUTTER_LINE_DECORATIONS: 4,
+      },
+    },
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, unknown>) =>
+      values?.line == null ? key : `${key} ${values.line}`,
+  }),
+}));
+
+vi.mock('y-monaco', () => ({
+  MonacoBinding: vi.fn().mockImplementation(() => ({ destroy: vi.fn() })),
+}));
+
+vi.mock('./lazy-monaco-editor.js', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  return {
+    LazyMonacoEditor: (props: {
+      onMount?: (editor: FakeEditor, monaco: typeof fakeMonacoState.monaco) => void;
+    }) => {
+      React.useEffect(() => {
+        if (fakeMonacoState.editor) {
+          props.onMount?.(fakeMonacoState.editor, fakeMonacoState.monaco);
+        }
+      }, [props]);
+
+      return React.createElement('div', { 'data-testid': 'mock-monaco-editor' });
+    },
+  };
+});
+
+afterEach(() => {
+  fakeMonacoState.editor = null;
+});
+
+interface FakeMouseEvent {
+  target: {
+    type: number;
+    position?: { lineNumber: number } | null;
+  };
+}
+
+interface FakeEditor {
+  addAction: ReturnType<typeof vi.fn>;
+  getModel: () => {
+    getLineCount: () => number;
+    getLineContent: (lineNumber: number) => string;
+    getValueInRange: () => string;
+  };
+  getPosition: () => { lineNumber: number };
+  getSelection: () => null;
+  getDomNode: () => HTMLElement;
+  focus: ReturnType<typeof vi.fn>;
+  onDidChangeCursorPosition: (listener: (event: { position: { lineNumber: number } }) => void) => {
+    dispose: () => void;
+  };
+  onDidChangeCursorSelection: (listener: () => void) => { dispose: () => void };
+  onDidScrollChange: (listener: () => void) => { dispose: () => void };
+  onDidLayoutChange: (listener: () => void) => { dispose: () => void };
+  onDidChangeModelContent: (listener: () => void) => { dispose: () => void };
+  onDidFocusEditorWidget: (listener: () => void) => { dispose: () => void };
+  onDidBlurEditorWidget: (listener: () => void) => { dispose: () => void };
+  onMouseDown: (listener: (event: FakeMouseEvent) => void) => { dispose: () => void };
+  onMouseMove: (listener: (event: FakeMouseEvent) => void) => { dispose: () => void };
+  getVisibleRanges: () => Array<{ startLineNumber: number; endLineNumber: number }>;
+  getLayoutInfo: () => { glyphMarginLeft: number; glyphMarginWidth: number; contentLeft: number };
+  getScrolledVisiblePosition: (position: { lineNumber: number; column: number }) => {
+    top: number;
+    left: number;
+    height: number;
+  };
+  deltaDecorations: ReturnType<typeof vi.fn>;
+  emitMouseMove: (lineNumber: number, targetType: number) => void;
+}
+
+function createFakeEditor(options: { readonly clientHeight?: number } = {}): FakeEditor {
+  const mouseMoveListeners: Array<(event: FakeMouseEvent) => void> = [];
+  const disposable = () => ({ dispose: vi.fn() });
+  const root = document.createElement('div');
+  Object.defineProperty(root, 'clientHeight', {
+    configurable: true,
+    value: options.clientHeight ?? 500,
+  });
+
+  return {
+    addAction: vi.fn(),
+    getModel: () => ({
+      getLineCount: () => 4,
+      getLineContent: (lineNumber) => `line ${lineNumber}`,
+      getValueInRange: () => 'selected',
+    }),
+    getPosition: () => ({ lineNumber: 1 }),
+    getSelection: () => null,
+    getDomNode: () => root,
+    focus: vi.fn(),
+    onDidChangeCursorPosition: () => disposable(),
+    onDidChangeCursorSelection: () => disposable(),
+    onDidScrollChange: () => disposable(),
+    onDidLayoutChange: () => disposable(),
+    onDidChangeModelContent: () => disposable(),
+    onDidFocusEditorWidget: () => disposable(),
+    onDidBlurEditorWidget: () => disposable(),
+    onMouseDown: () => disposable(),
+    onMouseMove: (listener) => {
+      mouseMoveListeners.push(listener);
+      return disposable();
+    },
+    getVisibleRanges: () => [{ startLineNumber: 1, endLineNumber: 4 }],
+    getLayoutInfo: () => ({ glyphMarginLeft: 0, glyphMarginWidth: 20, contentLeft: 80 }),
+    getScrolledVisiblePosition: ({ lineNumber }) => ({
+      top: lineNumber * 20,
+      left: 0,
+      height: 20,
+    }),
+    deltaDecorations: vi.fn(() => []),
+    emitMouseMove: (lineNumber, targetType) => {
+      for (const listener of mouseMoveListeners) {
+        listener({ target: { type: targetType, position: { lineNumber } } });
+      }
+    },
+  };
+}
 
 // Unit coverage for the Y.Text key selection logic that CollaborativeEditor relies on.
 // Mounting the real Monaco editor in jsdom is brittle — the important guarantee is that
@@ -35,6 +174,86 @@ describe('CollaborativeEditor Y.Text selection', () => {
 
     expect(first).toBe(second);
 
+    doc.destroy();
+  });
+});
+
+describe('CollaborativeEditor inline comments', () => {
+  it('GIVEN a gutter hover on a non-cursor line WHEN adding a comment THEN targets the hovered line', async () => {
+    const user = userEvent.setup();
+    const doc = new Y.Doc();
+    const awareness = new Awareness(doc);
+    const onAddComment = vi.fn();
+    const fakeEditor = createFakeEditor();
+    fakeMonacoState.editor = fakeEditor;
+
+    render(
+      <CollaborativeEditor
+        doc={doc}
+        awareness={awareness}
+        language="python"
+        readOnly={false}
+        canAddComments={true}
+        onAddComment={onAddComment}
+        onRunCode={vi.fn()}
+        onSubmitCode={vi.fn()}
+      />,
+    );
+
+    act(() => {
+      fakeEditor.emitMouseMove(
+        3,
+        fakeMonacoState.monaco.editor.MouseTargetType.GUTTER_LINE_NUMBERS,
+      );
+    });
+    await user.click(screen.getByRole('button', { name: 'workspace.addComment' }));
+    await user.type(screen.getByPlaceholderText('workspace.inlineCommentsPlaceholder 3'), 'Check');
+    const addButtons = screen.getAllByRole('button', { name: 'workspace.addComment' });
+    const submitButton = addButtons.at(-1);
+    if (!submitButton) {
+      throw new Error('Expected an add-comment submit button');
+    }
+    await user.click(submitButton);
+
+    expect(onAddComment).toHaveBeenCalledWith(3, 'Check');
+    awareness.destroy();
+    doc.destroy();
+  });
+
+  it('GIVEN the selected line is near the bottom WHEN adding a comment THEN the composer opens above the line', async () => {
+    const user = userEvent.setup();
+    const doc = new Y.Doc();
+    const awareness = new Awareness(doc);
+    const fakeEditor = createFakeEditor({ clientHeight: 100 });
+    fakeMonacoState.editor = fakeEditor;
+
+    render(
+      <CollaborativeEditor
+        doc={doc}
+        awareness={awareness}
+        language="python"
+        readOnly={false}
+        canAddComments={true}
+        onAddComment={vi.fn()}
+        onRunCode={vi.fn()}
+        onSubmitCode={vi.fn()}
+      />,
+    );
+
+    act(() => {
+      fakeEditor.emitMouseMove(
+        4,
+        fakeMonacoState.monaco.editor.MouseTargetType.GUTTER_LINE_NUMBERS,
+      );
+    });
+    await user.click(screen.getByRole('button', { name: 'workspace.addComment' }));
+
+    const composer = screen.getByText('workspace.selectedLine 4').closest('.pointer-events-auto');
+
+    expect(composer).not.toBeNull();
+    expect((composer as HTMLElement).style.bottom).not.toBe('');
+    expect((composer as HTMLElement).style.top).toBe('');
+    awareness.destroy();
     doc.destroy();
   });
 });

--- a/apps/web/src/components/collaborative-editor.tsx
+++ b/apps/web/src/components/collaborative-editor.tsx
@@ -17,6 +17,10 @@ import {
   handleEditorWillMount,
 } from './room-workspace-utils.js';
 
+const INLINE_COMMENT_PANEL_GAP_PX = 6;
+const COMMENT_COMPOSER_HEIGHT_ESTIMATE_PX = 160;
+const COMMENT_THREAD_HEIGHT_ESTIMATE_PX = 300;
+
 export interface EditorCodeContext {
   codeSnippet: string;
   startLine: number;
@@ -69,6 +73,7 @@ interface EditorLike {
   onDidFocusEditorWidget: (listener: () => void) => DisposableLike;
   onDidBlurEditorWidget: (listener: () => void) => DisposableLike;
   onMouseDown: (listener: (event: EditorMouseEventLike) => void) => DisposableLike;
+  onMouseMove: (listener: (event: EditorMouseEventLike) => void) => DisposableLike;
   getVisibleRanges: () => Array<{ startLineNumber: number; endLineNumber: number }>;
   getLayoutInfo: () => {
     glyphMarginLeft: number;
@@ -127,6 +132,8 @@ interface MonacoLike {
   editor: {
     MouseTargetType: {
       GUTTER_GLYPH_MARGIN: number;
+      GUTTER_LINE_NUMBERS?: number;
+      GUTTER_LINE_DECORATIONS?: number;
     };
   };
 }
@@ -152,6 +159,7 @@ export function CollaborativeEditor({
   const [editor, setEditor] = useState<EditorInstance | null>(null);
   const [editorRoot, setEditorRoot] = useState<HTMLElement | null>(null);
   const [selectedLine, setSelectedLine] = useState(1);
+  const [hoveredGutterLine, setHoveredGutterLine] = useState<number | null>(null);
   const [composerLine, setComposerLine] = useState<number | null>(null);
   const [composerDraft, setComposerDraft] = useState('');
   const [threadLine, setThreadLine] = useState<number | null>(null);
@@ -327,6 +335,15 @@ export function CollaborativeEditor({
     const blurDisposable = editorApi.onDidBlurEditorWidget(() => {
       onFocusChangeRef.current(false);
     });
+    const mouseMoveDisposable = editorApi.onMouseMove((event) => {
+      const lineNumber = event.target.position?.lineNumber;
+      if (lineNumber && isGutterMouseTarget(event.target.type, mouseTargetType)) {
+        setHoveredGutterLine(lineNumber);
+        return;
+      }
+
+      setHoveredGutterLine(null);
+    });
 
     const mouseDisposable = editorApi.onMouseDown((event) => {
       const lineNumber = event.target.position?.lineNumber;
@@ -353,6 +370,7 @@ export function CollaborativeEditor({
       contentDisposable.dispose();
       focusDisposable.dispose();
       blurDisposable.dispose();
+      mouseMoveDisposable.dispose();
       mouseDisposable.dispose();
     };
   }, [editor, commentLineSet, emitCodeContext]);
@@ -423,37 +441,46 @@ export function CollaborativeEditor({
     };
   }, [editor]);
 
-  const selectedLineOverlay = useMemo(() => {
+  const getVisibleLineOverlay = useCallback(
+    (lineNumber: number) => {
+      void overlayVersion;
+      if (!editor || lineNumber < 1) {
+        return null;
+      }
+
+      const editorApi = editor as unknown as EditorLike;
+      const visibleRanges = editorApi.getVisibleRanges();
+      const isVisible = visibleRanges.some(
+        (range) => lineNumber >= range.startLineNumber && lineNumber <= range.endLineNumber,
+      );
+      if (!isVisible) {
+        return null;
+      }
+
+      const linePosition = editorApi.getScrolledVisiblePosition({
+        lineNumber,
+        column: 1,
+      });
+      if (!linePosition) {
+        return null;
+      }
+
+      const layout = editorApi.getLayoutInfo();
+      return {
+        lineNumber,
+        top: linePosition.top,
+        height: linePosition.height,
+        glyphLeft: layout.glyphMarginLeft + Math.max((layout.glyphMarginWidth - 16) / 2, 0),
+      };
+    },
+    [editor, overlayVersion],
+  );
+
+  const addCommentLine = hoveredGutterLine ?? selectedLine;
+  const addCommentLineOverlay = useMemo(() => {
     void overlayVersion;
-    if (!editor || selectedLine < 1) {
-      return null;
-    }
-
-    const editorApi = editor as unknown as EditorLike;
-    const visibleRanges = editorApi.getVisibleRanges();
-    const isVisible = visibleRanges.some(
-      (range) => selectedLine >= range.startLineNumber && selectedLine <= range.endLineNumber,
-    );
-    if (!isVisible) {
-      return null;
-    }
-
-    const linePosition = editorApi.getScrolledVisiblePosition({
-      lineNumber: selectedLine,
-      column: 1,
-    });
-    if (!linePosition) {
-      return null;
-    }
-
-    const layout = editorApi.getLayoutInfo();
-    return {
-      top: linePosition.top,
-      height: linePosition.height,
-      glyphLeft: layout.glyphMarginLeft + Math.max((layout.glyphMarginWidth - 16) / 2, 0),
-      contentLeft: layout.contentLeft + 8,
-    };
-  }, [editor, selectedLine, overlayVersion]);
+    return getVisibleLineOverlay(addCommentLine);
+  }, [addCommentLine, getVisibleLineOverlay, overlayVersion]);
 
   const commentGlyphOverlays = useMemo(() => {
     void overlayVersion;
@@ -507,29 +534,7 @@ export function CollaborativeEditor({
     }
 
     const editorApi = editor as unknown as EditorLike;
-    const visibleRanges = editorApi.getVisibleRanges();
-    const isVisible = visibleRanges.some(
-      (range) => composerLine >= range.startLineNumber && composerLine <= range.endLineNumber,
-    );
-    if (!isVisible) {
-      return null;
-    }
-
-    const linePosition = editorApi.getScrolledVisiblePosition({
-      lineNumber: composerLine,
-      column: 1,
-    });
-    if (!linePosition) {
-      return null;
-    }
-
-    const layout = editorApi.getLayoutInfo();
-    return {
-      top: linePosition.top,
-      height: linePosition.height,
-      left: layout.contentLeft + 8,
-      lineNumber: composerLine,
-    };
+    return getVisibleLinePanelOverlay(editorApi, composerLine, COMMENT_COMPOSER_HEIGHT_ESTIMATE_PX);
   }, [editor, composerLine, overlayVersion]);
 
   const threadComments = threadLine == null ? [] : (commentsByLine.get(threadLine) ?? []);
@@ -541,29 +546,7 @@ export function CollaborativeEditor({
     }
 
     const editorApi = editor as unknown as EditorLike;
-    const visibleRanges = editorApi.getVisibleRanges();
-    const isVisible = visibleRanges.some(
-      (range) => threadLine >= range.startLineNumber && threadLine <= range.endLineNumber,
-    );
-    if (!isVisible) {
-      return null;
-    }
-
-    const linePosition = editorApi.getScrolledVisiblePosition({
-      lineNumber: threadLine,
-      column: 1,
-    });
-    if (!linePosition) {
-      return null;
-    }
-
-    const layout = editorApi.getLayoutInfo();
-    return {
-      top: linePosition.top,
-      height: linePosition.height,
-      left: layout.contentLeft + 8,
-      lineNumber: threadLine,
-    };
+    return getVisibleLinePanelOverlay(editorApi, threadLine, COMMENT_THREAD_HEIGHT_ESTIMATE_PX);
   }, [editor, threadLine, overlayVersion]);
 
   const submitComment = () => {
@@ -777,19 +760,23 @@ export function CollaborativeEditor({
           </button>
         ))}
 
-        {canAddComments && selectedLineOverlay ? (
+        {canAddComments && addCommentLineOverlay ? (
           <button
             type="button"
             onClick={() => {
               setThreadLine(null);
-              setComposerLine(selectedLine);
+              setSelectedLine(addCommentLineOverlay.lineNumber);
+              onActiveLineChangeRef.current(addCommentLineOverlay.lineNumber);
+              setComposerLine(addCommentLineOverlay.lineNumber);
               setComposerDraft('');
               (editor as unknown as EditorLike | null)?.focus();
             }}
             className="pointer-events-auto absolute flex size-5 items-center justify-center rounded-full border border-emerald-400/50 bg-background/95 text-emerald-300 shadow-sm shadow-black/40 transition-colors hover:border-emerald-300 hover:bg-emerald-500/15"
             style={{
-              top: selectedLineOverlay.top + Math.max(selectedLineOverlay.height / 2 - 10, 0),
-              left: selectedLineOverlay.glyphLeft + (commentLineSet.has(selectedLine) ? 18 : 0),
+              top: addCommentLineOverlay.top + Math.max(addCommentLineOverlay.height / 2 - 10, 0),
+              left:
+                addCommentLineOverlay.glyphLeft +
+                (commentLineSet.has(addCommentLineOverlay.lineNumber) ? 18 : 0),
             }}
             aria-label={t('workspace.addComment')}
             title={t('workspace.addComment')}
@@ -802,7 +789,7 @@ export function CollaborativeEditor({
           <div
             className="pointer-events-auto absolute w-[min(24rem,calc(100%-1rem))] rounded-lg border border-border bg-card/95 p-2.5 shadow-lg shadow-black/35 backdrop-blur"
             style={{
-              top: composerOverlay.top + composerOverlay.height + 6,
+              ...getLinePanelPositionStyle(composerOverlay),
               left: composerOverlay.left,
             }}
           >
@@ -870,7 +857,7 @@ export function CollaborativeEditor({
           <div
             className="pointer-events-auto absolute w-[min(26rem,calc(100%-1rem))] rounded-lg border border-emerald-400/30 bg-card/95 p-2.5 shadow-lg shadow-black/35 backdrop-blur"
             style={{
-              top: threadOverlay.top + threadOverlay.height + 6,
+              ...getLinePanelPositionStyle(threadOverlay),
               left: threadOverlay.left,
             }}
           >
@@ -923,4 +910,73 @@ export function CollaborativeEditor({
 
 function clampLine(lineNumber: number, lineCount: number): number {
   return Math.min(Math.max(1, Math.floor(lineNumber)), lineCount);
+}
+
+function isGutterMouseTarget(
+  targetType: number,
+  mouseTargetType: MonacoLike['editor']['MouseTargetType'],
+): boolean {
+  return (
+    targetType === mouseTargetType.GUTTER_GLYPH_MARGIN ||
+    targetType === mouseTargetType.GUTTER_LINE_NUMBERS ||
+    targetType === mouseTargetType.GUTTER_LINE_DECORATIONS
+  );
+}
+
+interface LinePanelOverlay {
+  top: number;
+  bottom: number | null;
+  height: number;
+  left: number;
+  lineNumber: number;
+}
+
+function getVisibleLinePanelOverlay(
+  editorApi: EditorLike,
+  lineNumber: number,
+  panelHeightEstimate: number,
+): LinePanelOverlay | null {
+  const visibleRanges = editorApi.getVisibleRanges();
+  const isVisible = visibleRanges.some(
+    (range) => lineNumber >= range.startLineNumber && lineNumber <= range.endLineNumber,
+  );
+  if (!isVisible) {
+    return null;
+  }
+
+  const linePosition = editorApi.getScrolledVisiblePosition({
+    lineNumber,
+    column: 1,
+  });
+  if (!linePosition) {
+    return null;
+  }
+
+  const layout = editorApi.getLayoutInfo();
+  const editorHeight = editorApi.getDomNode()?.clientHeight ?? 0;
+  const belowTop = linePosition.top + linePosition.height + INLINE_COMMENT_PANEL_GAP_PX;
+  const spaceBelow = Math.max(editorHeight - belowTop, 0);
+  const spaceAbove = Math.max(linePosition.top - INLINE_COMMENT_PANEL_GAP_PX, 0);
+  const shouldOpenAbove =
+    editorHeight > 0 && spaceBelow < panelHeightEstimate && spaceAbove > spaceBelow;
+
+  return {
+    top: belowTop,
+    bottom: shouldOpenAbove
+      ? Math.max(editorHeight - linePosition.top + INLINE_COMMENT_PANEL_GAP_PX, 0)
+      : null,
+    height: linePosition.height,
+    left: layout.contentLeft + 8,
+    lineNumber,
+  };
+}
+
+function getLinePanelPositionStyle(
+  overlay: LinePanelOverlay,
+): { top: number; bottom?: undefined } | { top?: undefined; bottom: number } {
+  if (overlay.bottom != null) {
+    return { bottom: overlay.bottom };
+  }
+
+  return { top: overlay.top };
 }

--- a/apps/web/src/hooks/use-inline-comments.spec.ts
+++ b/apps/web/src/hooks/use-inline-comments.spec.ts
@@ -1,3 +1,4 @@
+import { INLINE_COMMENTS_KEY } from '@syncode/shared';
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import * as Y from 'yjs';
@@ -104,6 +105,27 @@ describe('useInlineComments', () => {
     });
 
     expect(result.current.comments[0]?.lineNumber).toBe(3);
+    doc.destroy();
+  });
+
+  it('GIVEN comments hydrate before code WHEN initial code sync arrives THEN stored line numbers are preserved', () => {
+    const doc = makeDoc('');
+    const comments = doc.getMap<Y.Map<unknown>>(INLINE_COMMENTS_KEY);
+    const comment = new Y.Map<unknown>();
+    comment.set('authorId', 'u1');
+    comment.set('authorName', 'Alice');
+    comment.set('content', 'On beta');
+    comment.set('createdAt', '2026-05-19T00:00:00.000Z');
+    comment.set('updatedAt', '2026-05-19T00:00:00.000Z');
+    comment.set('lineNumber', 2);
+    comments.set('comment-1', comment);
+    const { result } = renderHook(() => useInlineComments(doc));
+
+    act(() => {
+      doc.getText(codeTextKey(TEST_LANGUAGE)).insert(0, 'alpha\nbeta\ngamma');
+    });
+
+    expect(result.current.comments[0]?.lineNumber).toBe(2);
     doc.destroy();
   });
 });

--- a/apps/web/src/hooks/use-inline-comments.ts
+++ b/apps/web/src/hooks/use-inline-comments.ts
@@ -51,6 +51,12 @@ export function useInlineComments(
       const nextCode = codeText.toString();
       const delta = event.changes.delta as InlineCommentTextDelta;
 
+      if (previousCode.length === 0 && commentsMap.size > 0) {
+        previousCodeRef.current = nextCode;
+        syncComments();
+        return;
+      }
+
       reconcileInlineCommentsForCodeChange(doc, language, previousCode, nextCode, delta);
       previousCodeRef.current = nextCode;
       syncComments();


### PR DESCRIPTION
## Summary
- let the inline-comment add control target the gutter line currently under the mouse
- preserve hydrated inline comment line numbers when comments sync before code text
- flip inline comment composer/thread panels above bottom lines so the output panel does not cover them

## Test Plan
- pnpm --filter @syncode/web test -- collaborative-editor.spec.tsx use-inline-comments.spec.ts
- pnpm check
- pnpm --filter @syncode/web typecheck
- pnpm --filter @syncode/web test
- pnpm --filter @syncode/web build
- pnpm typecheck
- git diff --check