### PR TITLE
fix(infra): allow interview media permissions

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -15,7 +15,7 @@ http {
     add_header X-Frame-Options SAMEORIGIN always;
     add_header X-Content-Type-Options nosniff always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Permissions-Policy "camera=(self), microphone=(self), geolocation=()" always;
 
     # The proxy VPS in front terminates TLS at :443, so we can safely declare HSTS here
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;


### PR DESCRIPTION
Emergency production hotfix.\n\nAllows camera and microphone through the origin Nginx Permissions-Policy header so LiveKit interview rooms can request media permissions.