### PR TITLE
fix(control-plane): use client ip for throttling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,8 +61,12 @@ COLLAB_PLANE_URL=http://localhost:3001
 CONTROL_PLANE_URL=http://localhost:3000
 
 # Trusted reverse proxies for control-plane client IP resolution (comma-separated)
-# Leave empty for local direct access. Production compose requires the exact nginx/proxy CIDR.
+# Leave empty for local direct access. Production compose should trust the Docker nginx hop.
 TRUSTED_PROXIES=
+
+# Control-plane request throttling. Auth endpoints have their own stricter 20/min limit.
+THROTTLE_TTL_SECS=60
+THROTTLE_LIMIT=120
 
 # AI plane (LLM proxy)
 AI_PROVIDER=openai-compatible

--- a/apps/control-plane/.env.example
+++ b/apps/control-plane/.env.example
@@ -48,13 +48,13 @@ USE_COLLAB_STUB=false
 
 # Rate limiting
 THROTTLE_TTL_SECS=60
-THROTTLE_LIMIT=10
+THROTTLE_LIMIT=120
 
 # CORS (comma-separated list of allowed origins)
 CORS_ORIGINS=http://localhost:5173
 
 # Trusted reverse proxies for Express client IP resolution (comma-separated)
-# Leave empty for local direct access. Production requires an explicit value.
+# Leave empty for local direct access. Production compose should trust the Docker nginx hop.
 TRUSTED_PROXIES=
 
 # Observability

--- a/apps/control-plane/src/app.module.ts
+++ b/apps/control-plane/src/app.module.ts
@@ -5,6 +5,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { LoggerModule } from 'nestjs-pino';
 import { AppController } from './app.controller.js';
+import { getClientIpFromRequest } from './common/client-ip.js';
 import { GlobalExceptionFilter } from './common/filters/global-exception.filter.js';
 import { type EnvConfig, validateEnv } from './config/env.config.js';
 import { InfrastructureModule } from './infrastructure/infrastructure.module.js';
@@ -107,9 +108,10 @@ if (!isProd) {
         throttlers: [
           {
             ttl: (config.get('THROTTLE_TTL_SECS', { infer: true }) ?? 60) * 1_000, // seconds -> ms
-            limit: config.get('THROTTLE_LIMIT', { infer: true }) ?? 10,
+            limit: config.get('THROTTLE_LIMIT', { infer: true }) ?? 120,
           },
         ],
+        getTracker: (request) => getClientIpFromRequest(request),
         skipIf: () => config.get('NODE_ENV', { infer: true }) === 'development',
       }),
     }),

--- a/apps/control-plane/src/common/client-ip.spec.ts
+++ b/apps/control-plane/src/common/client-ip.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { getClientIpFromRequest } from './client-ip.js';
+
+describe('getClientIpFromRequest', () => {
+  it('uses the Express trusted proxy client IP when available', () => {
+    expect(
+      getClientIpFromRequest({
+        headers: {
+          'x-real-ip': '198.51.100.10',
+          'x-forwarded-for': '198.51.100.11, 10.0.0.8',
+        },
+        ip: '203.0.113.10',
+        ips: ['203.0.113.20', '10.0.0.8'],
+      }),
+    ).toBe('203.0.113.20');
+  });
+
+  it('falls back to the nginx real IP header', () => {
+    expect(
+      getClientIpFromRequest({
+        headers: {
+          'x-real-ip': '198.51.100.10',
+          'x-forwarded-for': '198.51.100.11, 10.0.0.8',
+        },
+      }),
+    ).toBe('198.51.100.10');
+  });
+
+  it('uses the leftmost forwarded-for address when no real IP header exists', () => {
+    expect(
+      getClientIpFromRequest({
+        headers: {
+          'x-forwarded-for': '198.51.100.11, 10.0.0.8',
+        },
+      }),
+    ).toBe('198.51.100.11');
+  });
+
+  it('falls back to the socket remote address', () => {
+    expect(
+      getClientIpFromRequest({
+        socket: {
+          remoteAddress: '10.0.0.8',
+        },
+      }),
+    ).toBe('10.0.0.8');
+  });
+});

--- a/apps/control-plane/src/common/client-ip.ts
+++ b/apps/control-plane/src/common/client-ip.ts
@@ -1,0 +1,38 @@
+type HeaderValue = string | string[] | undefined;
+
+export interface ClientIpRequest {
+  headers?: Record<string, HeaderValue>;
+  ip?: string;
+  ips?: string[];
+  socket?: {
+    remoteAddress?: string;
+  };
+}
+
+function firstHeaderValue(value: HeaderValue): string | undefined {
+  if (Array.isArray(value)) {
+    return value.find((item) => item.trim().length > 0)?.trim();
+  }
+
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function firstForwardedForValue(value: HeaderValue): string | undefined {
+  const header = firstHeaderValue(value);
+  return header
+    ?.split(',')
+    .map((item) => item.trim())
+    .find(Boolean);
+}
+
+export function getClientIpFromRequest(request: ClientIpRequest): string {
+  return (
+    request.ips?.[0] ??
+    request.ip ??
+    firstHeaderValue(request.headers?.['x-real-ip']) ??
+    firstForwardedForValue(request.headers?.['x-forwarded-for']) ??
+    request.socket?.remoteAddress ??
+    'unknown'
+  );
+}

--- a/apps/control-plane/src/config/env.config.ts
+++ b/apps/control-plane/src/config/env.config.ts
@@ -78,7 +78,7 @@ const envSchema = z
       .positive()
       .default(60)
       .describe('Rate limit window in seconds'),
-    THROTTLE_LIMIT: z.coerce.number().positive().default(10),
+    THROTTLE_LIMIT: z.coerce.number().positive().default(120),
   })
   .refine(
     (env) => {

--- a/apps/control-plane/src/modules/auth/auth.controller.ts
+++ b/apps/control-plane/src/modules/auth/auth.controller.ts
@@ -42,7 +42,7 @@ export class AuthController {
 
   private static readonly AUTH_THROTTLE = {
     default: {
-      limit: 5,
+      limit: 20,
       ttl: 60 * 1_000,
     },
   } as const;

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -29,8 +29,9 @@ http {
 
     client_max_body_size 10m;
 
-    # Trust X-Forwarded-* only from the TLS-terminating VPS proxy.
-    # Control-plane must separately set TRUSTED_PROXIES to this nginx hop's exact CIDR/IP.
+    # Trust X-Forwarded-* from the edge Caddy proxy and Docker networks.
+    # Control-plane must separately set TRUSTED_PROXIES to trust this nginx hop.
+    set_real_ip_from 124.220.147.156;
     set_real_ip_from 10.0.0.0/8;
     set_real_ip_from 172.16.0.0/12;
     set_real_ip_from 192.168.0.0/16;


### PR DESCRIPTION
## Summary
- key control-plane throttling by the resolved client IP instead of the proxy hop
- raise default global throttle limit to 120/min and auth throttle to 20/min
- trust the edge Caddy IP in origin Nginx real-ip handling

## Tests
- pnpm --filter @syncode/control-plane test -- client-ip
- pnpm --filter @syncode/control-plane typecheck
- pnpm --filter @syncode/control-plane lint