### PR TITLE
ci(ci): deploy server after image push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,3 +70,108 @@ jobs:
               .
             echo "::endgroup::"
           done
+
+  deploy-server:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      DEPLOY_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+    steps:
+      - name: Configure SSH
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "${DEPLOY_HOST}" || { echo "DEPLOY_HOST is required"; exit 1; }
+          test -n "${DEPLOY_USER}" || { echo "DEPLOY_USER is required"; exit 1; }
+          test -n "${DEPLOY_PORT}" || { echo "DEPLOY_PORT is required"; exit 1; }
+          test -n "${DEPLOY_PATH}" || { echo "DEPLOY_PATH is required"; exit 1; }
+          test -n "${DEPLOY_SSH_KEY}" || { echo "DEPLOY_SSH_KEY is required"; exit 1; }
+
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${DEPLOY_SSH_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -p "${DEPLOY_PORT}" -H "${DEPLOY_HOST}" >> ~/.ssh/known_hosts
+
+      - name: Pull, migrate, recreate, and verify server stack
+        run: |
+          set -euo pipefail
+
+          ssh \
+            -i ~/.ssh/deploy_key \
+            -p "${DEPLOY_PORT}" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            "DEPLOY_BRANCH='${DEPLOY_BRANCH}' DEPLOY_PATH='${DEPLOY_PATH}' bash -s" <<'REMOTE'
+          set -euo pipefail
+
+          cd "${DEPLOY_PATH}"
+
+          services=(web control-plane collab-plane execution-plane ai-plane)
+          case "${DEPLOY_BRANCH}" in
+            main)
+              env_file=".env.production"
+              project_args=()
+              health_url="https://syncode.anggita.org/api/health"
+              nginx_container="syncode-nginx-1"
+              expected_tag="latest"
+              ;;
+            develop)
+              env_file=".env.staging"
+              project_args=(-p syncode-staging)
+              health_url="https://staging.syncode.anggita.org/api/health"
+              nginx_container="syncode-staging-nginx-1"
+              expected_tag="develop"
+              ;;
+            *)
+              echo "Unsupported deploy branch: ${DEPLOY_BRANCH}" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ ! -f "${env_file}" ]; then
+            echo "Missing ${env_file}" >&2
+            exit 1
+          fi
+
+          actual_tag=$(sudo awk -F= '/^IMAGE_TAG=/ { value=$2 } END { print value }' "${env_file}")
+          if [ "${actual_tag}" != "${expected_tag}" ]; then
+            echo "${env_file} has IMAGE_TAG=${actual_tag}; expected ${expected_tag}" >&2
+            exit 1
+          fi
+
+          compose=(sudo docker compose -f docker-compose.prod.yml --env-file "${env_file}" "${project_args[@]}")
+
+          echo "::group::Pull images"
+          "${compose[@]}" pull "${services[@]}"
+          echo "::endgroup::"
+
+          echo "::group::Run migrations"
+          "${compose[@]}" run -T --rm control-plane node migrate.mjs </dev/null
+          echo "::endgroup::"
+
+          echo "::group::Recreate app services"
+          "${compose[@]}" up -d "${services[@]}"
+          echo "::endgroup::"
+
+          echo "::group::Reload nginx"
+          sudo docker exec "${nginx_container}" nginx -t
+          sudo docker exec "${nginx_container}" nginx -s reload
+          echo "::endgroup::"
+
+          echo "::group::Container status"
+          "${compose[@]}" ps "${services[@]}" nginx livekit
+          echo "::endgroup::"
+
+          echo "::group::Health check"
+          curl --fail --show-error --silent --retry 10 --retry-delay 3 "${health_url}"
+          echo
+          echo "::endgroup::"
+          REMOTE


### PR DESCRIPTION
Updates the deploy workflow so successful CI on main/develop does more than publish images. After images are pushed, GitHub Actions now SSHes into the origin server, pulls the app services, runs control-plane migrations, recreates the stack, reloads Nginx, and verifies the public health endpoint for the matching environment.\n\nAlso configured the required DEPLOY_* repository secrets for the origin server connection.