### PR TITLE
chore(ci): promote deploy automation to production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,44 +73,17 @@ jobs:
 
   deploy-server:
     needs: build-and-push
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, syncode-deploy]
     permissions:
       contents: read
     env:
       DEPLOY_BRANCH: ${{ github.event.workflow_run.head_branch }}
-      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
-      DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
       DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
     steps:
-      - name: Configure SSH
-        env:
-          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
-        run: |
-          set -euo pipefail
-          test -n "${DEPLOY_HOST}" || { echo "DEPLOY_HOST is required"; exit 1; }
-          test -n "${DEPLOY_USER}" || { echo "DEPLOY_USER is required"; exit 1; }
-          test -n "${DEPLOY_PORT}" || { echo "DEPLOY_PORT is required"; exit 1; }
-          test -n "${DEPLOY_PATH}" || { echo "DEPLOY_PATH is required"; exit 1; }
-          test -n "${DEPLOY_SSH_KEY}" || { echo "DEPLOY_SSH_KEY is required"; exit 1; }
-
-          install -m 700 -d ~/.ssh
-          printf '%s\n' "${DEPLOY_SSH_KEY}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -T 30 -p "${DEPLOY_PORT}" -H "${DEPLOY_HOST}" >> ~/.ssh/known_hosts || true
-
       - name: Pull, migrate, recreate, and verify server stack
         run: |
           set -euo pipefail
-
-          ssh \
-            -i ~/.ssh/deploy_key \
-            -p "${DEPLOY_PORT}" \
-            -o IdentitiesOnly=yes \
-            -o StrictHostKeyChecking=accept-new \
-            "${DEPLOY_USER}@${DEPLOY_HOST}" \
-            "DEPLOY_BRANCH='${DEPLOY_BRANCH}' DEPLOY_PATH='${DEPLOY_PATH}' bash -s" <<'REMOTE'
-          set -euo pipefail
+          test -n "${DEPLOY_PATH}" || { echo "DEPLOY_PATH is required"; exit 1; }
 
           cd "${DEPLOY_PATH}"
 
@@ -174,4 +147,3 @@ jobs:
           curl --fail --show-error --silent --retry 10 --retry-delay 3 "${health_url}"
           echo
           echo "::endgroup::"
-          REMOTE

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,3 +70,108 @@ jobs:
               .
             echo "::endgroup::"
           done
+
+  deploy-server:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      DEPLOY_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+    steps:
+      - name: Configure SSH
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "${DEPLOY_HOST}" || { echo "DEPLOY_HOST is required"; exit 1; }
+          test -n "${DEPLOY_USER}" || { echo "DEPLOY_USER is required"; exit 1; }
+          test -n "${DEPLOY_PORT}" || { echo "DEPLOY_PORT is required"; exit 1; }
+          test -n "${DEPLOY_PATH}" || { echo "DEPLOY_PATH is required"; exit 1; }
+          test -n "${DEPLOY_SSH_KEY}" || { echo "DEPLOY_SSH_KEY is required"; exit 1; }
+
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${DEPLOY_SSH_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -p "${DEPLOY_PORT}" -H "${DEPLOY_HOST}" >> ~/.ssh/known_hosts
+
+      - name: Pull, migrate, recreate, and verify server stack
+        run: |
+          set -euo pipefail
+
+          ssh \
+            -i ~/.ssh/deploy_key \
+            -p "${DEPLOY_PORT}" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            "DEPLOY_BRANCH='${DEPLOY_BRANCH}' DEPLOY_PATH='${DEPLOY_PATH}' bash -s" <<'REMOTE'
+          set -euo pipefail
+
+          cd "${DEPLOY_PATH}"
+
+          services=(web control-plane collab-plane execution-plane ai-plane)
+          case "${DEPLOY_BRANCH}" in
+            main)
+              env_file=".env.production"
+              project_args=()
+              health_url="https://syncode.anggita.org/api/health"
+              nginx_container="syncode-nginx-1"
+              expected_tag="latest"
+              ;;
+            develop)
+              env_file=".env.staging"
+              project_args=(-p syncode-staging)
+              health_url="https://staging.syncode.anggita.org/api/health"
+              nginx_container="syncode-staging-nginx-1"
+              expected_tag="develop"
+              ;;
+            *)
+              echo "Unsupported deploy branch: ${DEPLOY_BRANCH}" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ ! -f "${env_file}" ]; then
+            echo "Missing ${env_file}" >&2
+            exit 1
+          fi
+
+          actual_tag=$(sudo awk -F= '/^IMAGE_TAG=/ { value=$2 } END { print value }' "${env_file}")
+          if [ "${actual_tag}" != "${expected_tag}" ]; then
+            echo "${env_file} has IMAGE_TAG=${actual_tag}; expected ${expected_tag}" >&2
+            exit 1
+          fi
+
+          compose=(sudo docker compose -f docker-compose.prod.yml --env-file "${env_file}" "${project_args[@]}")
+
+          echo "::group::Pull images"
+          "${compose[@]}" pull "${services[@]}"
+          echo "::endgroup::"
+
+          echo "::group::Run migrations"
+          "${compose[@]}" run -T --rm control-plane node migrate.mjs </dev/null
+          echo "::endgroup::"
+
+          echo "::group::Recreate app services"
+          "${compose[@]}" up -d "${services[@]}"
+          echo "::endgroup::"
+
+          echo "::group::Reload nginx"
+          sudo docker exec "${nginx_container}" nginx -t
+          sudo docker exec "${nginx_container}" nginx -s reload
+          echo "::endgroup::"
+
+          echo "::group::Container status"
+          "${compose[@]}" ps "${services[@]}" nginx livekit
+          echo "::endgroup::"
+
+          echo "::group::Health check"
+          curl --fail --show-error --silent --retry 10 --retry-delay 3 "${health_url}"
+          echo
+          echo "::endgroup::"
+          REMOTE

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,7 @@ jobs:
           install -m 700 -d ~/.ssh
           printf '%s\n' "${DEPLOY_SSH_KEY}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -p "${DEPLOY_PORT}" -H "${DEPLOY_HOST}" >> ~/.ssh/known_hosts
+          ssh-keyscan -T 30 -p "${DEPLOY_PORT}" -H "${DEPLOY_HOST}" >> ~/.ssh/known_hosts || true
 
       - name: Pull, migrate, recreate, and verify server stack
         run: |
@@ -107,7 +107,7 @@ jobs:
             -i ~/.ssh/deploy_key \
             -p "${DEPLOY_PORT}" \
             -o IdentitiesOnly=yes \
-            -o StrictHostKeyChecking=yes \
+            -o StrictHostKeyChecking=accept-new \
             "${DEPLOY_USER}@${DEPLOY_HOST}" \
             "DEPLOY_BRANCH='${DEPLOY_BRANCH}' DEPLOY_PATH='${DEPLOY_PATH}' bash -s" <<'REMOTE'
           set -euo pipefail


### PR DESCRIPTION
## Summary
- merge the develop deploy automation into main
- production deploys from main will build latest images and run migrations, recreate app services, reload nginx, and verify public health

## Verification
- develop CI passed for c961188
- develop Deploy passed: https://github.com/JosephJoshua/syncode/actions/runs/26084686134
- staging and production health endpoints return ok after the staging deploy